### PR TITLE
Add opaque background to search results section

### DIFF
--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -2987,6 +2987,10 @@ button.icon-button.active i.fa-retweet {
   font-weight: 500;
 }
 
+.search-results__section {
+  background: lighten($ui-base-color, 2%);
+}
+
 .search-results__hashtag {
   display: block;
   padding: 10px;

--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -2988,7 +2988,7 @@ button.icon-button.active i.fa-retweet {
 }
 
 .search-results__section {
-  background: lighten($ui-base-color, 2%);
+  background: $ui-base-color;
 }
 
 .search-results__hashtag {


### PR DESCRIPTION
This pull request addresses an issue apparent in Chrome 59 and Firefox 54 on desktop where the search results section background is transparent and hard to read as it overlaps the compose column.