### PR TITLE
Fixed js type error in advanced_options_dropdown.js

### DIFF
--- a/app/javascript/mastodon/features/compose/components/advanced_options_dropdown.js
+++ b/app/javascript/mastodon/features/compose/components/advanced_options_dropdown.js
@@ -75,7 +75,7 @@ export default class AdvancedOptionsDropdown extends React.PureComponent {
 
     const anyEnabled = values.some((enabled) => enabled);
     const optionElems = options.map((option) => {
-      const active = values.get(option.key) ? 'active' : '';
+      const active = values.get(option.key);
       return (
         <div role='button' className='advanced-options-dropdown__option' key={option.key} >
           <div className='advanced-options-dropdown__option__toggle'>


### PR DESCRIPTION
fixes this ugly JS error I was getting on master

![screenshot_20170706_133632](https://user-images.githubusercontent.com/2041118/27909321-695f6bee-6250-11e7-8f75-3b89c46e0085.png)

but I'm not sure why we don't get it on dev.glitch too, if it's on local ...