### PR TITLE
Added extra clickable area in status gutter

### DIFF
--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -421,6 +421,19 @@
   cursor: pointer;
 }
 
+// Extra clickable area in the status gutter
+@media screen and (min-width: 1024px) {
+  .status__content--with-action > div::after {
+    content: '';
+    display: block;
+    width: 68px;
+    height: calc(100% + 10px);
+    position: absolute;
+    left: -68px;
+    bottom: -40px;
+  }
+}
+
 .status__content,
 .reply-indicator__content {
   position: relative;


### PR DESCRIPTION
This PR expands the clickable area of a status in the desktop view.

![screenshot_20170710_094357](https://user-images.githubusercontent.com/2041118/28007653-813ac63a-6554-11e7-826e-facba403f9a8.png)

The area is behind the image, does not overlay it.

For mobile this shan't be an issue, the media query disables it for narrow displays.


