### PR TITLE
Fix toot context menu position

### DIFF
--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -720,6 +720,23 @@
   float: left;
   height: 18px;
   width: 18px;
+
+  // Dropdown style override for centering on the icon
+  .dropdown--active {
+    position: relative;
+
+    .dropdown__content.dropdown__right {
+      left: calc(50% + 3px);
+      right: initial;
+      transform: translate(-50%, 0);
+      top: 22px;
+    }
+
+    &::after {
+      right: 1px;
+      bottom: -2px;
+    }
+  }
 }
 
 .detailed-status__action-bar-dropdown {


### PR DESCRIPTION
It's now centered, so the issue with long texts in some languages when aligned left or right should not be a problem.

![screenshot_20170710_101509](https://user-images.githubusercontent.com/2041118/28008710-ef3ce538-6558-11e7-9a00-57f8b2844976.png)
