### PR TITLE
First lame pass at adding optional git commit hash display on /about/…

### DIFF
--- a/app/presenters/instance_presenter.rb
+++ b/app/presenters/instance_presenter.rb
@@ -29,4 +29,13 @@ class InstancePresenter
   def version_number
     Mastodon::Version
   end
+
+  def commit_hash
+    current_release_file = Pathname.new('~/CURRENT_RELEASE').expand_path
+    if current_release_file.file?
+        IO.read(current_release_file)
+    else
+        ""
+    end
+  end
 end

--- a/app/presenters/instance_presenter.rb
+++ b/app/presenters/instance_presenter.rb
@@ -31,7 +31,7 @@ class InstancePresenter
   end
 
   def commit_hash
-    current_release_file = Pathname.new('~/CURRENT_RELEASE').expand_path
+    current_release_file = Pathname.new('CURRENT_RELEASE').expand_path
     if current_release_file.file?
         IO.read(current_release_file)
     else

--- a/app/views/about/_version.html.haml
+++ b/app/views/about/_version.html.haml
@@ -1,4 +1,9 @@
 .panel
   .panel-header= t 'about.version'
   .panel-body
-    %strong= version.version_number
+    - if @instance_presenter.commit_hash == ""
+      %strong= version.version_number
+    - else
+      %strong= version.version_number
+      %strong= "#{@instance_presenter.commit_hash}"
+


### PR DESCRIPTION
…more page.

Currently, this is implemented by checking for the existence of a file called CURRENT_RELEASE in the home directory of the user running Mastodon. If the file exists, its contents are added.

I've modified my update process to include the following before precompiling assets:

`git log -1 | head -n 1 | cut -d " " -f2 > ~/CURRENT_RELEASE`

That puts the current commit hash into the file ~/CURRENT_RELEASE, but you figured that out because you're a smart cookie.

As I am quite sure this is a horrible methodology for implementing this, I look forward to any improvements you have to offer!