### PR TITLE
view specs: add commit_hash to instance presenter double

### DIFF
--- a/spec/views/about/show.html.haml_spec.rb
+++ b/spec/views/about/show.html.haml_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 describe 'about/show.html.haml', without_verify_partial_doubles: true do
+  let(:commit_hash) { '8925731c9869f55780644304e4420a1998e52607' }
+
   before do
     allow(view).to receive(:site_hostname).and_return('example.com')
     allow(view).to receive(:site_title).and_return('example site')
@@ -14,7 +16,9 @@ describe 'about/show.html.haml', without_verify_partial_doubles: true do
                                 site_description: 'something',
                                 version_number: '1.0',
                                 open_registrations: false,
-                                closed_registrations_message: 'yes')
+                                closed_registrations_message: 'yes',
+                                commit_hash: commit_hash)
+
     assign(:instance_presenter, instance_presenter)
     render
 


### PR DESCRIPTION
glitch-soc's about page grabs said value from InstancePresenter; the spec double needs to emulate that.