### PR TITLE
Add data- attributes to statuses for userstyle selectors

### DIFF
--- a/app/javascript/glitch/components/status/index.js
+++ b/app/javascript/glitch/components/status/index.js
@@ -671,14 +671,18 @@ Users can use those for theming, hiding avatars etc via UserStyle
 
 */
 
-    let selectorAttribs = {
+    const selectorAttribs = {
       'data-status-by': '@' + status.getIn(['account', 'acct']),
     };
 
     if (prepend && account) {
-      selectorAttribs['data-'+prepend+'-by'] = '@' + account.get('acct');
-    }
+      const notifKind = {
+        favourite: 'favourited',
+        reblog: 'boosted',
+      }[prepend];
 
+      selectorAttribs[`data-${notifKind}-by`] = '@' + account.get('acct');
+    }
 
 /*
 

--- a/app/javascript/glitch/components/status/index.js
+++ b/app/javascript/glitch/components/status/index.js
@@ -664,6 +664,21 @@ backgrounds for collapsed statuses are enabled.
       ) background = attachments.getIn([0, 'preview_url']);
     }
 
+/*
+
+Here we prepare extra data-* attributes for CSS selectors.
+Users can use those for theming, hiding avatars etc via UserStyle
+
+*/
+
+    let selectorAttribs = {
+      'data-status-by': '@' + status.getIn(['account', 'acct']),
+    };
+
+    if (prepend && account) {
+      selectorAttribs['data-'+prepend+'-by'] = '@' + account.get('acct');
+    }
+
 
 /*
 
@@ -694,6 +709,7 @@ collapsed.
           ),
         }}
         ref={handleRef}
+        {...selectorAttribs}
       >
         {prepend && account ? (
           <StatusPrepend

--- a/app/javascript/glitch/components/status/index.js
+++ b/app/javascript/glitch/components/status/index.js
@@ -672,7 +672,7 @@ Users can use those for theming, hiding avatars etc via UserStyle
 */
 
     const selectorAttribs = {
-      'data-status-by': '@' + status.getIn(['account', 'acct']),
+      'data-status-by': `@${status.getIn(['account', 'acct'])}`,
     };
 
     if (prepend && account) {
@@ -681,7 +681,7 @@ Users can use those for theming, hiding avatars etc via UserStyle
         reblog: 'boosted',
       }[prepend];
 
-      selectorAttribs[`data-${notifKind}-by`] = '@' + account.get('acct');
+      selectorAttribs[`data-${notifKind}-by`] = `@${account.get('acct')}`;
     }
 
 /*


### PR DESCRIPTION
This adds data attributes to statuses.

- `data-status-by`
- <s>`data-favourite-by`</s> `data-favourited-by`
- <s>`data-reblog-by`</s> `data-boosted-by`

It works fine locally, but I'm not sure whether it will add domains to foreign accounts.

the attributes
![screenshot_20170804_212640](https://user-images.githubusercontent.com/2041118/28984344-cd546612-795d-11e7-88ec-b67d1adb46f4.png)

example of targeted styling
![screenshot_20170804_212805](https://user-images.githubusercontent.com/2041118/28984347-d111f71a-795d-11e7-852b-c8e4cbbdd3d8.png)
