### PR TITLE
Fix error when following locked accounts (#4896)

### DIFF
--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -15,16 +15,9 @@ class Api::V1::AccountsController < Api::BaseController
   def follow
     FollowService.new.call(current_user.account, @account.acct)
 
-    unless @account.locked?
-      relationships = AccountRelationshipsPresenter.new(
-        [@account.id],
-        current_user.account_id,
-        following_map: { @account.id => true },
-        requested_map: { @account.id => false }
-      )
-    end
+    options = @account.locked? ? {} : { following_map: { @account.id => true }, requested_map: { @account.id => false } }
 
-    render json: @account, serializer: REST::RelationshipSerializer, relationships: relationships
+    render json: @account, serializer: REST::RelationshipSerializer, relationships: relationships(options)
   end
 
   def block
@@ -58,7 +51,7 @@ class Api::V1::AccountsController < Api::BaseController
     @account = Account.find(params[:id])
   end
 
-  def relationships
-    AccountRelationshipsPresenter.new([@account.id], current_user.account_id)
+  def relationships(options = {})
+    AccountRelationshipsPresenter.new([@account.id], current_user.account_id, options)
   end
 end


### PR DESCRIPTION
(cherry picked from commit 0ef9d45d0581dddf2f325033c43721f42fcfca9e)

This will make it into the 1.6.1 release, but it's a bug I'm hitting now so I figured I'd propose dragging in the fix.  Doing this shouldn't make the 1.6.1 merge any more complicated.