### PR TITLE
Configure webpack to poll for changes in development

### DIFF
--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -28,6 +28,7 @@ module.exports = merge(sharedConfig, {
     disableHostCheck: true,
     watchOptions: {
       ignored: /node_modules/,
+      poll: 1000,
     },
   },
 });


### PR DESCRIPTION
Vagrant on Linux/macOS hosts shared files via NFS, which doesn't support inotify-based watching of files. This tweak makes webpack check for changes every second, and rebuild if necessary. This removes the need to restart Foreman every time a frontend file changes. Note that rebuilding is still a relatively lengthy process.

The polling frequency can be changed to taste.