### PR TITLE
try to tighten up local only toot stuff, like... properly

### DIFF
--- a/app/controllers/stream_entries_controller.rb
+++ b/app/controllers/stream_entries_controller.rb
@@ -48,7 +48,7 @@ class StreamEntriesController < ApplicationController
     @type         = @stream_entry.activity_type.downcase
 
     raise ActiveRecord::RecordNotFound if @stream_entry.activity.nil?
-    authorize @stream_entry.activity, :show? if @stream_entry.hidden?
+    authorize @stream_entry.activity, :show? if @stream_entry.hidden? || @stream_entry.local_only?
   rescue Mastodon::NotPermittedError
     # Reraise in order to get a 404
     raise ActiveRecord::RecordNotFound

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -257,6 +257,11 @@ class Status < ApplicationRecord
     end
   end
 
+  def local_only?
+    # match both with and without U+FE0F (the emoji variation selector)
+    /👁\ufe0f?\z/.match?(content)
+  end
+
   private
 
   def store_uri

--- a/app/models/stream_entry.rb
+++ b/app/models/stream_entry.rb
@@ -28,7 +28,7 @@ class StreamEntry < ApplicationRecord
   scope :recent, -> { reorder(id: :desc) }
   scope :with_includes, -> { includes(:account, status: STATUS_INCLUDES) }
 
-  delegate :target, :title, :content, :thread,
+  delegate :target, :title, :content, :thread, :local_only?,
            to: :status,
            allow_nil: true
 

--- a/app/policies/status_policy.rb
+++ b/app/policies/status_policy.rb
@@ -9,6 +9,8 @@ class StatusPolicy
   end
 
   def show?
+    return false if local_only? && account.nil?
+
     if direct?
       owned? || status.mentions.where(account: account).exists?
     elsif private?
@@ -44,5 +46,9 @@ class StatusPolicy
 
   def private?
     status.private_visibility?
+  end
+  
+  def local_only?
+    status.local_only?
   end
 end


### PR DESCRIPTION
this should hopefully prevent statuses from being pulled to other instances through the search box and for thread context