### PR TITLE
 Make the compose area optionally scrollable

### DIFF
--- a/app/javascript/mastodon/features/compose/index.js
+++ b/app/javascript/mastodon/features/compose/index.js
@@ -105,7 +105,7 @@ export default class Compose extends React.PureComponent {
         <SearchContainer />
 
         <div className='drawer__pager'>
-          <div className='drawer__inner' onFocus={this.onFocus}>
+          <div className='drawer__inner scrollable optionally-scrollable' onFocus={this.onFocus}>
             <NavigationContainer onClose={this.onBlur} />
             <ComposeFormContainer />
           </div>


### PR DESCRIPTION
On desktop, the compose text box grows to accommodate the content.  On
mobile, the text box does not grow to accommodate text context, but does
grow to accommodate images.  It is possible in both cases to overflow
the available area, which makes accessing other UI elements (e.g.
visibility setttings) difficult.

This commit makes the compose area optionally scrollable, which allows
those UI elements to remain available even if they go off-screen.

Examples:

![out-mobile](https://user-images.githubusercontent.com/3859/31781564-65f7088e-b4be-11e7-810b-9c398bae9e4e.gif)
![out-desktop](https://user-images.githubusercontent.com/3859/31781576-6bf11180-b4be-11e7-8171-51f54939cb04.gif)
