### PR TITLE
Added app/javascript for imports

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -29,6 +29,11 @@ settings:
   import/ignore:
   - node_modules
   - \\.(css|scss|json)$
+  import/resolver:
+    node:
+      moduleDirectory:
+        - node_modules
+        - app/javascript
 
 rules:
   brace-style: warn


### PR DESCRIPTION
This fixes ESLint so that it will resolve modules to `app/javascript` if it doesn't find them in `node_modules`. This means eg `import StatusContainer from 'glitch/components/status/container';` should work again without throwing any linting errors.

Stylesheets still require a `.scss` extension though.