### PR TITLE
Introducing: Mastodon GO!

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "app/javascript/themes/mastodon-go"]
+	path = app/javascript/themes/mastodon-go
+	url = https://github.com/marrus-sh/mastodon-go

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -83,7 +83,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.provider :virtualbox do |vb|
     vb.name = "mastodon"
-    vb.customize ["modifyvm", :id, "--memory", "2048"]
+    vb.customize ["modifyvm", :id, "--memory", "4096"]
 
     # Disable VirtualBox DNS proxy to skip long-delay IPv6 resolutions.
     # https://github.com/mitchellh/vagrant/issues/1172


### PR DESCRIPTION
This adds the git submodule for Mastodon GO! at the current `v0.1.0` tag. This is *still* a *highly experimental development build*, but hopefully one polished enough for some live testing. You can get a sense for what features are missing here: https://github.com/marrus-sh/mastodon-go/milestone/2

The reason for merging this now is (1) easier testing of complicated stuff including non-local statuses, media, high traffic levels, etc., and (2) it lets me work on developing the more advanced themeïng stuff discussed in #156.

Some notes:

1. Adding an entire extra frontend makes `./bin/webpack-dev-server` go from a peak memory usage of ~1200M to ~1400M. Unfortunately this is enough of a change that the dev server (when also running rails/everything else) will crash on vagrant without extra memory, so I went and doubled the memory allocation in the vagrantfile. (This might be excessive.)

2. In order to get the frontend to actually show up and update we will need to do a `git submodule update --init` after pulling in these changes, and another `git submodule update` whenever the commit the submodule is tracking changes.

Other than that this all *should* go painlessly given the work that we've already done.