### PR TITLE
Maintain case-insensitivity when merging multiple matchers (#213)

### DIFF
--- a/app/models/glitch/keyword_mute.rb
+++ b/app/models/glitch/keyword_mute.rb
@@ -35,7 +35,7 @@ class Glitch::KeywordMute < ApplicationRecord
     def initialize(account_id)
       @account_id = account_id
       regex_text = Rails.cache.fetch("keyword_mutes:regex:#{account_id}") { regex_text_for_account }
-      @regex = /#{regex_text}/i
+      @regex = /#{regex_text}/
     end
 
     def =~(str)
@@ -60,7 +60,7 @@ class Glitch::KeywordMute < ApplicationRecord
       sb = keyword =~ /\A[[:word:]]/ ? '\b' : ''
       eb = keyword =~ /[[:word:]]\Z/ ? '\b' : ''
 
-      /#{sb}#{Regexp.escape(keyword)}#{eb}/
+      /(?mix:#{sb}#{Regexp.escape(keyword)}#{eb})/
     end
   end
 end

--- a/spec/models/glitch/keyword_mute_spec.rb
+++ b/spec/models/glitch/keyword_mute_spec.rb
@@ -60,6 +60,13 @@ RSpec.describe Glitch::KeywordMute, type: :model do
         expect(matcher =~ 'This is a HOT take').to be_truthy
       end
 
+      it 'maintains case-insensitivity when combining keywords into a single matcher' do
+        Glitch::KeywordMute.create!(account: alice, keyword: 'hot')
+        Glitch::KeywordMute.create!(account: alice, keyword: 'cold')
+
+        expect(matcher =~ 'This is a HOT take').to be_truthy
+      end
+
       it 'matches keywords surrounded by non-alphanumeric ornamentation' do
         Glitch::KeywordMute.create!(account: alice, keyword: 'hot')
 


### PR DESCRIPTION
When given two regexps, Regexp.union preserves the options set (or not
set) on each regex; this meant that none of the multiline (m),
case-insensitivity (i), or extended syntax (x) options were set.  Our
regexps are written expecting the m, i, and x options were set on all of
them, so we need to make sure that we preserve that behavior.