### PR TITLE
Allow streaming server to take bindhost from HOST env

### DIFF
--- a/streaming/index.js
+++ b/streaming/index.js
@@ -467,7 +467,7 @@ const startWorker = (workerId) => {
     });
   }, 30000);
 
-  server.listen(process.env.PORT || 4000, () => {
+  server.listen(process.env.PORT || 4000, process.env.HOST || '127.0.0.1', () => {
     log.info(`Worker ${workerId} now listening on ${server.address().address}:${server.address().port}`);
   });
 


### PR DESCRIPTION
A li'l commit which makes it possible to change what interface the streaming server to binds to.
Might come in handy for someone looking to scale up up their instance, and was taken from this old mainline suggestion from @tripougnif:

https://github.com/tootsuite/mastodon/issues/1283#issuecomment-295007564