### PR TITLE
Themed preloading

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,6 +13,7 @@ class ApplicationController < ActionController::Base
   helper_method :current_account
   helper_method :current_session
   helper_method :current_theme
+  helper_method :theme_data
   helper_method :single_user_mode?
 
   rescue_from ActionController::RoutingError, with: :not_found
@@ -86,6 +87,10 @@ class ApplicationController < ActionController::Base
   def current_theme
     return Setting.default_settings['theme'] unless Themes.instance.names.include? current_user&.setting_theme
     current_user.setting_theme
+  end
+
+  def theme_data
+    Themes.instance.get(current_theme)
   end
 
   def cache_collection(raw, klass)

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -6,7 +6,6 @@ class HomeController < ApplicationController
 
   def index
     @body_classes = 'app-body'
-    @frontend     = (params[:frontend] and Rails.configuration.x.available_frontends.include? params[:frontend] + '.js') ? params[:frontend] : 'mastodon'
   end
 
   private

--- a/app/javascript/themes/default/theme.yml
+++ b/app/javascript/themes/default/theme.yml
@@ -1,9 +1,18 @@
-#  (REQUIRED) Name must be unique across all installed themes.
-name: default
-
 #  (REQUIRED) The location of the pack file inside `pack_directory`.
 pack: application.js
 
 #  (OPTIONAL) The directory which contains the pack file.
-#  Defaults to the theme directory (`app/javascript/themes/[theme]`).
+#  Defaults to the theme directory (`app/javascript/themes/[theme]`),
+#  but in the case of the vanilla Mastodon theme the pack file is
+#  somewhere else.
 pack_directory: app/javascript/packs
+
+#  (OPTIONAL) Additional javascript resources to preload, for use with
+#  lazy-loaded components. It is **STRONGLY RECOMMENDED** that you
+#  derive these pathnames from `themes/[your-theme]` to ensure that
+#  they stay unique. (Of course, vanilla doesn't do this ^^;;)
+preload:
+- features/getting_started
+- features/compose
+- features/home_timeline
+- features/notifications

--- a/app/lib/themes.rb
+++ b/app/lib/themes.rb
@@ -10,11 +10,16 @@ class Themes
     result = Hash.new
     Dir.glob(Rails.root.join('app', 'javascript', 'themes', '*', 'theme.yml')) do |path|
       data = YAML.load_file(path)
-      if data['pack'] && data['name']
-        result[data['name']] = data
+      name = File.basename(File.dirname(path))
+      if data['pack']
+        result[name] = data
       end
     end
     @conf = result
+  end
+
+  def get(name)
+    @conf[name]
   end
 
   def names

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -1,8 +1,7 @@
 - content_for :header_tags do
-  %link{ href: asset_pack_path('features/getting_started.js'), crossorigin: 'anonymous', rel: 'preload', as: 'script' }/
-  %link{ href: asset_pack_path('features/compose.js'), crossorigin: 'anonymous', rel: 'preload', as: 'script' }/
-  %link{ href: asset_pack_path('features/home_timeline.js'), crossorigin: 'anonymous', rel: 'preload', as: 'script' }/
-  %link{ href: asset_pack_path('features/notifications.js'), crossorigin: 'anonymous', rel: 'preload', as: 'script' }/
+  - if theme_data['preload']
+    - theme_data['preload'].each do |link|
+      %link{ href: asset_pack_path("#{link}.js"), crossorigin: 'anonymous', rel: 'preload', as: 'script' }/
   %meta{name: 'applicationServerKey', content: Rails.configuration.x.vapid_public_key}
   %script#initial-state{ type: 'application/json' }!= json_escape(@initial_state_json)
 

--- a/config/webpack/configuration.js
+++ b/config/webpack/configuration.js
@@ -1,6 +1,6 @@
 // Common configuration for webpacker loaded from config/webpacker.yml
 
-const { dirname, join, resolve } = require('path');
+const { basename, dirname, join, resolve } = require('path');
 const { env } = require('process');
 const { safeLoad } = require('js-yaml');
 const { readFileSync } = require('fs');
@@ -18,8 +18,8 @@ for (let i = 0; i < themeFiles.length; i++) {
   if (!data.pack_directory) {
     data.pack_directory = dirname(themeFile);
   }
-  if (data.name && data.pack) {
-    themes[data.name] = data;
+  if (data.pack) {
+    themes[basename(dirname(themeFile))] = data;
   }
 }
 


### PR DESCRIPTION
I don't rails so someone might want to check my work. This just lets themes configure their own `preload` links instead of using vanilla Mastodon's all the time (regardless of whether they are needed). It also removes the `name` parameter from the theme YAML—the parent folder's name is used instead (this guarantees uniqueness).

One of the bullet points in #156.