### PR TITLE
Update StatusPolicy to check current_account for local_only? toots.

### DIFF
--- a/app/policies/status_policy.rb
+++ b/app/policies/status_policy.rb
@@ -6,7 +6,7 @@ class StatusPolicy < ApplicationPolicy
   end
 
   def show?
-    return false if local_only? && account.nil?
+    return false if local_only? && current_account.nil?
 
     if direct?
       owned? || record.mentions.where(account: current_account).exists?

--- a/spec/policies/status_policy_spec.rb
+++ b/spec/policies/status_policy_spec.rb
@@ -71,6 +71,12 @@ RSpec.describe StatusPolicy, type: :model do
 
       expect(subject).to_not permit(viewer, status)
     end
+
+    it 'denies access when local-only and the viewer is not logged in' do
+      allow(status).to receive(:local_only?) { true }
+
+      expect(subject).to_not permit(nil, status)
+    end
   end
 
   permissions :reblog? do


### PR DESCRIPTION
StatusPolicy#account was renamed to StatusPolicy#current_account in
upstream.  This commit renames the local-only changes to match and
augments the #show? policy spec with what we expect for local-only
toots.

Fixes #220.