### PR TITLE
Add option to remove DMs from home (#126)

### DIFF
--- a/app/javascript/flavours/glitch/features/home_timeline/components/column_settings.js
+++ b/app/javascript/flavours/glitch/features/home_timeline/components/column_settings.js
@@ -34,6 +34,10 @@ export default class ColumnSettings extends React.PureComponent {
           <SettingToggle prefix='home_timeline' settings={settings} settingKey={['shows', 'reply']} onChange={onChange} label={<FormattedMessage id='home.column_settings.show_replies' defaultMessage='Show replies' />} />
         </div>
 
+        <div className='column-settings__row'>
+          <SettingToggle prefix='home_timeline' settings={settings} settingKey={['shows', 'direct']} onChange={onChange} label={<FormattedMessage id='home.column_settings.show_direct' defaultMessage='Show DMs' />} />
+        </div>
+
         <span className='column-settings__section'><FormattedMessage id='home.column_settings.advanced' defaultMessage='Advanced' /></span>
 
         <div className='column-settings__row'>

--- a/app/javascript/flavours/glitch/features/ui/containers/status_list_container.js
+++ b/app/javascript/flavours/glitch/features/ui/containers/status_list_container.js
@@ -32,6 +32,10 @@ const makeGetStatusIds = () => createSelector([
       showStatus = showStatus && (statusForId.get('in_reply_to_id') === null || statusForId.get('in_reply_to_account_id') === me);
     }
 
+    if (columnSettings.getIn(['shows', 'direct']) === false) {
+      showStatus = showStatus && statusForId.get('visibility') !== 'direct';
+    }
+
     if (showStatus && regex && statusForId.get('account') !== me) {
       const searchIndex = statusForId.get('reblog') ? statuses.getIn([statusForId.get('reblog'), 'search_index']) : statusForId.get('search_index');
       showStatus = !regex.test(searchIndex);

--- a/app/javascript/flavours/glitch/reducers/settings.js
+++ b/app/javascript/flavours/glitch/reducers/settings.js
@@ -17,6 +17,7 @@ const initialState = ImmutableMap({
     shows: ImmutableMap({
       reblog: true,
       reply: true,
+      direct: true,
     }),
 
     regex: ImmutableMap({

--- a/app/javascript/glitch/locales/en.json
+++ b/app/javascript/glitch/locales/en.json
@@ -32,6 +32,8 @@
   "status.collapse": "Collapse",
   "status.uncollapse": "Uncollapse",
 
+  "home.column_settings.show_direct": "Show DMs",
+
   "notification.markForDeletion": "Mark for deletion",
   "notifications.clear": "Clear all my notifications",
   "notifications.marked_clear_confirmation": "Are you sure you want to permanently clear all selected notifications?",


### PR DESCRIPTION
Should fix #126 to make showing DMs in the home timeline a user-configurable option. Applies to both received toots and the user's own posts.