### PR TITLE
Remove getting-started picture

### DIFF
--- a/app/javascript/flavours/glitch/styles/components/index.scss
+++ b/app/javascript/flavours/glitch/styles/components/index.scss
@@ -2286,7 +2286,6 @@
 .getting-started {
   box-sizing: border-box;
   padding-bottom: 235px;
-  background: url('~images/mastodon-getting-started.png') no-repeat 0 100%;
   flex: 1 0 auto;
 
   p {


### PR DESCRIPTION
> why are you remove this picture?

im using 4k monitor
so i got space
![image](https://user-images.githubusercontent.com/28977652/33816484-8f4a684c-de7c-11e7-9775-c6b0fd067330.png)
i thought i want remove or stretch this
but i think it will not looks good if stretching this
so, i want remove this if using glitch edition
what do you think?
![image](https://user-images.githubusercontent.com/28977652/33816597-5e71d9b6-de7d-11e7-9115-e7008bd6068d.png)
