### PR TITLE
Route flavours ~ URLs

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -7,6 +7,7 @@ class HomeController < ApplicationController
 
   def index
     @body_classes = 'app-body'
+    redirect_to "/$#{current_flavour}/#{params[:glob] || ''}" unless Themes.instance.flavours.include?(params[:use_flavour].to_s) or request.path.start_with?("/$#{current_flavour}")
   end
 
   private
@@ -58,7 +59,7 @@ class HomeController < ApplicationController
   end
 
   def default_redirect_path
-    if request.path.start_with?('/web')
+    if request.path.start_with?('/web') || request.path.match?(/\A\$[\w-]+/)
       new_user_session_path
     elsif single_user_mode?
       short_account_path(Account.first)

--- a/app/javascript/flavours/glitch/containers/mastodon.js
+++ b/app/javascript/flavours/glitch/containers/mastodon.js
@@ -57,7 +57,7 @@ export default class Mastodon extends React.PureComponent {
     return (
       <IntlProvider locale={locale} messages={messages}>
         <Provider store={store}>
-          <BrowserRouter basename='/web'>
+          <BrowserRouter basename='/$glitch'>
             <ScrollContext>
               <Route path='/' component={UI} />
             </ScrollContext>

--- a/app/javascript/flavours/glitch/service_worker/web_push_notifications.js
+++ b/app/javascript/flavours/glitch/service_worker/web_push_notifications.js
@@ -17,7 +17,7 @@ const notify = options =>
         icon: '/android-chrome-192x192.png',
         tag: GROUP_TAG,
         data: {
-          url: (new URL('/web/notifications', self.location)).href,
+          url: (new URL('/$glitch/notifications', self.location)).href,
           count: notifications.length + 1,
           message: options.data.message,
         },

--- a/app/javascript/flavours/glitch/util/main.js
+++ b/app/javascript/flavours/glitch/util/main.js
@@ -12,8 +12,8 @@ function main() {
   if (window.history && history.replaceState) {
     const { pathname, search, hash } = window.location;
     const path = pathname + search + hash;
-    if (!(/^\/web[$/]/).test(path)) {
-      history.replaceState(null, document.title, `/web${path}`);
+    if (!(/^\/\$glitch[$/]/).test(path)) {
+      history.replaceState(null, document.title, `/$glitch${path}`);
     }
   }
 

--- a/app/javascript/mastodon/containers/mastodon.js
+++ b/app/javascript/mastodon/containers/mastodon.js
@@ -57,7 +57,7 @@ export default class Mastodon extends React.PureComponent {
     return (
       <IntlProvider locale={locale} messages={messages}>
         <Provider store={store}>
-          <BrowserRouter basename='/web'>
+          <BrowserRouter basename='/$vanilla'>
             <ScrollContext>
               <Route path='/' component={UI} />
             </ScrollContext>

--- a/app/javascript/mastodon/main.js
+++ b/app/javascript/mastodon/main.js
@@ -12,8 +12,8 @@ function main() {
   if (window.history && history.replaceState) {
     const { pathname, search, hash } = window.location;
     const path = pathname + search + hash;
-    if (!(/^\/web[$/]/).test(path)) {
-      history.replaceState(null, document.title, `/web${path}`);
+    if (!(/^\/\$vanilla[$/]/).test(path)) {
+      history.replaceState(null, document.title, `/$vanilla${path}`);
     }
   }
 

--- a/app/javascript/mastodon/service_worker/web_push_notifications.js
+++ b/app/javascript/mastodon/service_worker/web_push_notifications.js
@@ -102,16 +102,16 @@ const findBestClient = clients => {
 const openUrl = url =>
   self.clients.matchAll({ type: 'window' }).then(clientList => {
     if (clientList.length !== 0) {
-      const webClients = clientList.filter(client => /\/web\//.test(client.url));
+      const webClients = clientList.filter(client => /\/\$vanilla\//.test(client.url));
 
       if (webClients.length !== 0) {
         const client       = findBestClient(webClients);
         const { pathname } = new URL(url);
 
-        if (pathname.startsWith('/web/')) {
+        if (pathname.startsWith('/$vanilla/')) {
           return client.focus().then(client => client.postMessage({
             type: 'navigate',
-            path: pathname.slice('/web/'.length - 1),
+            path: pathname.slice('/$vanilla/'.length - 1),
           }));
         }
       } else if ('navigate' in clientList[0]) { // Chrome 42-48 does not support navigate

--- a/app/javascript/styles/win95.scss
+++ b/app/javascript/styles/win95.scss
@@ -1054,23 +1054,23 @@ body.admin {
   }
 }
 
-.column-link[href="/web/timelines/public"] {
+.column-link[href="/$vanilla/timelines/public"] {
   background-image: url("~images/icon_public.png");
   &:hover { background-image: url("~images/icon_public.png"); }
 }
-.column-link[href="/web/timelines/public/local"] {
+.column-link[href="/$vanilla/timelines/public/local"] {
   background-image: url("~images/icon_local.png");
   &:hover { background-image: url("~images/icon_local.png"); }
 }
-.column-link[href="/web/pinned"] {
+.column-link[href="/$vanilla/pinned"] {
   background-image: url("~images/icon_pin.png");
   &:hover { background-image: url("~images/icon_pin.png"); }
 }
-.column-link[href="/web/favourites"] {
+.column-link[href="/$vanilla/favourites"] {
   background-image: url("~images/icon_likes.png");
   &:hover { background-image: url("~images/icon_likes.png"); }
 }
-.column-link[href="/web/blocks"] {
+.column-link[href="/$vanilla/blocks"] {
   background-image: url("~images/icon_blocks.png");
   &:hover { background-image: url("~images/icon_blocks.png"); }
 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -240,7 +240,7 @@ Rails.application.routes.draw do
       resources :media,      only: [:create, :update]
       resources :blocks,     only: [:index]
       resources :mutes,      only: [:index] do
-        collection do 
+        collection do
           get 'details'
         end
       end
@@ -309,7 +309,8 @@ Rails.application.routes.draw do
     end
   end
 
-  get '/web/(*any)', to: 'home#index', as: :web
+  get '/web/(*glob)', to: 'home#index', as: :web
+  get "/$:use_flavour/(*glob)", to: 'home#index', constraints: { flavour: /[\w-]+/ }
 
   get '/about',      to: 'about#show'
   get '/about/more', to: 'about#more'


### PR DESCRIPTION
This PR gives flavours their own unique paths of the form `/$flavour-name/`. Having flavours be accessible via set paths is important for users who might want to use a different flavour on desktop versus mobile, among other reasons. The `$flavour-name` syntax is open to revision but I don't see Mastodon supporting cashtags any time soon lol so I just went with it. It looks a little `bash ~$`y which I kinda like.

As a result of this PR, the glitch flavour will be available at `/$glitch/` and the vanilla flavour will be available at `/$vanilla/`. The root path (`/`) and `/web/` will continue to serve your *default* flavour (the one you have configured in your preferences). However, for purposes of routing on the Javascript side, these will be redirected to the $ version on load.