### PR TITLE
Set packs on 2FA-related pages.  Fixes #271.

### DIFF
--- a/app/controllers/auth/sessions_controller.rb
+++ b/app/controllers/auth/sessions_controller.rb
@@ -8,8 +8,8 @@ class Auth::SessionsController < Devise::SessionsController
   skip_before_action :require_no_authentication, only: [:create]
   skip_before_action :check_suspension, only: [:destroy]
   prepend_before_action :authenticate_with_two_factor, if: :two_factor_enabled?, only: [:create]
+  prepend_before_action :set_pack
   before_action :set_instance_presenter, only: [:new]
-  before_action :set_pack
 
   def create
     super do |resource|

--- a/app/controllers/settings/two_factor_authentication/confirmations_controller.rb
+++ b/app/controllers/settings/two_factor_authentication/confirmations_controller.rb
@@ -2,11 +2,7 @@
 
 module Settings
   module TwoFactorAuthentication
-    class ConfirmationsController < ApplicationController
-      layout 'admin'
-
-      before_action :authenticate_user!
-
+    class ConfirmationsController < BaseController
       def new
         prepare_two_factor_form
       end

--- a/app/controllers/settings/two_factor_authentication/recovery_codes_controller.rb
+++ b/app/controllers/settings/two_factor_authentication/recovery_codes_controller.rb
@@ -2,11 +2,7 @@
 
 module Settings
   module TwoFactorAuthentication
-    class RecoveryCodesController < ApplicationController
-      layout 'admin'
-
-      before_action :authenticate_user!
-
+    class RecoveryCodesController < BaseController
       def create
         @recovery_codes = current_user.generate_otp_backup_codes!
         current_user.save!

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -615,8 +615,6 @@ ko:
     sensitive_content: 민감한 컨텐츠
   terms:
     title: "%{instance} 이용약관과 개인정보 취급 방침"
-  themes:
-    default: Mastodon
   time:
     formats:
       default: "%Y년 %m월 %d일 %H:%M"


### PR DESCRIPTION
This commit applies flavour packs on 2FA related pages as follows:

- changes `Settings::TwoFactorAuthentication::{Confirmations,RecoveryCodes}Controller` to derive from `Settings::BaseController`, because this gives us the necessary actions and packs
- prepends set_pack to `Auth::SessionsController`'s action chain so that it takes effect in time for `render :two_factor`