### PR TITLE
Fix #317: Attempting to switch flavors raises ActionController::ParameterMissing

### DIFF
--- a/app/controllers/settings/flavours_controller.rb
+++ b/app/controllers/settings/flavours_controller.rb
@@ -16,7 +16,7 @@ class Settings::FlavoursController < Settings::BaseController
   end
 
   def update
-    user_settings.update(user_settings_params(params[:flavour]))
+    user_settings.update(user_settings_params)
     redirect_to action: 'show', flavour: params[:flavour]
   end
 
@@ -26,7 +26,7 @@ class Settings::FlavoursController < Settings::BaseController
     UserSettingsDecorator.new(current_user)
   end
 
-  def user_settings_params(flavour)
+  def user_settings_params
     { setting_flavour: params.require(:flavour),
       setting_skin: params.dig(:user, :setting_skin)
     }.with_indifferent_access

--- a/app/controllers/settings/flavours_controller.rb
+++ b/app/controllers/settings/flavours_controller.rb
@@ -1,13 +1,12 @@
 # frozen_string_literal: true
 
 class Settings::FlavoursController < Settings::BaseController
-
   def index
     redirect_to action: 'show', flavour: current_flavour
   end
 
   def show
-    unless Themes.instance.flavours.include?(params[:flavour]) or params[:flavour] == current_flavour
+    unless Themes.instance.flavours.include?(params[:flavour]) || (params[:flavour] == current_flavour)
       redirect_to action: 'show', flavour: current_flavour
     end
 
@@ -28,7 +27,6 @@ class Settings::FlavoursController < Settings::BaseController
 
   def user_settings_params
     { setting_flavour: params.require(:flavour),
-      setting_skin: params.dig(:user, :setting_skin)
-    }.with_indifferent_access
+      setting_skin: params.dig(:user, :setting_skin) }.with_indifferent_access
   end
 end

--- a/app/controllers/settings/flavours_controller.rb
+++ b/app/controllers/settings/flavours_controller.rb
@@ -16,7 +16,7 @@ class Settings::FlavoursController < Settings::BaseController
   end
 
   def update
-    user_settings.update(user_settings_params(params[:flavour]).to_h)
+    user_settings.update(user_settings_params(params[:flavour]))
     redirect_to action: 'show', flavour: params[:flavour]
   end
 
@@ -27,9 +27,8 @@ class Settings::FlavoursController < Settings::BaseController
   end
 
   def user_settings_params(flavour)
-    params.require(:user).merge({ setting_flavour: flavour }).permit(
-      :setting_flavour,
-      :setting_skin
-    )
+    { setting_flavour: params.require(:flavour),
+      setting_skin: params.dig(:user, :setting_skin)
+    }.with_indifferent_access
   end
 end

--- a/spec/controllers/settings/flavours_controller_spec.rb
+++ b/spec/controllers/settings/flavours_controller_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe Settings::FlavoursController, type: :controller do
+  let(:user) { Fabricate(:user) }
+
+  before do
+    sign_in user, scope: :user
+  end
+
+  describe 'PUT #update' do
+    describe 'without a user[setting_skin] parameter' do
+      it 'sets the selected flavour' do
+        put :update, params: { flavour: 'schnozzberry' }
+
+        user.reload
+
+        expect(user.setting_flavour).to eq 'schnozzberry'
+      end
+    end
+
+    describe 'with a user[setting_skin] parameter' do
+      before do
+        put :update, params: { flavour: 'schnozzberry', user: { setting_skin: 'wallpaper' } }
+
+        user.reload
+      end
+
+      it 'sets the selected flavour' do
+        expect(user.setting_flavour).to eq 'schnozzberry'
+      end
+
+      it 'sets the selected skin' do
+        expect(user.setting_skin).to eq 'wallpaper'
+      end
+    end
+  end
+end

--- a/spec/controllers/settings/flavours_controller_spec.rb
+++ b/spec/controllers/settings/flavours_controller_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rails_helper'
 
 RSpec.describe Settings::FlavoursController, type: :controller do


### PR DESCRIPTION
If a flavour has only one skin, the skin selector will be omitted.  This
omits the user[setting_skin] field, and because that's the only
user[...] field on the page, the entire user object will not be present
in the request handler's params object.

This commit accounts for that scenario by avoiding params.require(:user)
and instead picking out what we need from the params hash.