### PR TITLE
dockerfile: Give more stack space to /sbin/tini

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,9 @@ RUN apk -U upgrade \
  && rm -rf /tmp/* /var/cache/apk/*
 
 COPY Gemfile Gemfile.lock package.json yarn.lock .yarnclean /mastodon/
+COPY stack-fix.c /lib
+RUN gcc -shared -fPIC /lib/stack-fix.c -o /lib/stack-fix.so
+RUN rm /lib/stack-fix.c
 
 RUN bundle config build.nokogiri --with-iconv-lib=/usr/local/lib --with-iconv-include=/usr/local/include \
  && bundle install -j$(getconf _NPROCESSORS_ONLN) --deployment --without test development \

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -11,4 +11,4 @@ echo "Updating permissions..."
 find /mastodon -path /mastodon/public/system -prune -o -not -user mastodon -not -group mastodon -print0 | xargs -0 chown -f mastodon:mastodon
 
 echo "Executing process..."
-exec su-exec mastodon:mastodon /sbin/tini -- "$@"
+LD_PRELOAD=/lib/stack-fix.so exec su-exec mastodon:mastodon /sbin/tini -- "$@"

--- a/stack-fix.c
+++ b/stack-fix.c
@@ -1,0 +1,32 @@
+#include <dlfcn.h>
+#include <pthread.h>
+#include <stdio.h>
+
+// THIS IS TO AVOID A SIGFAULT WHEN RUNNING python3.6 manage.py runserver
+// This should be fixed at some point by Alpine and/or Python
+// Check this issue for more info
+// https://github.com/docker-library/python/issues/211
+typedef int (*func_t)(pthread_t *thread, const pthread_attr_t *attr, void *(*start_routine)(void*), void *arg);
+
+int pthread_create(pthread_t *thread, const pthread_attr_t *attr, void *(*start_routine)(void*), void *arg) {
+
+    pthread_attr_t local;
+    int used = 0, ret;
+
+    if (!attr) {
+        used = 1;
+        pthread_attr_init(&local);
+        attr = &local;
+    }
+    pthread_attr_setstacksize((void*)attr, 2 * 1024 * 1024); // 2 MB
+
+    func_t orig = (func_t)dlsym(RTLD_NEXT, "pthread_create");
+
+    ret = orig(thread, attr, start_routine, arg);
+
+    if (used) {
+        pthread_attr_destroy(&local);
+    }
+
+    return ret;
+}


### PR DESCRIPTION
/sbin/tini ends up running the Sass compiler, which seems to need a
larger thread stack size than the musl default.  This patch incorporates
a fix from
https://raw.githubusercontent.com/jubel-han/dockerfiles/master/common/stack-fix.c,
as described in https://github.com/sass/node-sass/issues/2031.