### PR TITLE
[WIP] Add mute and block notes

### DIFF
--- a/app/models/account_domain_block.rb
+++ b/app/models/account_domain_block.rb
@@ -19,6 +19,8 @@ class AccountDomainBlock < ApplicationRecord
   after_create  :remove_blocking_cache
   after_destroy :remove_blocking_cache
 
+  has_one :note, class_name: 'Glitch::Note', as: :target
+
   private
 
   def remove_blocking_cache

--- a/app/models/block.rb
+++ b/app/models/block.rb
@@ -21,6 +21,8 @@ class Block < ApplicationRecord
   after_create  :remove_blocking_cache
   after_destroy :remove_blocking_cache
 
+  has_one :note, class_name: 'Glitch::Note', as: :target
+
   private
 
   def remove_blocking_cache

--- a/app/models/glitch/note.rb
+++ b/app/models/glitch/note.rb
@@ -1,0 +1,15 @@
+# == Schema Information
+#
+# Table name: glitch_notes
+#
+#  id          :integer          not null, primary key
+#  target_id   :integer          not null
+#  target_type :string           not null
+#  note        :text             not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+
+class Glitch::Note < ApplicationRecord
+  belongs_to :target, polymorphic: true
+end

--- a/app/models/mute.rb
+++ b/app/models/mute.rb
@@ -22,6 +22,8 @@ class Mute < ApplicationRecord
   after_create  :remove_blocking_cache
   after_destroy :remove_blocking_cache
 
+  has_one :note, class_name: 'Glitch::Note', as: :target
+
   private
 
   def remove_blocking_cache

--- a/db/migrate/20180118192721_create_glitch_notes.rb
+++ b/db/migrate/20180118192721_create_glitch_notes.rb
@@ -1,0 +1,11 @@
+class CreateGlitchNotes < ActiveRecord::Migration[5.1]
+  def change
+    create_table :glitch_notes do |t|
+      t.bigint :target_id, null: false
+      t.string :target_type, null: false
+      t.text :note, null: false
+      t.index [:target_id, :target_type]
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180106000232) do
+ActiveRecord::Schema.define(version: 20180118192721) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -180,6 +180,15 @@ ActiveRecord::Schema.define(version: 20180106000232) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["account_id"], name: "index_glitch_keyword_mutes_on_account_id"
+  end
+
+  create_table "glitch_notes", force: :cascade do |t|
+    t.bigint "target_id", null: false
+    t.string "target_type", null: false
+    t.text "note", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["target_id", "target_type"], name: "index_glitch_notes_on_target_id_and_target_type"
   end
 
   create_table "imports", force: :cascade do |t|

--- a/spec/fabricators/glitch_note_fabricator.rb
+++ b/spec/fabricators/glitch_note_fabricator.rb
@@ -1,0 +1,2 @@
+Fabricator('Glitch::Note') do
+end

--- a/spec/models/glitch/note_spec.rb
+++ b/spec/models/glitch/note_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Glitch::Note, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
This is really early, but I wanted to file this so that

1. people know it's being worked on
2. people know my proposed schema changes ASAP

Tasks:
- [X] Add `Glitch::Note` model
- [X] Integrate `Glitch::Note` with block/mute models
- [ ] Add an API endpoint to attach notes to existing blocks and mutes
- [ ] Extend block/mute API endpoint to accept a note with the block
- [ ] Add note textareas to glitch flavour UI 