### PR TITLE
Display a warning when composing unlisted toots with something looking like a hashtag

### DIFF
--- a/app/javascript/flavours/glitch/features/composer/hashtag_warning/index.js
+++ b/app/javascript/flavours/glitch/features/composer/hashtag_warning/index.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import Motion from 'flavours/glitch/util/optional_motion';
+import spring from 'react-motion/lib/spring';
+import { defineMessages, FormattedMessage } from 'react-intl';
+
+//  This is the spring used with our motion.
+const motionSpring = spring(1, { damping: 35, stiffness: 400 });
+
+//  Messages.
+const messages = defineMessages({
+  disclaimer: {
+    defaultMessage: 'This toot won\'t be listed under any hashtag as it is unlisted. Only public toots can be searched by hashtag.',
+    id: 'compose_form.hashtag_warning',
+  },
+});
+
+//  The component.
+export default function ComposerHashtagWarning () {
+  return (
+    <Motion
+      defaultStyle={{
+        opacity: 0,
+        scaleX: 0.85,
+        scaleY: 0.75,
+      }}
+      style={{
+        opacity: motionSpring,
+        scaleX: motionSpring,
+        scaleY: motionSpring,
+      }}
+    >
+      {({ opacity, scaleX, scaleY }) => (
+        <div
+          className='composer--warning'
+          style={{
+            opacity: opacity,
+            transform: `scale(${scaleX}, ${scaleY})`,
+          }}
+        >
+          <FormattedMessage
+            {...messages.disclaimer}
+          />
+        </div>
+      )}
+    </Motion>
+  );
+}
+
+ComposerHashtagWarning.propTypes = {};

--- a/app/javascript/flavours/glitch/features/composer/index.js
+++ b/app/javascript/flavours/glitch/features/composer/index.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 
+const APPROX_HASHTAG_RE = /(?:^|[^\/\)\w])#(\S+)/i;
+
 //  Actions.
 import {
   cancelReplyCompose,
@@ -36,6 +38,7 @@ import ComposerSpoiler from './spoiler';
 import ComposerTextarea from './textarea';
 import ComposerUploadForm from './upload_form';
 import ComposerWarning from './warning';
+import ComposerHashtagWarning from './hashtag_warning';
 
 //  Utils.
 import { countableText } from 'flavours/glitch/util/counter';
@@ -312,6 +315,7 @@ class Composer extends React.Component {
           text={spoilerText}
         />
         {privacy === 'private' && amUnlocked ? <ComposerWarning /> : null}
+        {privacy !== 'public' && APPROX_HASHTAG_RE.test(text) ? <ComposerHashtagWarning /> : null}
         {replyContent ? (
           <ComposerReply
             account={replyAccount}


### PR DESCRIPTION
This is a backport of b6af88192ff48372c5f6ed1321f21d99aaffcd3f to the glitch flavour.