### PR TITLE
Do not discard statuses obtained via websocket when API request finishes

### DIFF
--- a/app/javascript/flavours/glitch/reducers/timelines.js
+++ b/app/javascript/flavours/glitch/reducers/timelines.js
@@ -40,7 +40,7 @@ const normalizeTimeline = (state, timeline, statuses, next, isPartial) => {
     mMap.set('loaded', true);
     mMap.set('isLoading', false);
     if (!hadNext) mMap.set('next', next);
-    mMap.set('items', wasLoaded ? ids.concat(oldIds) : ids);
+    mMap.set('items', wasLoaded ? ids.concat(oldIds) : oldIds.concat(ids));
     mMap.set('isPartial', isPartial);
   }));
 };


### PR DESCRIPTION
This backports 0b888acfd4ffddd29f25c878373e9b9f5ec6c0ab