### PR TITLE
Fix error 500 page

### DIFF
--- a/public/500.html
+++ b/public/500.html
@@ -1,0 +1,1 @@
+assets/500.html


### PR DESCRIPTION
For some reason, asserts/500.html, which was supposed to be a symlink, was a blank page instead