### PR TITLE
Port attachment lists to glitch-soc flavour

### DIFF
--- a/app/javascript/flavours/glitch/components/attachment_list.js
+++ b/app/javascript/flavours/glitch/components/attachment_list.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import ImmutablePropTypes from 'react-immutable-proptypes';
+import PropTypes from 'prop-types';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 
 const filename = url => url.split('/').pop().split('#')[0].split('?')[0];
@@ -8,10 +9,25 @@ export default class AttachmentList extends ImmutablePureComponent {
 
   static propTypes = {
     media: ImmutablePropTypes.list.isRequired,
+    compact: PropTypes.bool,
   };
 
   render () {
-    const { media } = this.props;
+    const { media, compact } = this.props;
+
+    if (compact) {
+      return (
+        <div className='attachment-list compact'>
+          <ul className='attachment-list__list'>
+            {media.map(attachment => (
+              <li key={attachment.get('id')}>
+                <a href={attachment.get('remote_url')} target='_blank' rel='noopener'><i className='fa fa-link' /> {filename(attachment.get('remote_url'))}</a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      );
+    }
 
     return (
       <div className='attachment-list'>

--- a/app/javascript/flavours/glitch/components/attachment_list.js
+++ b/app/javascript/flavours/glitch/components/attachment_list.js
@@ -19,11 +19,15 @@ export default class AttachmentList extends ImmutablePureComponent {
       return (
         <div className='attachment-list compact'>
           <ul className='attachment-list__list'>
-            {media.map(attachment => (
-              <li key={attachment.get('id')}>
-                <a href={attachment.get('remote_url')} target='_blank' rel='noopener'><i className='fa fa-link' /> {filename(attachment.get('remote_url'))}</a>
-              </li>
-            ))}
+            {media.map(attachment => {
+              const displayUrl = attachment.get('remote_url') || attachment.get('url');
+
+              return (
+                <li key={attachment.get('id')}>
+                  <a href={displayUrl} target='_blank' rel='noopener'><i className='fa fa-link' /> {filename(displayUrl)}</a>
+                </li>
+              );
+            })}
           </ul>
         </div>
       );
@@ -36,11 +40,13 @@ export default class AttachmentList extends ImmutablePureComponent {
         </div>
 
         <ul className='attachment-list__list'>
-          {media.map(attachment =>
-            (<li key={attachment.get('id')}>
-              <a href={attachment.get('remote_url')} target='_blank' rel='noopener'>{filename(attachment.get('remote_url'))}</a>
+          const displayUrl = attachment.get('remote_url') || attachment.get('url');
+
+          {media.map(attachment => {
+            return (<li key={attachment.get('id')}>
+              <a href={displayUrl} target='_blank' rel='noopener'>{filename(displayUrl)}</a>
             </li>)
-          )}
+          })}
         </ul>
       </div>
     );

--- a/app/javascript/flavours/glitch/components/status.js
+++ b/app/javascript/flavours/glitch/components/status.js
@@ -6,6 +6,7 @@ import StatusHeader from './status_header';
 import StatusIcons from './status_icons';
 import StatusContent from './status_content';
 import StatusActionBar from './status_action_bar';
+import AttachmentList from './attachment_list';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 import { MediaGallery, Video } from 'flavours/glitch/util/async-components';
 import { HotKeys } from 'react-hotkeys';
@@ -311,7 +312,12 @@ export default class Status extends ImmutablePureComponent {
     attachments = status.get('media_attachments');
     if (attachments.size > 0 && !muted) {
       if (attachments.some(item => item.get('type') === 'unknown')) {  //  Media type is 'unknown'
-        /*  Do nothing  */
+        media = (
+          <AttachmentList
+            compact
+            media={status.get('media_attachments')}
+          />
+        );
       } else if (attachments.getIn([0, 'type']) === 'video') {  //  Media type is 'video'
         const video = status.getIn(['media_attachments', 0]);
 

--- a/app/javascript/flavours/glitch/components/status.js
+++ b/app/javascript/flavours/glitch/components/status.js
@@ -302,16 +302,16 @@ export default class Status extends ImmutablePureComponent {
       background = status.getIn(['account', 'header']);
     }
 
-    //  This handles our media attachments. Note that we don't show media on
-    //  muted (notification) statuses. If the media type is unknown, then we
-    //  simply ignore it.
+    //  This handles our media attachments.
+    //  If a media file is of unknwon type or if the status is muted
+    //  (notification), we show a list of links instead of embedded media.
 
     //  After we have generated our appropriate media element and stored it in
     //  `media`, we snatch the thumbnail to use as our `background` if media
     //  backgrounds for collapsed statuses are enabled.
     attachments = status.get('media_attachments');
-    if (attachments.size > 0 && !muted) {
-      if (attachments.some(item => item.get('type') === 'unknown')) {  //  Media type is 'unknown'
+    if (attachments.size > 0) {
+      if (muted || attachments.some(item => item.get('type') === 'unknown')) {
         media = (
           <AttachmentList
             compact

--- a/app/javascript/flavours/glitch/styles/components/lists.scss
+++ b/app/javascript/flavours/glitch/styles/components/lists.scss
@@ -5,45 +5,59 @@
   border-radius: 4px;
   margin-top: 14px;
   overflow: hidden;
-}
 
-.attachment-list__icon {
-  flex: 0 0 auto;
-  color: $ui-base-lighter-color;
-  padding: 8px 18px;
-  cursor: default;
-  border-right: 1px solid lighten($ui-base-color, 8%);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  font-size: 26px;
-
-  .fa {
-    display: block;
-  }
-}
-
-.attachment-list__list {
-  list-style: none;
-  padding: 4px 0;
-  padding-left: 8px;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-
-  li {
-    display: block;
-    padding: 4px 0;
-  }
-
-  a {
-    text-decoration: none;
+  &__icon {
+    flex: 0 0 auto;
     color: $ui-base-lighter-color;
-    font-weight: 500;
+    padding: 8px 18px;
+    cursor: default;
+    border-right: 1px solid lighten($ui-base-color, 8%);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    font-size: 26px;
 
-    &:hover {
-      text-decoration: underline;
+    .fa {
+      display: block;
+    }
+  }
+
+  &__list {
+    list-style: none;
+    padding: 4px 0;
+    padding-left: 8px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+
+    li {
+      display: block;
+      padding: 4px 0;
+    }
+
+    a {
+      text-decoration: none;
+      color: $ui-base-lighter-color;
+      font-weight: 500;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+  }
+
+  &.compact {
+    border: 0;
+    margin-top: 4px;
+
+    .attachment-list__list {
+      padding: 0;
+      display: block;
+    }
+
+    .fa {
+      color: $ui-base-lighter-color;
     }
   }
 }


### PR DESCRIPTION
Port two changes from Mastodon's UI:
- display a list of attachments in toots if some couldn't be fetched/processed
- display such a list in notifications instead of dropping attached media entirely