### PR TITLE
Remove ignored 'u' parameter on regexp (#392)

### DIFF
--- a/app/lib/frontmatter_handler.rb
+++ b/app/lib/frontmatter_handler.rb
@@ -10,7 +10,7 @@ class FrontmatterHandler
   #  CONVENIENCE FUNCTIONS  #
 
   def self.unirex(str)
-    Regexp.new str, Regexp::MULTILINE, 'u'
+    Regexp.new str, Regexp::MULTILINE
   end
   def self.rexstr(exp)
     '(?:' + exp.source + ')'


### PR DESCRIPTION
Fixes #392 by removing superfluous parameter