### PR TITLE
Port the “unfold thread” feature from Mastodon's UI to glitch-soc flavour

### DIFF
--- a/app/javascript/flavours/glitch/components/column_header.js
+++ b/app/javascript/flavours/glitch/components/column_header.js
@@ -28,7 +28,6 @@ export default class ColumnHeader extends React.PureComponent {
     active: PropTypes.bool,
     localSettings : ImmutablePropTypes.map,
     multiColumn: PropTypes.bool,
-    focusable: PropTypes.bool,
     showBackButton: PropTypes.bool,
     notifCleaning: PropTypes.bool, // true only for the notification column
     notifCleaningActive: PropTypes.bool,
@@ -40,10 +39,6 @@ export default class ColumnHeader extends React.PureComponent {
     onClick: PropTypes.func,
     intl: PropTypes.object.isRequired,
   };
-
-  static defaultProps = {
-    focusable: true,
-  }
 
   state = {
     collapsed: true,
@@ -91,7 +86,7 @@ export default class ColumnHeader extends React.PureComponent {
   }
 
   render () {
-    const { intl, icon, active, children, pinned, onPin, multiColumn, focusable, showBackButton, intl: { formatMessage }, notifCleaning, notifCleaningActive } = this.props;
+    const { intl, icon, active, children, pinned, onPin, multiColumn, showBackButton, intl: { formatMessage }, notifCleaning, notifCleaningActive } = this.props;
     const { collapsed, animating, animatingNCD } = this.state;
 
     let title = this.props.title;
@@ -172,11 +167,13 @@ export default class ColumnHeader extends React.PureComponent {
 
     return (
       <div className={wrapperClassName}>
-        <h1 tabIndex={focusable ? 0 : null} role='button' className={buttonClassName} aria-label={title} onClick={this.handleTitleClick}>
-          <i className={`fa fa-fw fa-${icon} column-header__icon`} />
-          <span className='column-header__title'>
-            {title}
-          </span>
+        <h1 className={buttonClassName}>
+          <button onClick={this.handleTitleClick}>
+            <i className={`fa fa-fw fa-${icon} column-header__icon`} />
+            <span className='column-header__title'>
+              {title}
+            </span>
+          </button>
           <div className='column-header__buttons'>
             {backButton}
             { notifCleaning ? (

--- a/app/javascript/flavours/glitch/components/column_header.js
+++ b/app/javascript/flavours/glitch/components/column_header.js
@@ -23,11 +23,12 @@ export default class ColumnHeader extends React.PureComponent {
 
   static propTypes = {
     intl: PropTypes.object.isRequired,
-    title: PropTypes.node.isRequired,
-    icon: PropTypes.string.isRequired,
+    title: PropTypes.node,
+    icon: PropTypes.string,
     active: PropTypes.bool,
     localSettings : ImmutablePropTypes.map,
     multiColumn: PropTypes.bool,
+    extraButton: PropTypes.node,
     showBackButton: PropTypes.bool,
     notifCleaning: PropTypes.bool, // true only for the notification column
     notifCleaningActive: PropTypes.bool,
@@ -86,7 +87,7 @@ export default class ColumnHeader extends React.PureComponent {
   }
 
   render () {
-    const { intl, icon, active, children, pinned, onPin, multiColumn, showBackButton, intl: { formatMessage }, notifCleaning, notifCleaningActive } = this.props;
+    const { intl, icon, active, children, pinned, onPin, multiColumn, extraButton, showBackButton, intl: { formatMessage }, notifCleaning, notifCleaningActive } = this.props;
     const { collapsed, animating, animatingNCD } = this.state;
 
     let title = this.props.title;
@@ -162,18 +163,26 @@ export default class ColumnHeader extends React.PureComponent {
     }
 
     if (children || multiColumn) {
-      collapseButton = <button className={collapsibleButtonClassName} aria-label={formatMessage(collapsed ? messages.show : messages.hide)} aria-pressed={collapsed ? 'false' : 'true'} onClick={this.handleToggleClick}><i className='fa fa-sliders' /></button>;
+      collapseButton = <button className={collapsibleButtonClassName} title={formatMessage(collapsed ? messages.show : messages.hide)} aria-label={formatMessage(collapsed ? messages.show : messages.hide)} aria-pressed={collapsed ? 'false' : 'true'} onClick={this.handleToggleClick}><i className='fa fa-sliders' /></button>;
     }
+
+    const hasTitle = icon && title;
 
     return (
       <div className={wrapperClassName}>
         <h1 className={buttonClassName}>
-          <button onClick={this.handleTitleClick}>
-            <i className={`fa fa-fw fa-${icon} column-header__icon`} />
-            {title}
-          </button>
+          {hasTitle && (
+            <button onClick={this.handleTitleClick}>
+              <i className={`fa fa-fw fa-${icon} column-header__icon`} />
+              {title}
+            </button>
+          )}
+
+          {!hasTitle && backButton}
+
           <div className='column-header__buttons'>
-            {backButton}
+            {hasTitle && backButton}
+            {extraButton}
             { notifCleaning ? (
               <button
                 aria-label={msgEnterNotifCleaning}

--- a/app/javascript/flavours/glitch/components/column_header.js
+++ b/app/javascript/flavours/glitch/components/column_header.js
@@ -170,9 +170,7 @@ export default class ColumnHeader extends React.PureComponent {
         <h1 className={buttonClassName}>
           <button onClick={this.handleTitleClick}>
             <i className={`fa fa-fw fa-${icon} column-header__icon`} />
-            <span className='column-header__title'>
-              {title}
-            </span>
+            {title}
           </button>
           <div className='column-header__buttons'>
             {backButton}

--- a/app/javascript/flavours/glitch/components/status.js
+++ b/app/javascript/flavours/glitch/components/status.js
@@ -47,10 +47,11 @@ export default class Status extends ImmutablePureComponent {
     onMoveDown: PropTypes.func,
     getScrollPosition: PropTypes.func,
     updateScrollBottom: PropTypes.func,
+    expanded: PropTypes.bool,
   };
 
   state = {
-    isExpanded: false,
+    isExpanded: this.props.expanded,
     isCollapsed: false,
     autoCollapsed: false,
   }
@@ -92,6 +93,9 @@ export default class Status extends ImmutablePureComponent {
       nextProps.collapse !== this.props.collapse &&
       nextProps.collapse !== undefined
     ) this.setCollapsed(nextProps.collapse);
+    if (nextProps.expanded !== this.props.expanded &&
+      nextProps.expanded !== undefined
+    ) this.setExpansion(nextProps.expanded);
   }
 
   //  When mounting, we just check to see if our status should be collapsed,
@@ -465,7 +469,7 @@ export default class Status extends ImmutablePureComponent {
             media={media}
             mediaIcon={mediaIcon}
             expanded={isExpanded}
-            setExpansion={setExpansion}
+            onExpandedToggle={this.handleExpandedToggle}
             parseClick={parseClick}
             disabled={!router}
           />

--- a/app/javascript/flavours/glitch/components/status_content.js
+++ b/app/javascript/flavours/glitch/components/status_content.js
@@ -12,7 +12,7 @@ export default class StatusContent extends React.PureComponent {
     status: ImmutablePropTypes.map.isRequired,
     expanded: PropTypes.bool,
     collapsed: PropTypes.bool,
-    setExpansion: PropTypes.func,
+    onExpandedToggle: PropTypes.func,
     media: PropTypes.element,
     mediaIcon: PropTypes.string,
     parseClick: PropTypes.func,
@@ -112,8 +112,8 @@ export default class StatusContent extends React.PureComponent {
   handleSpoilerClick = (e) => {
     e.preventDefault();
 
-    if (this.props.setExpansion) {
-      this.props.setExpansion(!this.props.expanded);
+    if (this.props.onExpandedToggle) {
+      this.props.onExpandedToggle();
     } else {
       this.setState({ hidden: !this.state.hidden });
     }
@@ -132,7 +132,7 @@ export default class StatusContent extends React.PureComponent {
       disabled,
     } = this.props;
 
-    const hidden = this.props.setExpansion ? !this.props.expanded : this.state.hidden;
+    const hidden = this.props.onExpandedToggle ? !this.props.expanded : this.state.hidden;
 
     const content = { __html: status.get('contentHtml') };
     const spoilerContent = { __html: status.get('spoilerHtml') };

--- a/app/javascript/flavours/glitch/components/status_content.js
+++ b/app/javascript/flavours/glitch/components/status_content.js
@@ -11,6 +11,7 @@ export default class StatusContent extends React.PureComponent {
   static propTypes = {
     status: ImmutablePropTypes.map.isRequired,
     expanded: PropTypes.bool,
+    collapsed: PropTypes.bool,
     setExpansion: PropTypes.func,
     media: PropTypes.element,
     mediaIcon: PropTypes.string,
@@ -64,7 +65,7 @@ export default class StatusContent extends React.PureComponent {
   }
 
   onLinkClick = (e) => {
-    if (this.props.expanded === false) {
+    if (this.props.collapsed) {
       if (this.props.parseClick) this.props.parseClick(e);
     }
   }
@@ -112,7 +113,7 @@ export default class StatusContent extends React.PureComponent {
     e.preventDefault();
 
     if (this.props.setExpansion) {
-      this.props.setExpansion(this.props.expanded ? null : true);
+      this.props.setExpansion(!this.props.expanded);
     } else {
       this.setState({ hidden: !this.state.hidden });
     }

--- a/app/javascript/flavours/glitch/components/status_icons.js
+++ b/app/javascript/flavours/glitch/components/status_icons.js
@@ -22,15 +22,15 @@ export default class StatusIcons extends React.PureComponent {
     mediaIcon: PropTypes.string,
     collapsible: PropTypes.bool,
     collapsed: PropTypes.bool,
-    setExpansion: PropTypes.func.isRequired,
+    setCollapsed: PropTypes.func.isRequired,
     intl: PropTypes.object.isRequired,
   };
 
   //  Handles clicks on collapsed button
   handleCollapsedClick = (e) => {
-    const { collapsed, setExpansion } = this.props;
+    const { collapsed, setCollapsed } = this.props;
     if (e.button === 0) {
-      setExpansion(collapsed ? null : false);
+      setCollapsed(!collapsed);
       e.preventDefault();
     }
   }

--- a/app/javascript/flavours/glitch/features/status/components/detailed_status.js
+++ b/app/javascript/flavours/glitch/features/status/components/detailed_status.js
@@ -24,6 +24,8 @@ export default class DetailedStatus extends ImmutablePureComponent {
     settings: ImmutablePropTypes.map.isRequired,
     onOpenMedia: PropTypes.func.isRequired,
     onOpenVideo: PropTypes.func.isRequired,
+    onToggleHidden: PropTypes.func.isRequired,
+    expanded: PropTypes.bool,
   };
 
   handleAccountClick = (e) => {
@@ -41,7 +43,7 @@ export default class DetailedStatus extends ImmutablePureComponent {
 
   render () {
     const status = this.props.status.get('reblog') ? this.props.status.get('reblog') : this.props.status;
-    const { expanded, setExpansion, settings } = this.props;
+    const { expanded, onToggleHidden, settings } = this.props;
 
     let media           = '';
     let mediaIcon       = null;
@@ -115,7 +117,7 @@ export default class DetailedStatus extends ImmutablePureComponent {
           mediaIcon={mediaIcon}
           expanded={expanded}
           collapsed={false}
-          setExpansion={setExpansion}
+          onExpandedToggle={onToggleHidden}
         />
 
         <div className='detailed-status__meta'>

--- a/app/javascript/flavours/glitch/features/status/components/detailed_status.js
+++ b/app/javascript/flavours/glitch/features/status/components/detailed_status.js
@@ -114,6 +114,7 @@ export default class DetailedStatus extends ImmutablePureComponent {
           media={media}
           mediaIcon={mediaIcon}
           expanded={expanded}
+          collapsed={false}
           setExpansion={setExpansion}
         />
 

--- a/app/javascript/flavours/glitch/features/status/index.js
+++ b/app/javascript/flavours/glitch/features/status/index.js
@@ -29,6 +29,7 @@ import { initReport } from 'flavours/glitch/actions/reports';
 import { makeGetStatus } from 'flavours/glitch/selectors';
 import { ScrollContainer } from 'react-router-scroll-4';
 import ColumnBackButton from 'flavours/glitch/components/column_back_button';
+import ColumnHeader from '../../components/column_header';
 import StatusContainer from 'flavours/glitch/containers/status_container';
 import { openModal } from 'flavours/glitch/actions/modal';
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
@@ -41,6 +42,8 @@ const messages = defineMessages({
   deleteConfirm: { id: 'confirmations.delete.confirm', defaultMessage: 'Delete' },
   deleteMessage: { id: 'confirmations.delete.message', defaultMessage: 'Are you sure you want to delete this status?' },
   blockConfirm: { id: 'confirmations.block.confirm', defaultMessage: 'Block' },
+  revealAll: { id: 'status.show_more_all', defaultMessage: 'Show more for all' },
+  hideAll: { id: 'status.show_less_all', defaultMessage: 'Show less for all' },
 });
 
 const makeMapStateToProps = () => {
@@ -77,6 +80,7 @@ export default class Status extends ImmutablePureComponent {
   state = {
     fullscreen: false,
     isExpanded: false,
+    threadExpanded: null,
   };
 
   componentWillMount () {
@@ -190,6 +194,11 @@ export default class Status extends ImmutablePureComponent {
     }
   }
 
+  handleToggleAll = () => {
+    const { isExpanded } = this.state;
+    this.setState({ isExpanded: !isExpanded, threadExpanded: !isExpanded });
+  }
+
   handleBlockClick = (account) => {
     const { dispatch, intl } = this.props;
 
@@ -285,6 +294,7 @@ export default class Status extends ImmutablePureComponent {
       <StatusContainer
         key={id}
         id={id}
+        expanded={this.state.threadExpanded}
         onMoveUp={this.handleMoveUp}
         onMoveDown={this.handleMoveDown}
       />
@@ -327,7 +337,7 @@ export default class Status extends ImmutablePureComponent {
   render () {
     let ancestors, descendants;
     const { setExpansion } = this;
-    const { status, settings, ancestorsIds, descendantsIds } = this.props;
+    const { status, settings, ancestorsIds, descendantsIds, intl } = this.props;
     const { fullscreen, isExpanded } = this.state;
 
     if (status === null) {
@@ -360,7 +370,12 @@ export default class Status extends ImmutablePureComponent {
 
     return (
       <Column>
-        <ColumnBackButton />
+        <ColumnHeader
+          showBackButton
+          extraButton={(
+            <button className='column-header__button' title={intl.formatMessage(!isExpanded ? messages.revealAll : messages.hideAll)} aria-label={intl.formatMessage(!isExpanded ? messages.revealAll : messages.hideAll)} onClick={this.handleToggleAll} aria-pressed={!isExpanded ? 'false' : 'true'}><i className={`fa fa-${!isExpanded ? 'eye-slash' : 'eye'}`} /></button>
+          )}
+        />
 
         <ScrollContainer scrollKey='thread'>
           <div className={classNames('scrollable', 'detailed-status__wrapper', { fullscreen })} ref={this.setRef}>
@@ -374,7 +389,7 @@ export default class Status extends ImmutablePureComponent {
                   onOpenVideo={this.handleOpenVideo}
                   onOpenMedia={this.handleOpenMedia}
                   expanded={isExpanded}
-                  setExpansion={setExpansion}
+                  onToggleHidden={this.handleExpandedToggle}
                 />
 
                 <ActionBar

--- a/app/javascript/flavours/glitch/features/status/index.js
+++ b/app/javascript/flavours/glitch/features/status/index.js
@@ -76,7 +76,7 @@ export default class Status extends ImmutablePureComponent {
 
   state = {
     fullscreen: false,
-    isExpanded: null,
+    isExpanded: false,
   };
 
   componentWillMount () {
@@ -96,7 +96,7 @@ export default class Status extends ImmutablePureComponent {
 
   handleExpandedToggle = () => {
     if (this.props.status.get('spoiler_text')) {
-      this.setExpansion(this.state.isExpanded ? null : true);
+      this.setExpansion(!this.state.isExpanded);
     }
   };
 
@@ -292,7 +292,7 @@ export default class Status extends ImmutablePureComponent {
   }
 
   setExpansion = value => {
-    this.setState({ isExpanded: value ? true : null });
+    this.setState({ isExpanded: value });
   }
 
   setRef = c => {

--- a/app/javascript/flavours/glitch/features/ui/components/column_header.js
+++ b/app/javascript/flavours/glitch/features/ui/components/column_header.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
 export default class ColumnHeader extends React.PureComponent {
 
@@ -16,19 +17,20 @@ export default class ColumnHeader extends React.PureComponent {
   }
 
   render () {
-    const { type, active, columnHeaderId } = this.props;
+    const { icon, type, active, columnHeaderId } = this.props;
+    let iconElement = '';
 
-    let icon = '';
-
-    if (this.props.icon) {
-      icon = <i className={`fa fa-fw fa-${this.props.icon} column-header__icon`} />;
+    if (icon) {
+      iconElement = <i className={`fa fa-fw fa-${icon} column-header__icon`} />;
     }
 
     return (
-      <div role='heading' tabIndex='0' className={`column-header ${active ? 'active' : ''}`} onClick={this.handleClick} id={columnHeaderId || null}>
-        {icon}
-        {type}
-      </div>
+      <h1 className={classNames('column-header', { active })} id={columnHeaderId || null}>
+        <button onClick={this.handleClick}>
+          {iconElement}
+          {type}
+        </button>
+      </h1>
     );
   }
 

--- a/app/javascript/flavours/glitch/reducers/statuses.js
+++ b/app/javascript/flavours/glitch/reducers/statuses.js
@@ -62,16 +62,20 @@ const normalizeStatus = (state, status) => {
     normalStatus.reblog = status.reblog.id;
   }
 
-  const searchContent = [status.spoiler_text, status.content].join('\n\n').replace(/<br \/>/g, '\n').replace(/<\/p><p>/g, '\n\n');
+  // Only calculate these values when status first encountered
+  // Otherwise keep the ones already in the reducer
+  if (!state.has(status.id)) {
+    const searchContent = [status.spoiler_text, status.content].join('\n\n').replace(/<br \/>/g, '\n').replace(/<\/p><p>/g, '\n\n');
 
-  const emojiMap = normalStatus.emojis.reduce((obj, emoji) => {
-    obj[`:${emoji.shortcode}:`] = emoji;
-    return obj;
-  }, {});
+    const emojiMap = normalStatus.emojis.reduce((obj, emoji) => {
+      obj[`:${emoji.shortcode}:`] = emoji;
+      return obj;
+    }, {});
 
-  normalStatus.search_index = domParser.parseFromString(searchContent, 'text/html').documentElement.textContent;
-  normalStatus.contentHtml = emojify(normalStatus.content, emojiMap);
-  normalStatus.spoilerHtml = emojify(escapeTextContentForBrowser(normalStatus.spoiler_text || ''), emojiMap);
+    normalStatus.search_index = domParser.parseFromString(searchContent, 'text/html').documentElement.textContent;
+    normalStatus.contentHtml  = emojify(normalStatus.content, emojiMap);
+    normalStatus.spoilerHtml  = emojify(escapeTextContentForBrowser(normalStatus.spoiler_text || ''), emojiMap);
+  }
 
   return state.update(status.id, ImmutableMap(), map => map.mergeDeep(fromJS(normalStatus)));
 };

--- a/app/javascript/flavours/glitch/styles/components/columns.scss
+++ b/app/javascript/flavours/glitch/styles/components/columns.scss
@@ -243,7 +243,6 @@
 .column-header {
   display: flex;
   font-size: 16px;
-  padding: 15px;
   background: lighten($ui-base-color, 4%);
   flex: 0 0 auto;
   cursor: pointer;
@@ -255,7 +254,7 @@
   & > button {
     margin: 0;
     border: none;
-    padding: 15px 0 15px 15px;
+    padding: 15px;
     color: inherit;
     background: transparent;
     font: inherit;
@@ -303,7 +302,6 @@
 .column-header__buttons {
   height: 48px;
   display: flex;
-  margin: -15px;
   margin-left: 0;
 }
 

--- a/app/javascript/flavours/glitch/styles/components/columns.scss
+++ b/app/javascript/flavours/glitch/styles/components/columns.scss
@@ -265,6 +265,10 @@
     flex: 1;
   }
 
+  & > .column-header__back-button {
+    color: $ui-highlight-color;
+  }
+
   &.active {
     box-shadow: 0 1px 0 rgba($ui-highlight-color, 0.3);
 


### PR DESCRIPTION
This is a very much in progress PR aiming to implement he “unfold thread” feature of Mastodon (fixes #387). Unfortunately, as the code has diverged quite a bit and is pretty hard to reason about, it will take some work.

- [x] Port related changes to column headers
- [x] Refactor the collapsed/extended logic to make it easier to reason about
- [x] Port the feature itself

~~~It is still work in progress as the interaction between CWs and collapsed toots is not satisfactory.~~~