### PR TITLE
Render toots with empty contents

### DIFF
--- a/app/javascript/flavours/glitch/components/status_content.js
+++ b/app/javascript/flavours/glitch/components/status_content.js
@@ -131,10 +131,6 @@ export default class StatusContent extends React.PureComponent {
       disabled,
     } = this.props;
 
-    if (status.get('content').length === 0) {
-      return null;
-    }
-
     const hidden = this.props.setExpansion ? !this.props.expanded : this.state.hidden;
 
     const content = { __html: status.get('contentHtml') };


### PR DESCRIPTION
This is necessary to display toots with media but otherwise no contents,
as glitch-soc displays the media as a child of StatusContent, unlike
Mastodon.