### PR TITLE
Fix extended video player (gifv) modal size

### DIFF
--- a/app/javascript/flavours/glitch/styles/components/media.scss
+++ b/app/javascript/flavours/glitch/styles/components/media.scss
@@ -161,6 +161,12 @@
   max-width: 100vw;
   max-height: 100vh;
   position: relative;
+}
+
+.media-modal {
+  width: 100%;
+  height: 100%;
+  position: relative;
 
   .extended-video-player {
     width: 100%;
@@ -174,12 +180,6 @@
       max-height: $media-modal-media-max-height;
     }
   }
-}
-
-.media-modal {
-  width: 100%;
-  height: 100%;
-  position: relative;
 }
 
 .media-modal__closer {


### PR DESCRIPTION
Sorry, I messed up porting the SCSS in an older pull request and as a result, gifv videos may take 100% of the screen estate, with no borders whatsoever.
This PR fixes that.