### PR TITLE
Add fade and margin to collapsed statuses

### DIFF
--- a/app/javascript/flavours/glitch/styles/components/status.scss
+++ b/app/javascript/flavours/glitch/styles/components/status.scss
@@ -244,9 +244,17 @@
       height: 20px;
       overflow: hidden;
       text-overflow: ellipsis;
-      margin: 0;
       padding-top: 0;
 
+      &:after {
+        content: "";
+        position: absolute;
+        top: 0; bottom: 0;
+        left: 0; right: 0;
+        background: linear-gradient(rgba($ui-base-color, 0), rgba($ui-base-color, 1));
+        pointer-events: none;
+      }
+      
       a:hover {
         text-decoration: none;
       }


### PR DESCRIPTION
before: 
![image](https://user-images.githubusercontent.com/6185037/39096690-70e3986c-4621-11e8-9c03-82151d0e8c2b.png)

after:
![image](https://user-images.githubusercontent.com/6185037/39096618-91205c7e-4620-11e8-9a29-b2a902ffa080.png)