### PR TITLE
Also treat non-whole-word mutes as case-insensitive (#450)

### DIFF
--- a/app/models/glitch/keyword_mute.rb
+++ b/app/models/glitch/keyword_mute.rb
@@ -70,7 +70,7 @@ class Glitch::KeywordMute < ApplicationRecord
 
     def make_regex_text
       kws = keywords.map! do |whole_word, keyword|
-        whole_word ? boundary_regex_for_keyword(keyword) : keyword
+        whole_word ? boundary_regex_for_keyword(keyword) : /(?i:#{keyword})/
       end
 
       Regexp.union(kws).source

--- a/spec/models/glitch/keyword_mute_spec.rb
+++ b/spec/models/glitch/keyword_mute_spec.rb
@@ -60,6 +60,12 @@ RSpec.describe Glitch::KeywordMute, type: :model do
         expect(matcher.matches?('This is a HOT take')).to be_truthy
       end
 
+      it 'matches if at least one non-whole-word keyword case-insensitively matches the text' do
+        Glitch::KeywordMute.create!(account: alice, keyword: 'hot', whole_word: false)
+
+        expect(matcher.matches?('This is a HOTTY take')).to be_truthy
+      end
+
       it 'maintains case-insensitivity when combining keywords into a single matcher' do
         Glitch::KeywordMute.create!(account: alice, keyword: 'hot')
         Glitch::KeywordMute.create!(account: alice, keyword: 'cold')


### PR DESCRIPTION
This PR modifies keyword mute behavior so that mutes are matched case-insensitively for both whole-word and non-whole-word mutes.