### PR TITLE
“Enable” high contrast theme

### DIFF
--- a/app/javascript/skins/vanilla/contrast/common.scss
+++ b/app/javascript/skins/vanilla/contrast/common.scss
@@ -1,0 +1,1 @@
+@import 'styles/contrast';

--- a/app/javascript/skins/vanilla/contrast/names.yml
+++ b/app/javascript/skins/vanilla/contrast/names.yml
@@ -1,0 +1,4 @@
+en:
+  skins:
+    vanilla:
+      contrast: High contrast


### PR DESCRIPTION
Now we can’t use high contrast theme even that it’s included in source. This PR changes it