### PR TITLE
Escape regex metachars in keyword mutes

### DIFF
--- a/app/models/glitch/keyword_mute.rb
+++ b/app/models/glitch/keyword_mute.rb
@@ -70,7 +70,7 @@ class Glitch::KeywordMute < ApplicationRecord
 
     def make_regex_text
       kws = keywords.map! do |whole_word, keyword|
-        whole_word ? boundary_regex_for_keyword(keyword) : /(?i:#{keyword})/
+        whole_word ? boundary_regex_for_keyword(keyword) : /(?i:#{Regexp.escape(keyword)})/
       end
 
       Regexp.union(kws).source


### PR DESCRIPTION
Keywords containing regex metacharacters are causing the `FeedInsertWorker` to break.

This small change fixes that.