### PR TITLE
Change local settings SCSS to be more consistent with modals

### DIFF
--- a/app/javascript/flavours/glitch/styles/components/local_settings.scss
+++ b/app/javascript/flavours/glitch/styles/components/local_settings.scss
@@ -35,8 +35,8 @@
   display: block;
   padding: 15px 20px;
   color: inherit;
-  background: $primary-text-color;
-  border-bottom: 1px $ui-primary-color solid;
+  background: lighten($ui-secondary-color, 8%);
+  border-bottom: 1px $ui-secondary-color solid;
   cursor: pointer;
   text-decoration: none;
   outline: none;
@@ -58,8 +58,7 @@
 }
 
 .glitch.local-settings__navigation {
-  background: $simple-background-color;
-  color: $inverted-text-color;
+  background: lighten($ui-secondary-color, 8%);
   width: 200px;
   font-size: 15px;
   line-height: 20px;


### PR DESCRIPTION
This PR slightly changes the colors used by the local settings modal to better match those of other modals. The changes are subtle with the default theme, but are more apparent with other themes.

Before
![screenshot-2018-5-11 mastodon instance perso de thibg 3](https://user-images.githubusercontent.com/384364/39933070-3ac4067e-5542-11e8-89d5-091a1ddedbbd.png)

After
![screenshot-2018-5-11 mastodon instance perso de thibg 4](https://user-images.githubusercontent.com/384364/39934419-01bb9208-5546-11e8-9574-fe3ea8e1fa09.png)