### PR TITLE
Hardcode default skin/theme in error layout (fixes #373)

### DIFF
--- a/app/views/layouts/error.html.haml
+++ b/app/views/layouts/error.html.haml
@@ -5,8 +5,8 @@
     %meta{ charset: 'utf-8' }/
     %title= safe_join([yield(:page_title), Setting.default_settings['site_title']], ' - ')
     %meta{ content: 'width=device-width,initial-scale=1', name: 'viewport' }/
-    = render partial: 'layouts/theme', object: @core
-    = render partial: 'layouts/theme', object: @theme
+    = render partial: 'layouts/theme', object: (@core || { pack: 'common' })
+    = render partial: 'layouts/theme', object: (@theme || { pack: 'common', flavour: 'glitch', skin: 'default' })
   %body.error
     .dialog
       %img{ alt: Setting.default_settings['site_title'], src: '/oops.gif' }/


### PR DESCRIPTION
This is a bit hackish. The best way would simply to somehow
use Mastodon's ApplicationController with `use_pack 'error'` from
the Rake task, but I'm not sure how to do that.