### PR TITLE
Use history.state to decide whether we should goBack() or go to / (fixes #247)

### DIFF
--- a/app/javascript/flavours/glitch/components/column_back_button.js
+++ b/app/javascript/flavours/glitch/components/column_back_button.js
@@ -10,10 +10,10 @@ export default class ColumnBackButton extends React.PureComponent {
 
   handleClick = () => {
     // if history is exhausted, or we would leave mastodon, just go to root.
-    if (window.history && (window.history.length === 1 || window.history.length === window._mastoInitialHistoryLen)) {
-      this.context.router.history.push('/');
-    } else {
+    if (window.history.state) {
       this.context.router.history.goBack();
+    } else {
+      this.context.router.history.push('/');
     }
   }
 

--- a/app/javascript/flavours/glitch/components/column_back_button_slim.js
+++ b/app/javascript/flavours/glitch/components/column_back_button_slim.js
@@ -10,10 +10,10 @@ export default class ColumnBackButtonSlim extends React.PureComponent {
 
   handleClick = () => {
     // if history is exhausted, or we would leave mastodon, just go to root.
-    if (window.history && (window.history.length === 1 || window.history.length === window._mastoInitialHistoryLen)) {
-      this.context.router.history.push('/');
-    } else {
+    if (window.history.state) {
       this.context.router.history.goBack();
+    } else {
+      this.context.router.history.push('/');
     }
   }
 

--- a/app/javascript/flavours/glitch/components/column_header.js
+++ b/app/javascript/flavours/glitch/components/column_header.js
@@ -66,10 +66,10 @@ export default class ColumnHeader extends React.PureComponent {
 
   handleBackClick = () => {
     // if history is exhausted, or we would leave mastodon, just go to root.
-    if (window.history && (window.history.length === 1 || window.history.length === window._mastoInitialHistoryLen)) {
-      this.context.router.history.push('/');
-    } else {
+    if (window.history.state) {
       this.context.router.history.goBack();
+    } else {
+      this.context.router.history.push('/');
     }
   }
 

--- a/app/javascript/flavours/glitch/features/ui/index.js
+++ b/app/javascript/flavours/glitch/features/ui/index.js
@@ -99,10 +99,6 @@ const keyMap = {
 @withRouter
 export default class UI extends React.Component {
 
-  static contextTypes = {
-    router: PropTypes.object.isRequired,
-  };
-
   static propTypes = {
     dispatch: PropTypes.func.isRequired,
     children: PropTypes.node,
@@ -113,6 +109,7 @@ export default class UI extends React.Component {
     isComposing: PropTypes.bool,
     hasComposingText: PropTypes.bool,
     location: PropTypes.object,
+    router: PropTypes.object,
     intl: PropTypes.object.isRequired,
     dropdownMenuIsOpen: PropTypes.bool,
   };
@@ -200,7 +197,7 @@ export default class UI extends React.Component {
 
   handleServiceWorkerPostMessage = ({ data }) => {
     if (data.type === 'navigate') {
-      this.context.router.history.push(data.path);
+      this.props.router.history.push(data.path);
     } else {
       console.warn('Unknown message type:', data.type);
     }
@@ -306,9 +303,9 @@ export default class UI extends React.Component {
 
   handleHotkeyBack = () => {
     if (window.history && window.history.length === 1) {
-      this.context.router.history.push('/');
+      this.props.router.history.push('/');
     } else {
-      this.context.router.history.goBack();
+      this.props.router.history.goBack();
     }
   }
 
@@ -318,54 +315,54 @@ export default class UI extends React.Component {
 
   handleHotkeyToggleHelp = () => {
     if (this.props.location.pathname === '/keyboard-shortcuts') {
-      this.context.router.history.goBack();
+      this.props.router.history.goBack();
     } else {
-      this.context.router.history.push('/keyboard-shortcuts');
+      this.props.router.history.push('/keyboard-shortcuts');
     }
   }
 
   handleHotkeyGoToHome = () => {
-    this.context.router.history.push('/timelines/home');
+    this.props.router.history.push('/timelines/home');
   }
 
   handleHotkeyGoToNotifications = () => {
-    this.context.router.history.push('/notifications');
+    this.props.router.history.push('/notifications');
   }
 
   handleHotkeyGoToLocal = () => {
-    this.context.router.history.push('/timelines/public/local');
+    this.props.router.history.push('/timelines/public/local');
   }
 
   handleHotkeyGoToFederated = () => {
-    this.context.router.history.push('/timelines/public');
+    this.props.router.history.push('/timelines/public');
   }
 
   handleHotkeyGoToDirect = () => {
-    this.context.router.history.push('/timelines/direct');
+    this.props.router.history.push('/timelines/direct');
   }
 
   handleHotkeyGoToStart = () => {
-    this.context.router.history.push('/getting-started');
+    this.props.router.history.push('/getting-started');
   }
 
   handleHotkeyGoToFavourites = () => {
-    this.context.router.history.push('/favourites');
+    this.props.router.history.push('/favourites');
   }
 
   handleHotkeyGoToPinned = () => {
-    this.context.router.history.push('/pinned');
+    this.props.router.history.push('/pinned');
   }
 
   handleHotkeyGoToProfile = () => {
-    this.context.router.history.push(`/accounts/${me}`);
+    this.props.router.history.push(`/accounts/${me}`);
   }
 
   handleHotkeyGoToBlocked = () => {
-    this.context.router.history.push('/blocks');
+    this.props.router.history.push('/blocks');
   }
 
   handleHotkeyGoToMuted = () => {
-    this.context.router.history.push('/mutes');
+    this.props.router.history.push('/mutes');
   }
 
   render () {

--- a/app/javascript/flavours/glitch/features/ui/index.js
+++ b/app/javascript/flavours/glitch/features/ui/index.js
@@ -302,10 +302,11 @@ export default class UI extends React.Component {
   }
 
   handleHotkeyBack = () => {
-    if (window.history && window.history.length === 1) {
-      this.props.router.history.push('/');
+    // if history is exhausted, or we would leave mastodon, just go to root.
+    if (window.history.state) {
+      this.context.router.history.goBack();
     } else {
-      this.props.router.history.goBack();
+      this.context.router.history.push('/');
     }
   }
 

--- a/app/javascript/flavours/glitch/util/main.js
+++ b/app/javascript/flavours/glitch/util/main.js
@@ -28,11 +28,6 @@ function main() {
       store.dispatch(registerPushNotifications.register());
     }
     perf.stop('main()');
-
-    // remember the initial URL
-    if (window.history && typeof window._mastoInitialHistoryLen === 'undefined') {
-      window._mastoInitialHistoryLen = window.history.length;
-    }
   });
 }
 


### PR DESCRIPTION
So far, glitch-soc used history.length to decide whether to call `goBack()` or go to / in order to not leave the webUI. This made clicking the “Back” button go to the “Getting started” column instead of going back in the browser's history when such an action would leave the web UI, but also when:
- The WebUI is refreshed (F5)
- A tab is restored
- The history length reaches its maximum (e.g., 50 in Firefox)

This commit fixes these shortcomings by checking `window.history.state`. Indeed, we only want to go back in the browser's history when the current location has been reached from within the WebUI, which only happens via `pushState` as far as I know. Since browser store the serialized state in the browser history, this also survives page reload and session restoration.

I am not sure that is the cleanest way to do that, and I am not sure it works across all current browsers, although I'm pretty confident it does.

The first commit is some simple cleanup I haven't generalized throughout the codebase and is not really important.