### PR TITLE
Change direct message warning to match upstream

### DIFF
--- a/app/javascript/flavours/glitch/features/composer/direct_warning/index.js
+++ b/app/javascript/flavours/glitch/features/composer/direct_warning/index.js
@@ -9,9 +9,13 @@ const motionSpring = spring(1, { damping: 35, stiffness: 400 });
 //  Messages.
 const messages = defineMessages({
   disclaimer: {
-    defaultMessage: 'This toot will only be sent to all the mentioned users. However, the operators of your instance and any receiving instances may see this message.',
+    defaultMessage: 'This toot will only be sent to all the mentioned users.',
     id: 'compose_form.direct_message_warning',
   },
+  learn_more: {
+    defaultMessage: 'Learn more',
+    id: 'compose_form.direct_message_warning_learn_more'
+  }
 });
 
 //  The component.
@@ -37,9 +41,9 @@ export default function ComposerDirectWarning () {
             transform: `scale(${scaleX}, ${scaleY})`,
           }}
         >
-          <FormattedMessage
-            {...messages.disclaimer}
-          />
+          <span>
+            <FormattedMessage {...messages.disclaimer} /> <a href='/terms' target='_blank'><FormattedMessage {...messages.learn_more} /></a>
+          </span>
         </div>
       )}
     </Motion>


### PR DESCRIPTION
I prefer the one we had so far, but since the translations are shared, it makes more sense to update it.