### PR TITLE
Prevent a rare crash when a status' root node is undefined

### DIFF
--- a/app/javascript/flavours/glitch/components/status.js
+++ b/app/javascript/flavours/glitch/components/status.js
@@ -153,6 +153,11 @@ export default class Status extends ImmutablePureComponent {
       muted,
       prepend,
     } = this.props;
+
+    // Prevent a crash when node is undefined. Not completely sure why this
+    // happens, might be because status === null.
+    if (node === undefined) return;
+
     const autoCollapseSettings = settings.getIn(['collapsed', 'auto']);
 
     if (function () {


### PR DESCRIPTION
I have seen this crash occur at least twice already, but I'm not completely sure what could trigger it.
I guess it could be caused by the `status` prop being null.