### PR TITLE
[Glitch] Fix low-contrasted cancel button of reply indicator

### DIFF
--- a/app/javascript/flavours/glitch/features/composer/reply/index.js
+++ b/app/javascript/flavours/glitch/features/composer/reply/index.js
@@ -58,6 +58,7 @@ export default class ComposerReply extends React.PureComponent {
             icon='times'
             onClick={handleClick}
             title={intl.formatMessage(messages.cancel)}
+            inverted
           />
           {account ? (
             <AccountContainer


### PR DESCRIPTION
Port 86efccce2a874d16aa783d989ff4824bcfac40b5 to glitch-soc

Before
![screenshot-2018-5-27 mastodon instance perso de thibg](https://user-images.githubusercontent.com/384364/40587394-c5631c28-61ce-11e8-9ce0-fd8f8949f7dc.png)

After
![screenshot-2018-5-27 mastodon instance perso de thibg 1](https://user-images.githubusercontent.com/384364/40587397-cb0cfd92-61ce-11e8-957e-d1f87f56984f.png)
