### PR TITLE
Note that favourite confirmation applies to Glitch flavour only (#491)

### DIFF
--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -55,7 +55,7 @@ en:
         setting_default_sensitive: Always mark media as sensitive
         setting_delete_modal: Show confirmation dialog before deleting a toot
         setting_display_sensitive_media: Always show media marked as sensitive
-        setting_favourite_modal: Show confirmation dialog before favouriting
+        setting_favourite_modal: Show confirmation dialog before favouriting (applies to Glitch flavour only)
         setting_hide_network: Hide your network
         setting_noindex: Opt-out of search engine indexing
         setting_reduce_motion: Reduce motion in animations


### PR DESCRIPTION
This is probably the simplest candidate change to address #491.  Here's what it does:

![screenshot_20180603_034008](https://user-images.githubusercontent.com/3859/40884807-23e63f12-66e0-11e8-8df0-b520bfec8f92.png)

 @kit-ty-kate: what do you think?
