### PR TITLE
Fix clicking on collapsed toots with a background (fixes #547)

### DIFF
--- a/app/javascript/flavours/glitch/styles/components/status.scss
+++ b/app/javascript/flavours/glitch/styles/components/status.scss
@@ -229,6 +229,7 @@
       top: 0;
       bottom: 0;
       background-image: linear-gradient(to bottom, rgba($base-shadow-color, .75), rgba($base-shadow-color, .65) 24px, rgba($base-shadow-color, .8));
+      pointer-events: none;
       content: "";
     }
 


### PR DESCRIPTION
This is still a bit of a mess, especially since the addition of linear gradients on collapsed toots, but at least those gradients shouldn't prevent interactions now.