### PR TITLE
add option to enable auto visibility on secondary toot button

### DIFF
--- a/app/javascript/flavours/glitch/features/composer/index.js
+++ b/app/javascript/flavours/glitch/features/composer/index.js
@@ -51,6 +51,9 @@ import { wrap } from 'flavours/glitch/util/redux_helpers';
 //  State mapping.
 function mapStateToProps (state) {
   const inReplyTo = state.getIn(['compose', 'in_reply_to']);
+  const replyPrivacy = inReplyTo ? state.getIn(['statuses', inReplyTo, 'visibility']) : null;
+  const sideArmBasePrivacy = state.getIn(['local_settings', 'side_arm']);
+  const sideArmPrivacy = (state.getIn(['local_settings', 'side_arm_reply_mode']) === 'copy' ? replyPrivacy : null) || sideArmBasePrivacy;
   return {
     acceptContentTypes: state.getIn(['media_attachments', 'accept_content_types']).toArray().join(','),
     advancedOptions: state.getIn(['compose', 'advanced_options']),
@@ -67,7 +70,7 @@ function mapStateToProps (state) {
     replyAccount: inReplyTo ? state.getIn(['statuses', inReplyTo, 'account']) : null,
     replyContent: inReplyTo ? state.getIn(['statuses', inReplyTo, 'contentHtml']) : null,
     resetFileKey: state.getIn(['compose', 'resetFileKey']),
-    sideArm: (state.getIn(['local_settings', 'side_arm_auto']) ? state.getIn(['compose', 'reply_privacy']) : null) || state.getIn(['local_settings', 'side_arm']),
+    sideArm: sideArmPrivacy,
     sensitive: state.getIn(['compose', 'sensitive']),
     showSearch: state.getIn(['search', 'submitted']) && !state.getIn(['search', 'hidden']),
     spoiler: state.getIn(['compose', 'spoiler']),

--- a/app/javascript/flavours/glitch/features/composer/index.js
+++ b/app/javascript/flavours/glitch/features/composer/index.js
@@ -67,7 +67,7 @@ function mapStateToProps (state) {
     replyAccount: inReplyTo ? state.getIn(['statuses', inReplyTo, 'account']) : null,
     replyContent: inReplyTo ? state.getIn(['statuses', inReplyTo, 'contentHtml']) : null,
     resetFileKey: state.getIn(['compose', 'resetFileKey']),
-    sideArm: state.getIn(['local_settings', 'side_arm']),
+    sideArm: (state.getIn(['local_settings', 'side_arm_auto']) ? state.getIn(['compose', 'reply_privacy']) : null) || state.getIn(['local_settings', 'side_arm']),
     sensitive: state.getIn(['compose', 'sensitive']),
     showSearch: state.getIn(['search', 'submitted']) && !state.getIn(['search', 'hidden']),
     spoiler: state.getIn(['compose', 'spoiler']),

--- a/app/javascript/flavours/glitch/features/local_settings/page/index.js
+++ b/app/javascript/flavours/glitch/features/local_settings/page/index.js
@@ -78,11 +78,11 @@ export default class LocalSettingsPage extends React.PureComponent {
           </LocalSettingsPageItem>
           <LocalSettingsPageItem
             settings={settings}
-            item={['side_arm_auto']}
-            id='mastodon-settings--side_arm_auto'
+            item={['side_arm_reply_mode']}
+            id='mastodon-settings--side_arm_reply_mode'
             onChange={onChange}
           >
-            <FormattedMessage id='settings.side_arm_auto' defaultMessage='Auto privacy for secondary toot button' />
+            <FormattedMessage id='settings.side_arm_reply_mode' defaultMessage='When replying to a toot:' />
           </LocalSettingsPageItem>
         </section>
       </div>

--- a/app/javascript/flavours/glitch/features/local_settings/page/index.js
+++ b/app/javascript/flavours/glitch/features/local_settings/page/index.js
@@ -14,6 +14,8 @@ const messages = defineMessages({
   layout_desktop: { id: 'layout.desktop', defaultMessage: 'Desktop' },
   layout_mobile: { id: 'layout.single', defaultMessage: 'Mobile' },
   side_arm_none: { id: 'settings.side_arm.none', defaultMessage: 'None' },
+  side_arm_keep: { id: 'settings.side_arm_reply_mode.keep', defaultMessage: 'Keep secondary toot button to set privacy' },
+  side_arm_copy: { id: 'settings.side_arm_reply_mode.copy', defaultMessage: 'Copy privacy setting of the toot being replied to' },
 });
 
 @injectIntl
@@ -80,6 +82,10 @@ export default class LocalSettingsPage extends React.PureComponent {
             settings={settings}
             item={['side_arm_reply_mode']}
             id='mastodon-settings--side_arm_reply_mode'
+            options={[
+              { value: 'keep', message: intl.formatMessage(messages.side_arm_keep) },
+              { value: 'copy', message: intl.formatMessage(messages.side_arm_copy) }
+            ]}
             onChange={onChange}
           >
             <FormattedMessage id='settings.side_arm_reply_mode' defaultMessage='When replying to a toot:' />

--- a/app/javascript/flavours/glitch/features/local_settings/page/index.js
+++ b/app/javascript/flavours/glitch/features/local_settings/page/index.js
@@ -76,6 +76,14 @@ export default class LocalSettingsPage extends React.PureComponent {
           >
             <FormattedMessage id='settings.side_arm' defaultMessage='Secondary toot button:' />
           </LocalSettingsPageItem>
+          <LocalSettingsPageItem
+            settings={settings}
+            item={['side_arm_auto']}
+            id='mastodon-settings--side_arm_auto'
+            onChange={onChange}
+          >
+            <FormattedMessage id='settings.side_arm_auto' defaultMessage='Auto privacy for secondary toot button' />
+          </LocalSettingsPageItem>
         </section>
       </div>
     ),

--- a/app/javascript/flavours/glitch/reducers/compose.js
+++ b/app/javascript/flavours/glitch/reducers/compose.js
@@ -56,7 +56,6 @@ const initialState = ImmutableMap({
   spoiler: false,
   spoiler_text: '',
   privacy: null,
-  reply_privacy: null,
   text: '',
   focusDate: null,
   caretPosition: null,
@@ -291,7 +290,6 @@ export default function compose(state = initialState, action) {
       map.set('in_reply_to', action.status.get('id'));
       map.set('text', statusToTextMentions(state, action.status));
       map.set('privacy', privacyPreference(action.status.get('visibility'), state.get('default_privacy')));
-      map.set('reply_privacy', action.status.get('visibility'));
       map.update(
         'advanced_options',
         map => map.merge(new ImmutableMap({ do_not_federate: /👁\ufe0f?\u200b?(?:<\/p>)?$/.test(action.status.get('content')) }))
@@ -317,7 +315,6 @@ export default function compose(state = initialState, action) {
       map.set('spoiler', false);
       map.set('spoiler_text', '');
       map.set('privacy', state.get('default_privacy'));
-      map.set('reply_privacy', null);
       map.update(
         'advanced_options',
         map => map.mergeWith(overwrite, state.get('default_advanced_options'))

--- a/app/javascript/flavours/glitch/reducers/compose.js
+++ b/app/javascript/flavours/glitch/reducers/compose.js
@@ -56,6 +56,7 @@ const initialState = ImmutableMap({
   spoiler: false,
   spoiler_text: '',
   privacy: null,
+  reply_privacy: null,
   text: '',
   focusDate: null,
   caretPosition: null,
@@ -290,6 +291,7 @@ export default function compose(state = initialState, action) {
       map.set('in_reply_to', action.status.get('id'));
       map.set('text', statusToTextMentions(state, action.status));
       map.set('privacy', privacyPreference(action.status.get('visibility'), state.get('default_privacy')));
+      map.set('reply_privacy', action.status.get('visibility'));
       map.update(
         'advanced_options',
         map => map.merge(new ImmutableMap({ do_not_federate: /👁\ufe0f?\u200b?(?:<\/p>)?$/.test(action.status.get('content')) }))
@@ -315,6 +317,7 @@ export default function compose(state = initialState, action) {
       map.set('spoiler', false);
       map.set('spoiler_text', '');
       map.set('privacy', state.get('default_privacy'));
+      map.set('reply_privacy', null);
       map.update(
         'advanced_options',
         map => map.mergeWith(overwrite, state.get('default_advanced_options'))

--- a/app/javascript/flavours/glitch/reducers/local_settings.js
+++ b/app/javascript/flavours/glitch/reducers/local_settings.js
@@ -10,7 +10,7 @@ const initialState = ImmutableMap({
   stretch   : true,
   navbar_under : false,
   side_arm  : 'none',
-  side_arm_auto : false,
+  side_arm_reply_mode : 'keep',
   collapsed : ImmutableMap({
     enabled     : true,
     auto        : ImmutableMap({

--- a/app/javascript/flavours/glitch/reducers/local_settings.js
+++ b/app/javascript/flavours/glitch/reducers/local_settings.js
@@ -10,6 +10,7 @@ const initialState = ImmutableMap({
   stretch   : true,
   navbar_under : false,
   side_arm  : 'none',
+  side_arm_auto : false,
   collapsed : ImmutableMap({
     enabled     : true,
     auto        : ImmutableMap({


### PR DESCRIPTION
this adds an option which makes the secondary toot button automatically change to the visibility of the status you're replying to, regardless of the static setting for it.