### PR TITLE
[Glitch] Make whole-word filter regex consistent between Ruby and JS

### DIFF
--- a/app/javascript/flavours/glitch/selectors/index.js
+++ b/app/javascript/flavours/glitch/selectors/index.js
@@ -47,7 +47,18 @@ export const regexFromFilters = filters => {
 
   return new RegExp(filters.map(filter => {
     let expr = escapeRegExp(filter.get('phrase'));
-    return filter.get('whole_word') ? `\\b${expr}\\b` : expr;
+
+    if (filter.get('whole_word')) {
+      if (/^[\w]/.test(expr)) {
+        expr = `\\b${expr}`;
+      }
+
+      if (/[\w]$/.test(expr)) {
+        expr = `${expr}\\b`;
+      }
+    }
+
+    return expr;
   }).join('|'), 'i');
 };
 


### PR DESCRIPTION
Port front-end part of 20fefdb7145b48449e9d6a824a9846dadfd6ac2f to glitch-soc