### PR TITLE
Do not cause an error if domain_lists.blocks.next is undefined (fixes #572)

### DIFF
--- a/app/javascript/flavours/glitch/actions/domain_blocks.js
+++ b/app/javascript/flavours/glitch/actions/domain_blocks.js
@@ -128,7 +128,7 @@ export function expandDomainBlocks() {
   return (dispatch, getState) => {
     const url = getState().getIn(['domain_lists', 'blocks', 'next']);
 
-    if (url === null) {
+    if (!url) {
       return;
     }
 


### PR DESCRIPTION
Port d0d23b8f0aa72946fe0c8d3327ce1d8bbc049d4f to glitch-soc