### PR TITLE
Give some more time for assets precompilation in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ before_install:
   - gem install bundler
 
 before_script:
-  - travis_wait ./bin/rails parallel:create parallel:load_schema parallel:prepare assets:precompile
+  - travis_wait 30 ./bin/rails parallel:create parallel:load_schema parallel:prepare assets:precompile
   - yarn install --no-progress
 
 script:


### PR DESCRIPTION
A lot of recent CI failures are due to assets compilation taking too much time…