### PR TITLE
[Glitch] Ensure container of React components has full width

### DIFF
--- a/app/javascript/flavours/glitch/styles/stream_entries.scss
+++ b/app/javascript/flavours/glitch/styles/stream_entries.scss
@@ -2,6 +2,10 @@
   clear: both;
   box-shadow: 0 0 15px rgba($base-shadow-color, 0.2);
 
+  div[data-component] {
+    width: 100%;
+  }
+
   .entry {
     background: $simple-background-color;
 


### PR DESCRIPTION
Port f6910fba02c8a99dcad901c193be08d06a65c1c6 to glitch-soc

I have not witnessed the issue myself, but the fix should apply the same way to glitch-soc than it applied to upstream.