### PR TITLE
Show reply indicator for empty toots, not undefined toots (fixes #610)

### DIFF
--- a/app/javascript/flavours/glitch/features/composer/index.js
+++ b/app/javascript/flavours/glitch/features/composer/index.js
@@ -328,7 +328,7 @@ class Composer extends React.Component {
         {privacy === 'direct' ? <ComposerDirectWarning /> : null}
         {privacy === 'private' && amUnlocked ? <ComposerWarning /> : null}
         {privacy !== 'public' && APPROX_HASHTAG_RE.test(text) ? <ComposerHashtagWarning /> : null}
-        {replyContent !== null && (
+        {replyAccount && (
           <ComposerReply
             account={replyAccount}
             content={replyContent}


### PR DESCRIPTION
Fix a regression introduced by 612b00d1bb91c6b11f00fdb273dd8cd2ca883b12