### PR TITLE
[Glitch] Fix accounts' display name/bio not being set from initial state

### DIFF
--- a/app/javascript/flavours/glitch/reducers/accounts.js
+++ b/app/javascript/flavours/glitch/reducers/accounts.js
@@ -122,7 +122,7 @@ const initialState = ImmutableMap();
 export default function accounts(state = initialState, action) {
   switch(action.type) {
   case STORE_HYDRATE:
-    return state.merge(action.state.get('accounts'));
+    return normalizeAccounts(state, Object.values(action.state.get('accounts').toJS()));
   case ACCOUNT_FETCH_SUCCESS:
   case NOTIFICATIONS_UPDATE:
     return normalizeAccount(state, action.account);


### PR DESCRIPTION
Port 20d1be18af8c10b6f1bc5597643b85ac6dbae9f2 to glitch-soc

This fixes stuff like starting the web UI with one's account as the rightmost column