### PR TITLE
Fix styling of toot prepended text on public profiles

### DIFF
--- a/app/javascript/flavours/glitch/styles/stream_entries.scss
+++ b/app/javascript/flavours/glitch/styles/stream_entries.scss
@@ -128,11 +128,18 @@
     }
 
     &__prepend {
+      padding: 8px 0;
+      padding-bottom: 2px;
+      margin: initial;
       margin-left: 48px + 15px * 2;
       padding-top: 15px;
     }
 
     &__prepend-icon-wrapper {
+      position: absolute;
+      margin: initial;
+      float: initial;
+      width: auto;
       left: -32px;
     }
 


### PR DESCRIPTION
Fixes how “Pinned toot”, “… boosted” etc. are styled on public profiles.