### PR TITLE
Import upstream's emojify function in settings.js

### DIFF
--- a/app/javascript/core/settings.js
+++ b/app/javascript/core/settings.js
@@ -2,6 +2,7 @@
 
 const { length } = require('stringz');
 const { delegate } = require('rails-ujs');
+import emojify from '../mastodon/features/emoji/emoji';
 
 delegate(document, '#account_display_name', 'input', ({ target }) => {
   const nameCounter = document.querySelector('.name-counter');


### PR DESCRIPTION
This fixes updating the profile preview when changing display name.

I'm not too sure about importing that, but we already do this for `admin.js`, so…