### PR TITLE
Don't prevent opening links in tabs with keyboard modifiers

### DIFF
--- a/app/javascript/flavours/glitch/components/status.js
+++ b/app/javascript/flavours/glitch/components/status.js
@@ -241,7 +241,7 @@ export default class Status extends ImmutablePureComponent {
         status.getIn(['reblog', 'id'], status.get('id'))
       }`;
     }
-    if (e.button === 0) {
+    if (e.button === 0 && !(e.ctrlKey || e.altKey || e.metaKey)) {
       if (isCollapsed) this.setCollapsed(false);
       else if (e.shiftKey) {
         this.setCollapsed(true);


### PR DESCRIPTION
Ctrl+click usually allows opening a link in a new tab. This was prevented for hashtag or user links in toots.

This changes prevents special handling of status-contained links when ctrl, alt, or meta are pressed.