### PR TITLE
Split custom filter migration script using the post-deployment migration system

### DIFF
--- a/db/migrate/20180707193142_migrate_filters.rb
+++ b/db/migrate/20180707193142_migrate_filters.rb
@@ -29,20 +29,20 @@ class MigrateFilters < ActiveRecord::Migration[5.2]
         whole_word: filter.whole_word,
         irreversible: true)
     end
-
-    drop_table :glitch_keyword_mutes
   end
 
   def down
-    create_table "glitch_keyword_mutes" do |t|
-      t.references :account, null: false
-      t.string :keyword, null: false
-      t.boolean :whole_word, default: true, null: false
-      t.boolean :apply_to_mentions, default: true, null: false
-      t.timestamps
-    end
+    unless table_exists? :glitch_keyword_mutes
+      create_table :glitch_keyword_mutes do |t|
+        t.references :account, null: false
+        t.string :keyword, null: false
+        t.boolean :whole_word, default: true, null: false
+        t.boolean :apply_to_mentions, default: true, null: false
+        t.timestamps
+      end
 
-    add_foreign_key :glitch_keyword_mutes, :accounts, on_delete: :cascade
+      add_foreign_key :glitch_keyword_mutes, :accounts, on_delete: :cascade
+    end
 
     CustomFilter.where(irreversible: true).find_each do |filter|
       GlitchKeywordMute.where(account: filter.account).create!(

--- a/db/post_migrate/20180813160548_post_migrate_filters.rb
+++ b/db/post_migrate/20180813160548_post_migrate_filters.rb
@@ -1,0 +1,11 @@
+class PostMigrateFilters < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def up
+    drop_table :glitch_keyword_mutes if table_exists? :glitch_keyword_mutes
+  end
+
+  def down
+  end
+end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_12_123222) do
+ActiveRecord::Schema.define(version: 2018_08_13_160548) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
There were some concerns with the custom filter migration script dropping a table,
thus making it unsafe to run in a zero-downtime setting. Upstream introduced
a way to run migrations after deployment, so revisit the old migration script to
make use of this.

@nightpool does that address the concerns you had?