### PR TITLE
Adapt github issue template to glitch-soc

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,4 +9,4 @@ about: Create a report to help us improve
 * * * *
 
 - [ ] I searched or browsed the repo’s other issues to ensure this is not a duplicate.
-- [ ] This bug happens on a [tagged release](https://github.com/tootsuite/mastodon/releases) and not on `master` (If you're a user, don't worry about this).
+- [ ] This bugs also occur on vanilla Mastodon


### PR DESCRIPTION
We don't have releases, so it don't make sense to mention.
On the other hand, a lot of our code is from upstream, so encourage people to
check whether it is a bug in glitch-soc or upstream.