### PR TITLE
 Make the privacy dropdown button not look strange when using top placement

### DIFF
--- a/app/javascript/flavours/glitch/features/composer/options/dropdown/index.js
+++ b/app/javascript/flavours/glitch/features/composer/options/dropdown/index.js
@@ -168,6 +168,7 @@ export default class ComposerOptionsDropdown extends React.PureComponent {
     const computedClass = classNames('composer--options--dropdown', {
       active,
       open,
+      top: placement === 'top',
     });
 
     //  The result.

--- a/app/javascript/flavours/glitch/styles/components/composer.scss
+++ b/app/javascript/flavours/glitch/styles/components/composer.scss
@@ -406,6 +406,12 @@
       background: $ui-highlight-color;
       transition: none;
     }
+    &.top {
+      & > .value {
+        border-radius: 0 0 4px 4px;
+        box-shadow: 0 4px 4px rgba($base-shadow-color, 0.1);
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Inspired by 8fe1f8d4cecb9f2f749c1e1e77b2439dd640ddc5

Before:
![screenshot_2018-08-19 dev instance](https://user-images.githubusercontent.com/384364/44310434-8a18a580-a3d6-11e8-840f-5c6cff9bc8c0.png)

After:
![screenshot_2018-08-19 dev instance 1](https://user-images.githubusercontent.com/384364/44310436-8d139600-a3d6-11e8-9e2d-d40c459246f6.png)