### PR TITLE
Make non-link ColumnLinks behave as links

### DIFF
--- a/app/javascript/flavours/glitch/features/ui/components/column_link.js
+++ b/app/javascript/flavours/glitch/features/ui/components/column_link.js
@@ -22,8 +22,13 @@ const ColumnLink = ({ icon, text, to, onClick, href, method, badge }) => {
       </Link>
     );
   } else {
+    const handleOnClick = (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      return onClick(e);
+    }
     return (
-      <a onClick={onClick} className='column-link' role='button' tabIndex='0' data-method={method}>
+      <a href='#' onClick={onClick && handleOnClick} className='column-link' tabIndex='0'>
         <i className={`fa fa-fw fa-${icon} column-link__icon`} />
         {text}
         {badgeElement}


### PR DESCRIPTION
Similar to 3eb3c21327b262ad7a3b929248ff30161ab87da3 but applies to any `ColumnLink` that has no `href` or `to` attribute, such as “App settings” or “Show me around”.