### PR TITLE
Add option to auto-unfold CWs except those matching a regexp

### DIFF
--- a/app/javascript/flavours/glitch/components/status.js
+++ b/app/javascript/flavours/glitch/components/status.js
@@ -56,6 +56,7 @@ export default class Status extends ImmutablePureComponent {
   state = {
     isCollapsed: false,
     autoCollapsed: false,
+    isExpanded: this.props.settings.getIn(['content_warnings', 'auto_unfold']),
   }
 
   // Avoid checking props that are functions (and whose equality will always

--- a/app/javascript/flavours/glitch/components/status.js
+++ b/app/javascript/flavours/glitch/components/status.js
@@ -13,6 +13,7 @@ import { MediaGallery, Video } from 'flavours/glitch/util/async-components';
 import { HotKeys } from 'react-hotkeys';
 import NotificationOverlayContainer from 'flavours/glitch/features/notifications/containers/overlay_container';
 import classNames from 'classnames';
+import { autoUnfoldCW } from 'flavours/glitch/util/content_warning';
 
 // We use the component (and not the container) since we do not want
 // to use the progress bar to show download progress
@@ -56,7 +57,7 @@ export default class Status extends ImmutablePureComponent {
   state = {
     isCollapsed: false,
     autoCollapsed: false,
-    isExpanded: this.props.settings.getIn(['content_warnings', 'auto_unfold']),
+    isExpanded: undefined,
   }
 
   // Avoid checking props that are functions (and whose equality will always
@@ -122,6 +123,17 @@ export default class Status extends ImmutablePureComponent {
       update.isExpanded = nextProps.expanded;
       if (nextProps.expanded) update.isCollapsed = false;
       updated = true;
+    }
+
+    if (nextProps.expanded === undefined &&
+      prevState.isExpanded === undefined &&
+      update.isExpanded === undefined
+    ) {
+      const isExpanded = autoUnfoldCW(nextProps.settings, nextProps.status);
+      if (isExpanded !== undefined) {
+        update.isExpanded = isExpanded;
+        updated = true;
+      }
     }
 
     return updated ? update : null;

--- a/app/javascript/flavours/glitch/features/local_settings/navigation/index.js
+++ b/app/javascript/flavours/glitch/features/local_settings/navigation/index.js
@@ -10,6 +10,7 @@ import LocalSettingsNavigationItem from './item';
 
 const messages = defineMessages({
   general: {  id: 'settings.general', defaultMessage: 'General' },
+  content_warnings: { id: 'settings.content_warnings', defaultMessage: 'Content Warnings' },
   collapsed: { id: 'settings.collapsed_statuses', defaultMessage: 'Collapsed toots' },
   media: { id: 'settings.media', defaultMessage: 'Media' },
   preferences: { id: 'settings.preferences', defaultMessage: 'Preferences' },
@@ -42,25 +43,31 @@ export default class LocalSettingsNavigation extends React.PureComponent {
           active={index === 1}
           index={1}
           onNavigate={onNavigate}
-          title={intl.formatMessage(messages.collapsed)}
+          title={intl.formatMessage(messages.content_warnings)}
         />
         <LocalSettingsNavigationItem
           active={index === 2}
           index={2}
           onNavigate={onNavigate}
-          title={intl.formatMessage(messages.media)}
+          title={intl.formatMessage(messages.collapsed)}
         />
         <LocalSettingsNavigationItem
           active={index === 3}
-          href='/settings/preferences'
           index={3}
+          onNavigate={onNavigate}
+          title={intl.formatMessage(messages.media)}
+        />
+        <LocalSettingsNavigationItem
+          active={index === 4}
+          href='/settings/preferences'
+          index={4}
           icon='cog'
           title={intl.formatMessage(messages.preferences)}
         />
         <LocalSettingsNavigationItem
-          active={index === 4}
+          active={index === 5}
           className='close'
-          index={4}
+          index={5}
           onNavigate={onClose}
           title={intl.formatMessage(messages.close)}
         />

--- a/app/javascript/flavours/glitch/features/local_settings/page/index.js
+++ b/app/javascript/flavours/glitch/features/local_settings/page/index.js
@@ -17,6 +17,7 @@ const messages = defineMessages({
   side_arm_keep: { id: 'settings.side_arm_reply_mode.keep', defaultMessage: 'Keep secondary toot button to set privacy' },
   side_arm_copy: { id: 'settings.side_arm_reply_mode.copy', defaultMessage: 'Copy privacy setting of the toot being replied to' },
   side_arm_restrict: { id: 'settings.side_arm_reply_mode.restrict', defaultMessage: 'Restrict privacy setting to that of the toot being replied to' },
+  regexp: { id: 'settings.content_warnings.regexp', defaultMessage: 'Regular expression' },
 });
 
 @injectIntl
@@ -122,7 +123,7 @@ export default class LocalSettingsPage extends React.PureComponent {
         </section>
       </div>
     ),
-    ({ onChange, settings }) => (
+    ({ intl, onChange, settings }) => (
       <div className='glitch local-settings__page content_warnings'>
         <h1><FormattedMessage id='settings.content_warnings' defaultMessage='Content warnings' /></h1>
         <LocalSettingsPageItem
@@ -132,6 +133,16 @@ export default class LocalSettingsPage extends React.PureComponent {
           onChange={onChange}
         >
           <FormattedMessage id='settings.enable_content_warnings_auto_unfold' defaultMessage='Automatically unfold content-warnings' />
+        </LocalSettingsPageItem>
+        <LocalSettingsPageItem
+          settings={settings}
+          item={['content_warnings', 'filter']}
+          id='mastodon-settings--content_warnings-auto_unfold'
+          onChange={onChange}
+          dependsOn={[['content_warnings', 'auto_unfold']]}
+          placeholder={intl.formatMessage(messages.regexp)}
+        >
+          <FormattedMessage id='settings.content_warnings_filter' defaultMessage='Content warnings to not automatically unfold:' />
         </LocalSettingsPageItem>
       </div>
     ),

--- a/app/javascript/flavours/glitch/features/local_settings/page/index.js
+++ b/app/javascript/flavours/glitch/features/local_settings/page/index.js
@@ -123,6 +123,19 @@ export default class LocalSettingsPage extends React.PureComponent {
       </div>
     ),
     ({ onChange, settings }) => (
+      <div className='glitch local-settings__page content_warnings'>
+        <h1><FormattedMessage id='settings.content_warnings' defaultMessage='Content warnings' /></h1>
+        <LocalSettingsPageItem
+          settings={settings}
+          item={['content_warnings', 'auto_unfold']}
+          id='mastodon-settings--content_warnings-auto_unfold'
+          onChange={onChange}
+        >
+          <FormattedMessage id='settings.enable_content_warnings_auto_unfold' defaultMessage='Automatically unfold content-warnings' />
+        </LocalSettingsPageItem>
+      </div>
+    ),
+    ({ onChange, settings }) => (
       <div className='glitch local-settings__page collapsed'>
         <h1><FormattedMessage id='settings.collapsed_statuses' defaultMessage='Collapsed toots' /></h1>
         <LocalSettingsPageItem

--- a/app/javascript/flavours/glitch/features/local_settings/page/item/index.js
+++ b/app/javascript/flavours/glitch/features/local_settings/page/item/index.js
@@ -19,18 +19,20 @@ export default class LocalSettingsPageItem extends React.PureComponent {
       message: PropTypes.string.isRequired,
     })),
     settings: ImmutablePropTypes.map.isRequired,
+    placeholder: PropTypes.string,
   };
 
   handleChange = e => {
     const { target } = e;
-    const { item, onChange, options } = this.props;
+    const { item, onChange, options, placeholder } = this.props;
     if (options && options.length > 0) onChange(item, target.value);
+    else if (placeholder) onChange(item, target.value);
     else onChange(item, target.checked);
   }
 
   render () {
     const { handleChange } = this;
-    const { settings, item, id, options, children, dependsOn, dependsOnNot } = this.props;
+    const { settings, item, id, options, children, dependsOn, dependsOnNot, placeholder } = this.props;
     let enabled = true;
 
     if (dependsOn) {
@@ -67,6 +69,22 @@ export default class LocalSettingsPageItem extends React.PureComponent {
             >
               {optionElems}
             </select>
+          </p>
+        </label>
+      );
+    } else if (placeholder) {
+      return (
+        <label className='glitch local-settings__page__item' htmlFor={id}>
+          <p>{children}</p>
+          <p>
+            <input
+              id={id}
+              type='text'
+              value={settings.getIn(item)}
+              placeholder={placeholder}
+              onChange={handleChange}
+              disabled={!enabled}
+            />
           </p>
         </label>
       );

--- a/app/javascript/flavours/glitch/features/status/index.js
+++ b/app/javascript/flavours/glitch/features/status/index.js
@@ -38,6 +38,7 @@ import ImmutablePureComponent from 'react-immutable-pure-component';
 import { HotKeys } from 'react-hotkeys';
 import { boostModal, favouriteModal, deleteModal } from 'flavours/glitch/util/initial_state';
 import { attachFullscreenListener, detachFullscreenListener, isFullscreen } from 'flavours/glitch/util/fullscreen';
+import { autoUnfoldCW } from 'flavours/glitch/util/content_warning';
 
 const messages = defineMessages({
   deleteConfirm: { id: 'confirmations.delete.confirm', defaultMessage: 'Delete' },
@@ -82,7 +83,7 @@ export default class Status extends ImmutablePureComponent {
 
   state = {
     fullscreen: false,
-    isExpanded: this.props.settings.getIn(['content_warnings', 'auto_unfold']),
+    isExpanded: undefined,
     threadExpanded: undefined,
   };
 
@@ -95,9 +96,14 @@ export default class Status extends ImmutablePureComponent {
   }
 
   componentWillReceiveProps (nextProps) {
+    if (this.state.isExpanded === undefined) {
+      const isExpanded = autoUnfoldCW(nextProps.settings, nextProps.status);
+      if (isExpanded !== undefined) this.setState({ isExpanded: isExpanded });
+    }
     if (nextProps.params.statusId !== this.props.params.statusId && nextProps.params.statusId) {
       this._scrolledIntoView = false;
       this.props.dispatch(fetchStatus(nextProps.params.statusId));
+      this.setState({ isExpanded: autoUnfoldCW(nextProps.settings, nextProps.status) });
     }
   }
 

--- a/app/javascript/flavours/glitch/features/status/index.js
+++ b/app/javascript/flavours/glitch/features/status/index.js
@@ -82,8 +82,8 @@ export default class Status extends ImmutablePureComponent {
 
   state = {
     fullscreen: false,
-    isExpanded: false,
-    threadExpanded: null,
+    isExpanded: this.props.settings.getIn(['content_warnings', 'auto_unfold']),
+    threadExpanded: undefined,
   };
 
   componentWillMount () {

--- a/app/javascript/flavours/glitch/reducers/local_settings.js
+++ b/app/javascript/flavours/glitch/reducers/local_settings.js
@@ -16,6 +16,7 @@ const initialState = ImmutableMap({
   confirm_missing_media_description: false,
   content_warnings : ImmutableMap({
     auto_unfold : false,
+    filter      : null,
   }),
   collapsed : ImmutableMap({
     enabled     : true,

--- a/app/javascript/flavours/glitch/reducers/local_settings.js
+++ b/app/javascript/flavours/glitch/reducers/local_settings.js
@@ -14,6 +14,9 @@ const initialState = ImmutableMap({
   show_reply_count : false,
   always_show_spoilers_field: false,
   confirm_missing_media_description: false,
+  content_warnings : ImmutableMap({
+    auto_unfold : false,
+  }),
   collapsed : ImmutableMap({
     enabled     : true,
     auto        : ImmutableMap({

--- a/app/javascript/flavours/glitch/util/content_warning.js
+++ b/app/javascript/flavours/glitch/util/content_warning.js
@@ -1,0 +1,19 @@
+export function autoUnfoldCW (settings, status) {
+  if (!settings.getIn(['content_warnings', 'auto_unfold'])) {
+    return false;
+  }
+
+  const rawRegex = settings.getIn(['content_warnings', 'filter']);
+  let regex      = null;
+
+  try {
+    regex = rawRegex && new RegExp(rawRegex.trim(), 'i');
+  } catch (e) {
+    // Bad regex, don't affect filters
+  }
+
+  if (!(status && regex)) {
+    return undefined;
+  }
+  return !regex.test(status.get('spoiler_text'));
+}


### PR DESCRIPTION
Fixes #678

![screenshot_2018-08-28 dev instance](https://user-images.githubusercontent.com/384364/44732904-a1e2de80-aae6-11e8-9fcc-14215761fa35.png)

I'm not 100% convinced by the implementation nor the UI (using regexps is not so user-friendly, but more powerful and somewhat easier to implement than keywords…)