### PR TITLE
[Glitch] Reduce padding of profile metadata boxes to allow more text

### DIFF
--- a/app/javascript/flavours/glitch/styles/components/metadata.scss
+++ b/app/javascript/flavours/glitch/styles/components/metadata.scss
@@ -21,7 +21,7 @@
   dt,
   dd {
     box-sizing: border-box;
-    padding: 14px 20px;
+    padding: 14px 5px;
     text-align: center;
     max-height: 48px;
     overflow: hidden;


### PR DESCRIPTION
Port 9463bba5fb6873fa70e05f239079ee1a0072b70c to glitch-soc

Before:
![screenshot_2018-08-29 mastodon instance perso de thibg](https://user-images.githubusercontent.com/384364/44782495-b5925180-ab87-11e8-9a79-623c1f9b36af.png)


After:
![screenshot_2018-08-29 mastodon instance perso de thibg 1](https://user-images.githubusercontent.com/384364/44782496-b88d4200-ab87-11e8-8a2e-e249646ef252.png)
