### PR TITLE
Simplify scrolling code by postponing scroll restore to after content is drawn

### DIFF
--- a/app/javascript/flavours/glitch/components/scrollable_list.js
+++ b/app/javascript/flavours/glitch/components/scrollable_list.js
@@ -67,23 +67,7 @@ export default class ScrollableList extends PureComponent {
     this.handleScroll();
   }
 
-  getScrollPosition = () => {
-    if (this.node && this.node.scrollTop > 0) {
-      return {height: this.node.scrollHeight, top: this.node.scrollTop};
-    } else {
-      return null;
-    }
-  }
-
-  updateScrollBottom = (snapshot) => {
-    const newScrollTop = this.node.scrollHeight - snapshot;
-
-    if (this.node.scrollTop !== newScrollTop) {
-      this.node.scrollTop = newScrollTop;
-    }
-  }
-
-  getSnapshotBeforeUpdate (prevProps, prevState) {
+  getSnapshotBeforeUpdate (prevProps) {
     const someItemInserted = React.Children.count(prevProps.children) > 0 &&
       React.Children.count(prevProps.children) < React.Children.count(this.props.children) &&
       this.getFirstChildKey(prevProps) !== this.getFirstChildKey(this.props);
@@ -97,7 +81,15 @@ export default class ScrollableList extends PureComponent {
   componentDidUpdate (prevProps, prevState, snapshot) {
     // Reset the scroll position when a new child comes in in order not to
     // jerk the scrollbar around if you're already scrolled down the page.
-    if (snapshot !== null) this.updateScrollBottom(snapshot);
+    if (snapshot !== null) {
+      window.requestAnimationFrame(() => {
+        const newScrollTop = this.node.scrollHeight - snapshot;
+
+        if (this.node.scrollTop !== newScrollTop) {
+          this.node.scrollTop = newScrollTop;
+        }
+      });
+    }
   }
 
   componentWillUnmount () {
@@ -172,7 +164,7 @@ export default class ScrollableList extends PureComponent {
                 intersectionObserverWrapper={this.intersectionObserverWrapper}
                 saveHeightKey={trackScroll ? `${this.context.router.route.location.key}:${scrollKey}` : null}
               >
-                {React.cloneElement(child, {getScrollPosition: this.getScrollPosition, updateScrollBottom: this.updateScrollBottom})}
+                {child}
               </IntersectionObserverArticleContainer>
             ))}
 

--- a/app/javascript/flavours/glitch/components/status.js
+++ b/app/javascript/flavours/glitch/components/status.js
@@ -48,14 +48,11 @@ export default class Status extends ImmutablePureComponent {
     withDismiss: PropTypes.bool,
     onMoveUp: PropTypes.func,
     onMoveDown: PropTypes.func,
-    getScrollPosition: PropTypes.func,
-    updateScrollBottom: PropTypes.func,
     expanded: PropTypes.bool,
   };
 
   state = {
     isCollapsed: false,
-    autoCollapsed: false,
   }
 
   // Avoid checking props that are functions (and whose equality will always
@@ -178,28 +175,6 @@ export default class Status extends ImmutablePureComponent {
       }
     }()) {
       this.setCollapsed(true);
-      // Hack to fix timeline jumps on second rendering when auto-collapsing
-      this.setState({ autoCollapsed: true });
-    }
-  }
-
-  getSnapshotBeforeUpdate (prevProps, prevState) {
-    if (this.props.getScrollPosition) {
-      return this.props.getScrollPosition();
-    } else {
-      return null;
-    }
-  }
-
-  //  Hack to fix timeline jumps on second rendering when auto-collapsing
-  componentDidUpdate (prevProps, prevState, snapshot) {
-    if (this.state.autoCollapsed) {
-      this.setState({ autoCollapsed: false });
-      if (snapshot !== null && this.props.updateScrollBottom) {
-        if (this.node.offsetTop < snapshot.top) {
-          this.props.updateScrollBottom(snapshot.height - snapshot.top);
-        }
-      }
     }
   }
 

--- a/app/javascript/flavours/glitch/features/notifications/components/notification.js
+++ b/app/javascript/flavours/glitch/features/notifications/components/notification.js
@@ -16,8 +16,6 @@ export default class Notification extends ImmutablePureComponent {
     onMoveUp: PropTypes.func.isRequired,
     onMoveDown: PropTypes.func.isRequired,
     onMention: PropTypes.func.isRequired,
-    getScrollPosition: PropTypes.func,
-    updateScrollBottom: PropTypes.func,
   };
 
   render () {
@@ -27,8 +25,6 @@ export default class Notification extends ImmutablePureComponent {
       onMoveDown,
       onMoveUp,
       onMention,
-      getScrollPosition,
-      updateScrollBottom,
     } = this.props;
 
     switch(notification.get('type')) {
@@ -55,8 +51,6 @@ export default class Notification extends ImmutablePureComponent {
           onMoveUp={onMoveUp}
           onMention={onMention}
           contextType='notifications'
-          getScrollPosition={getScrollPosition}
-          updateScrollBottom={updateScrollBottom}
           withDismiss
         />
       );
@@ -73,8 +67,6 @@ export default class Notification extends ImmutablePureComponent {
           onMoveDown={onMoveDown}
           onMoveUp={onMoveUp}
           onMention={onMention}
-          getScrollPosition={getScrollPosition}
-          updateScrollBottom={updateScrollBottom}
           withDismiss
         />
       );
@@ -91,8 +83,6 @@ export default class Notification extends ImmutablePureComponent {
           onMoveDown={onMoveDown}
           onMoveUp={onMoveUp}
           onMention={onMention}
-          getScrollPosition={getScrollPosition}
-          updateScrollBottom={updateScrollBottom}
           withDismiss
         />
       );


### PR DESCRIPTION
One reason we had to use such a hack is because statuses are render()-ed
multiple time in the pipeline when they are auto-collapsed, which meant the
ScrollableList lifecycle functions were called before statuses had their final
height. By postponing the scroll repositioning to after the content is drawn,
we can bypass such limitations while simplifying the code.

This needs some more testing, but I think this is a better way to handle the issue than I did in 694337d9bbaa2505f659d9b9980d393bd317679a