### PR TITLE
fix invisible compose area on chrome, mobile mode

### DIFF
--- a/app/javascript/flavours/glitch/styles/components/columns.scss
+++ b/app/javascript/flavours/glitch/styles/components/columns.scss
@@ -80,10 +80,6 @@
       padding: 0;
     }
 
-    .columns-area {
-      flex-direction: column;
-    }
-
     .search__input,
     .autosuggest-textarea__textarea {
       font-size: 16px;


### PR DESCRIPTION
fixes it for me but to be honest i am not sure if this causes any unwanted side effects. didn't notice any yet...

i used chrome's inspector and tried messing with styles until i found what was making the compose area invisible but i'm no expert.

if this is wrong maybe it's at least a nudge in the right direction