### PR TITLE
[Glitch] Add white outline to black emoji

### DIFF
--- a/app/javascript/flavours/glitch/styles/accessibility.scss
+++ b/app/javascript/flavours/glitch/styles/accessibility.scss
@@ -1,0 +1,13 @@
+$emojis-requiring-outlines: '8ball' 'ant' 'back' 'black_circle' 'black_heart' 'black_large_square' 'black_medium_small_square' 'black_medium_square' 'black_nib' 'black_small_square' 'bomb' 'bowling' 'bust_in_silhouette' 'busts_in_silhouette' 'camera' 'camera_with_flash' 'clubs' 'copyright' 'curly_loop' 'currency_exchange' 'dark_sunglasses' 'eight_pointed_black_star' 'electric_plug' 'end' 'female-guard' 'film_projector' 'fried_egg' 'gorilla' 'guardsman' 'heavy_check_mark' 'heavy_division_sign' 'heavy_dollar_sign' 'heavy_minus_sign' 'heavy_multiplication_x' 'heavy_plus_sign' 'hocho' 'hole' 'joystick' 'kaaba' 'lower_left_ballpoint_pen' 'lower_left_fountain_pen' 'male-guard' 'microphone' 'mortar_board' 'movie_camera' 'musical_score' 'on' 'registered' 'soon' 'spades' 'speaking_head_in_silhouette' 'spider' 'telephone_receiver' 'tm' 'top' 'tophat' 'turkey' 'vhs' 'video_camera' 'video_game' 'water_buffalo' 'waving_black_flag' 'wavy_dash' !default;
+
+%emoji-outline {
+  filter: drop-shadow(1px 1px 0 $primary-text-color) drop-shadow(-1px 1px 0 $primary-text-color) drop-shadow(1px -1px 0 $primary-text-color) drop-shadow(-1px -1px 0 $primary-text-color);
+}
+
+.emojione {
+  @each $emoji in $emojis-requiring-outlines {
+    &[title=':#{$emoji}:'] {
+      @extend %emoji-outline;
+    }
+  }
+}

--- a/app/javascript/flavours/glitch/styles/index.scss
+++ b/app/javascript/flavours/glitch/styles/index.scss
@@ -19,5 +19,6 @@
 @import 'about';
 @import 'tables';
 @import 'admin';
+@import 'accessibility';
 @import 'rtl';
 @import 'dashboard';


### PR DESCRIPTION
Inspired from 0bfa0f237495249a322cd3a1100b394211755e8c

![screenshot_2018-09-03 thib thib mastodev sitedethib com](https://user-images.githubusercontent.com/384364/44998174-be35be00-afb3-11e8-9c70-95a85533f23f.png)

Unlike upstream, there is no transform to make the emoji smaller and compensate for the added outline. This is because I think it makes them less legible, and also uglier on Firefox.

Another departure from upstream is that I'm not using `$white` but `$primary-text-color` and that I changed the name of the variables. This is so that other skins may reuse this for other color schemes.