### PR TITLE
Minor media gallery design fixes

### DIFF
--- a/app/javascript/flavours/glitch/components/media_gallery.js
+++ b/app/javascript/flavours/glitch/components/media_gallery.js
@@ -163,7 +163,8 @@ class Item extends React.PureComponent {
             sizes={sizes}
             alt={attachment.get('description')}
             title={attachment.get('description')}
-            style={{ objectPosition: `${x}% ${y}%` }} />
+            style={{ objectPosition: `${x}% ${y}%` }}
+          />
         </a>
       );
     } else if (attachment.get('type') === 'gifv') {
@@ -191,7 +192,7 @@ class Item extends React.PureComponent {
     }
 
     return (
-      <div className={classNames('media-gallery__item', { standalone })} key={attachment.get('id')} style={{ left: left, top: top, right: right, bottom: bottom, width: `${width}%`, height: `${height}%` }}>
+      <div className={classNames('media-gallery__item', { standalone, letterbox })} key={attachment.get('id')} style={{ left: left, top: top, right: right, bottom: bottom, width: `${width}%`, height: `${height}%` }}>
         {thumbnail}
       </div>
     );
@@ -261,6 +262,8 @@ export default class MediaGallery extends React.PureComponent {
 
     if (this.isStandaloneEligible() && width) {
       style.height = width / this.props.media.getIn([0, 'meta', 'small', 'aspect']);
+    } else if (width) {
+      style.height = width / (16/9);
     }
 
     if (!visible) {
@@ -280,7 +283,7 @@ export default class MediaGallery extends React.PureComponent {
       }
     }
 
-    const computedClass = classNames('media-gallery', `size-${size}`, { 'full-width': fullwidth });
+    const computedClass = classNames('media-gallery', { 'full-width': fullwidth });
 
     return (
       <div className={computedClass} style={style} ref={this.handleRef}>

--- a/app/javascript/flavours/glitch/components/media_gallery.js
+++ b/app/javascript/flavours/glitch/components/media_gallery.js
@@ -70,7 +70,7 @@ class Item extends React.PureComponent {
   handleClick = (e) => {
     const { index, onClick } = this.props;
 
-    if (e.button === 0) {
+    if (e.button === 0 && !(e.ctrlKey || e.metaKey)) {
       e.preventDefault();
       onClick(index);
     }

--- a/app/javascript/flavours/glitch/components/media_gallery.js
+++ b/app/javascript/flavours/glitch/components/media_gallery.js
@@ -163,7 +163,7 @@ class Item extends React.PureComponent {
             sizes={sizes}
             alt={attachment.get('description')}
             title={attachment.get('description')}
-            style={{ objectPosition: `${x}% ${y}%` }}
+            style={{ objectPosition: letterbox ? null : `${x}% ${y}%` }}
           />
         </a>
       );

--- a/app/javascript/flavours/glitch/features/status/components/detailed_status.js
+++ b/app/javascript/flavours/glitch/features/status/components/detailed_status.js
@@ -77,6 +77,7 @@ export default class DetailedStatus extends ImmutablePureComponent {
             sensitive={status.get('sensitive')}
             media={status.get('media_attachments')}
             letterbox={settings.getIn(['media', 'letterbox'])}
+            fullwidth={settings.getIn(['media', 'fullwidth'])}
             onOpenMedia={this.props.onOpenMedia}
           />
         );

--- a/app/javascript/flavours/glitch/styles/_mixins.scss
+++ b/app/javascript/flavours/glitch/styles/_mixins.scss
@@ -43,8 +43,8 @@
 
 @mixin fullwidth-gallery {
   &.full-width {
-    margin-left: -22px;
-    margin-right: -22px;
+    margin-left: -14px;
+    margin-right: -14px;
     width: inherit;
     max-width: none;
     height: 250px;

--- a/app/javascript/flavours/glitch/styles/_mixins.scss
+++ b/app/javascript/flavours/glitch/styles/_mixins.scss
@@ -48,5 +48,6 @@
     width: inherit;
     max-width: none;
     height: 250px;
+    border-radius: 0px;
   }
 }

--- a/app/javascript/flavours/glitch/styles/components/media.scss
+++ b/app/javascript/flavours/glitch/styles/components/media.scss
@@ -78,16 +78,10 @@
   box-sizing: border-box;
   margin-top: 8px;
   overflow: hidden;
+  border-radius: 4px;
   position: relative;
-  background: $base-shadow-color;
   width: 100%;
   height: 110px;
-
-  .detailed-status & {
-    margin-left: -14px;
-    width: calc(100% + 28px);
-    height: 250px;
-  }
 
   @include fullwidth-gallery;
 }
@@ -98,6 +92,12 @@
   display: block;
   float: left;
   position: relative;
+  border-radius: 4px;
+  overflow: hidden;
+
+  .full-width & {
+    border-radius: 0;
+  }
 
   &.standalone {
     .media-gallery__item-gifv-thumbnail {
@@ -105,13 +105,17 @@
       top: 0;
     }
   }
+
+  &.letterbox {
+    background: $base-shadow-color;
+  }
 }
 
 .media-gallery__item-thumbnail {
   cursor: zoom-in;
   display: block;
   text-decoration: none;
-  height: 100%;
+  color: $secondary-text-color;
   line-height: 0;
 
   &,


### PR DESCRIPTION
# Changes

There are a few changes in this one, but basically:
- Have approximately the same behavior as upstream in terms of aspect ratio
- Use rounded borders like upstream (except when full-width is enabled)
- Drop background color of the whole gallery, use background color for individual items if they are letterboxed
- Fix full-width margins
- Fix weird interaction between letterboxing and focal points

# Comparison with prior versions

(Too lazy to do a comparison with tootsuite though)

## No letterboxing, no fullwidth

### Before

![screenshot_2018-09-03 dev instance](https://user-images.githubusercontent.com/384364/44999083-fe4c6f00-afba-11e8-80e9-94fd49ebba0a.png)

![screenshot_2018-09-03 dev instance 1](https://user-images.githubusercontent.com/384364/44999087-0c01f480-afbb-11e8-9bdf-212dc0cdde98.png)

### After

![screenshot_2018-09-03 dev instance 7](https://user-images.githubusercontent.com/384364/44999957-57b79c80-afc1-11e8-920b-91602b329520.png)

![screenshot_2018-09-03 dev instance 8](https://user-images.githubusercontent.com/384364/44999959-5ab28d00-afc1-11e8-9a27-c557ea9b3f11.png)


## No letterboxing, fullwidth

### Before

![screenshot_2018-09-03 dev instance 2](https://user-images.githubusercontent.com/384364/44999101-1cb26a80-afbb-11e8-965d-decd2bc854cc.png)

![screenshot_2018-09-03 dev instance 3](https://user-images.githubusercontent.com/384364/44999102-20de8800-afbb-11e8-8826-f639e22e6738.png)

### After

![screenshot_2018-09-03 dev instance 11](https://user-images.githubusercontent.com/384364/44999975-7ae24c00-afc1-11e8-86fd-4934ffe5c6e3.png)

![screenshot_2018-09-03 dev instance 12](https://user-images.githubusercontent.com/384364/44999980-803f9680-afc1-11e8-8494-207cfc44c4db.png)


## Letterboxing, fullwidth

### Before

![screenshot_2018-09-03 dev instance 5](https://user-images.githubusercontent.com/384364/44999115-39e73900-afbb-11e8-8c87-77fcb9d859a8.png)

![screenshot_2018-09-03 dev instance 4](https://user-images.githubusercontent.com/384364/44999117-3d7ac000-afbb-11e8-86f9-4cce4a7e82b3.png)


### After

![screenshot_2018-09-03 dev instance 13](https://user-images.githubusercontent.com/384364/44999982-86ce0e00-afc1-11e8-9117-01821c1c7f92.png)

![screenshot_2018-09-03 dev instance 14](https://user-images.githubusercontent.com/384364/44999986-89c8fe80-afc1-11e8-82b3-3ce76c7bb5d0.png)