### PR TITLE
Add manifest_src to CSP

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -27,6 +27,7 @@ if Rails.env.production?
     p.frame_src       :self, :https
     p.worker_src      :self, assets_host
     p.connect_src     :self, :blob, Rails.configuration.x.streaming_api_base_url, *data_hosts
+    p.manifest_src    :self, :https
   end
 end
 


### PR DESCRIPTION
Fixes manifest.json not being loaded because of CSP violation

h/t https://vulpine.club/@binary/100662852252438648