### PR TITLE
prepend re: to replies to spoiler-text

### DIFF
--- a/app/javascript/flavours/glitch/reducers/compose.js
+++ b/app/javascript/flavours/glitch/reducers/compose.js
@@ -314,8 +314,12 @@ export default function compose(state = initialState, action) {
       map.set('idempotencyKey', uuid());
 
       if (action.status.get('spoiler_text').length > 0) {
+        let spoiler_text = action.status.get('spoiler_text');
+        if (!spoiler_text.match(/^re[: ]/i)) {
+          spoiler_text = 're: '.concat(spoiler_text);
+        }
         map.set('spoiler', true);
-        map.set('spoiler_text', action.status.get('spoiler_text'));
+        map.set('spoiler_text', spoiler_text);
       } else {
         map.set('spoiler', false);
         map.set('spoiler_text', '');


### PR DESCRIPTION
if spoiler-text doesn't already start with re:, we prepend `re: `
ourselves in replies.

This implements https://github.com/tootsuite/mastodon/issues/8667
Following Plemora's example: https://git.pleroma.social/pleroma/pleroma-fe/merge_requests/318