### PR TITLE
Don't prepend 're: ' to spoiler text on self-replies

### DIFF
--- a/app/javascript/flavours/glitch/reducers/compose.js
+++ b/app/javascript/flavours/glitch/reducers/compose.js
@@ -315,7 +315,7 @@ export default function compose(state = initialState, action) {
 
       if (action.status.get('spoiler_text').length > 0) {
         let spoiler_text = action.status.get('spoiler_text');
-        if (!spoiler_text.match(/^re[: ]/i)) {
+        if (!spoiler_text.match(/^re[: ]/i) && action.status.getIn(['account', 'id']) !== me) {
           spoiler_text = 're: '.concat(spoiler_text);
         }
         map.set('spoiler', true);


### PR DESCRIPTION
A small modification to the feature added in 8433bd89e431d5834e4252c7ca197771944aa6d1 (adding "re: " to the beginning of spoiler text when replying). This PR makes it so that this doesn't happen to replies to your own toots.

This makes writing a thread "manually" (by clicking "reply" on your own posts) behave the same as using threaded mode.

The change was made here rather than adding "re: " in threaded mode because when a user puts a content warning on a thread, that content warning will likely be relevant for the rest of the thread. It's also less confusing because, although they are technically "replying" to their post, you don't tend to think of posts in a thread as "replies". They're more like a continuation of the first post. Adding a reply indicator seems misleading for this reason.