### PR TITLE
Disable the “TOOT” button (and secondary toot button) if the toot text is empty

### DIFF
--- a/app/javascript/flavours/glitch/features/composer/index.js
+++ b/app/javascript/flavours/glitch/features/composer/index.js
@@ -242,7 +242,7 @@ const handlers = {
     }
 
     // Submit disabled:
-    if (isSubmitting || isUploading || (!!text.length && !text.trim().length && !anyMedia)) {
+    if (isSubmitting || isUploading || (!text.trim().length && !anyMedia)) {
       return;
     }
 
@@ -415,7 +415,7 @@ class Composer extends React.Component {
       spoilersAlwaysOn,
     } = this.props;
 
-    let disabledButton = isSubmitting || isUploading || (!!text.length && !text.trim().length && !anyMedia);
+    let disabledButton = isSubmitting || isUploading || (!text.trim().length && !anyMedia);
 
     return (
       <div className='composer'>


### PR DESCRIPTION
The following has been bugging me for a while:
![screenshot_2018-09-21 mastodon instance perso de thibg](https://user-images.githubusercontent.com/384364/45906610-1282cf80-bdf5-11e8-82b7-c7574f85a912.png)

But it's intentional, as per https://github.com/tootsuite/mastodon/pull/2154#discussion_r113025942 so I don't know.

After:
![screenshot_2018-09-21 dev instance](https://user-images.githubusercontent.com/384364/45907765-86bf7200-bdf9-11e8-856f-216349d3cf7a.png)
