### PR TITLE
Fix build status link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 >   Now with automated deploys!
 
-[![Build Status](https://img.shields.io/circleci/project/github/glitch-soc/mastodon.svg)](https://travis-ci.org/glitch-soc/mastodon)
+[![Build Status](https://img.shields.io/circleci/project/github/glitch-soc/mastodon.svg)][circleci]
 
 [circleci]: https://circleci.com/gh/glitch-soc/mastodon
 


### PR DESCRIPTION
It was still linking to Travis, oops.