### PR TITLE
Add option to hide action bar in collapsed toots

### DIFF
--- a/app/javascript/flavours/glitch/components/status.js
+++ b/app/javascript/flavours/glitch/components/status.js
@@ -539,7 +539,7 @@ export default class Status extends ImmutablePureComponent {
             parseClick={parseClick}
             disabled={!router}
           />
-          {!isCollapsed || !muted ? (
+          {!isCollapsed || !(muted || !settings.getIn(['collapsed', 'show_action_bar'])) ? (
             <StatusActionBar
               {...other}
               status={status}

--- a/app/javascript/flavours/glitch/features/local_settings/page/index.js
+++ b/app/javascript/flavours/glitch/features/local_settings/page/index.js
@@ -261,6 +261,18 @@ export default class LocalSettingsPage extends React.PureComponent {
             <FormattedMessage id='settings.image_backgrounds_media' defaultMessage='Preview collapsed toot media' />
           </LocalSettingsPageItem>
         </section>
+        <section>
+          <h2></h2>
+          <LocalSettingsPageItem
+            settings={settings}
+            item={['collapsed', 'show_action_bar']}
+            id='mastodon-settings--collapsed-show-action-bar'
+            onChange={onChange}
+            dependsOn={[['collapsed', 'enabled']]}
+          >
+            <FormattedMessage id='settings.show_action_bar' defaultMessage='Show action buttons in collapsed toots' />
+          </LocalSettingsPageItem>
+        </section>
       </div>
     ),
     ({ onChange, settings }) => (

--- a/app/javascript/flavours/glitch/locales/en.js
+++ b/app/javascript/flavours/glitch/locales/en.js
@@ -18,6 +18,7 @@ const messages = {
   'settings.auto_collapse_notifications': 'Notifications',
   'settings.auto_collapse_reblogs': 'Boosts',
   'settings.auto_collapse_replies': 'Replies',
+  'settings.show_action_bar': 'Show action buttons in collapsed toots',
   'settings.close': 'Close',
   'settings.collapsed_statuses': 'Collapsed toots',
   'settings.enable_collapsed': 'Enable collapsed toots',

--- a/app/javascript/flavours/glitch/reducers/local_settings.js
+++ b/app/javascript/flavours/glitch/reducers/local_settings.js
@@ -32,6 +32,7 @@ const initialState = ImmutableMap({
       user_backgrounds : false,
       preview_images   : false,
     }),
+    show_action_bar : true,
   }),
   media     : ImmutableMap({
     letterbox   : true,


### PR DESCRIPTION
I felt like it was a waste of space. The default is to keep existing behavior ("show action bar" on). The appearance could be tweaked, but for now here's what a status looks like without the buttons ("show action bar" off):
![image](https://user-images.githubusercontent.com/1307275/46251451-21c2d800-c408-11e8-84f5-10fd9cf84b44.png)
The new option is called "Show action buttons in collapsed toots," and is in a new section in the "Collapsed toots" app settings, below "Image backgrounds."