### PR TITLE
Slight redesign of the local settings dialog

### DIFF
--- a/app/javascript/flavours/glitch/features/local_settings/page/index.js
+++ b/app/javascript/flavours/glitch/features/local_settings/page/index.js
@@ -186,6 +186,15 @@ export default class LocalSettingsPage extends React.PureComponent {
         >
           <FormattedMessage id='settings.enable_collapsed' defaultMessage='Enable collapsed toots' />
         </LocalSettingsPageItem>
+        <LocalSettingsPageItem
+          settings={settings}
+          item={['collapsed', 'show_action_bar']}
+          id='mastodon-settings--collapsed-show-action-bar'
+          onChange={onChange}
+          dependsOn={[['collapsed', 'enabled']]}
+        >
+          <FormattedMessage id='settings.show_action_bar' defaultMessage='Show action buttons in collapsed toots' />
+        </LocalSettingsPageItem>
         <section>
           <h2><FormattedMessage id='settings.auto_collapse' defaultMessage='Automatic collapsing' /></h2>
           <LocalSettingsPageItem
@@ -267,18 +276,6 @@ export default class LocalSettingsPage extends React.PureComponent {
             dependsOn={[['collapsed', 'enabled']]}
           >
             <FormattedMessage id='settings.image_backgrounds_media' defaultMessage='Preview collapsed toot media' />
-          </LocalSettingsPageItem>
-        </section>
-        <section>
-          <h2></h2>
-          <LocalSettingsPageItem
-            settings={settings}
-            item={['collapsed', 'show_action_bar']}
-            id='mastodon-settings--collapsed-show-action-bar'
-            onChange={onChange}
-            dependsOn={[['collapsed', 'enabled']]}
-          >
-            <FormattedMessage id='settings.show_action_bar' defaultMessage='Show action buttons in collapsed toots' />
           </LocalSettingsPageItem>
         </section>
       </div>

--- a/app/javascript/flavours/glitch/features/local_settings/page/item/index.js
+++ b/app/javascript/flavours/glitch/features/local_settings/page/item/index.js
@@ -48,57 +48,62 @@ export default class LocalSettingsPageItem extends React.PureComponent {
 
     if (options && options.length > 0) {
       const currentValue = settings.getIn(item);
-      const optionElems = options && options.length > 0 && options.map((opt) => (
-        <option
-          key={opt.value}
-          value={opt.value}
-        >
-          {opt.message}
-        </option>
-      ));
-      return (
-        <label className='glitch local-settings__page__item' htmlFor={id}>
-          <p>{children}</p>
-          <p>
-            <select
-              id={id}
-              disabled={!enabled}
+      const optionElems = options && options.length > 0 && options.map((opt) => {
+        let optionId = `${id}--${opt.value}`;
+        return (
+          <label htmlFor={optionId}>
+            <input type='radio'
+              name={id}
+              id={optionId}
+              value={opt.value}
               onBlur={handleChange}
               onChange={handleChange}
-              value={currentValue}
-            >
-              {optionElems}
-            </select>
-          </p>
-        </label>
+              checked={ currentValue === opt.value }
+              disabled={!enabled}
+            />
+            {opt.message}
+          </label>
+        );
+      });
+      return (
+        <div class='glitch local-settings__page__item radio_buttons'>
+          <fieldset>
+            <legend>{children}</legend>
+            {optionElems}
+          </fieldset>
+        </div>
       );
     } else if (placeholder) {
       return (
-        <label className='glitch local-settings__page__item' htmlFor={id}>
-          <p>{children}</p>
-          <p>
-            <input
-              id={id}
-              type='text'
-              value={settings.getIn(item)}
-              placeholder={placeholder}
-              onChange={handleChange}
-              disabled={!enabled}
-            />
-          </p>
-        </label>
+        <div className='glitch local-settings__page__item string'>
+          <label htmlFor={id}>
+            <p>{children}</p>
+            <p>
+              <input
+                id={id}
+                type='text'
+                value={settings.getIn(item)}
+                placeholder={placeholder}
+                onChange={handleChange}
+                disabled={!enabled}
+              />
+            </p>
+          </label>
+        </div>
       );
     } else return (
-      <label className='glitch local-settings__page__item' htmlFor={id}>
-        <input
-          id={id}
-          type='checkbox'
-          checked={settings.getIn(item)}
-          onChange={handleChange}
-          disabled={!enabled}
-        />
-        {children}
-      </label>
+      <div className='glitch local-settings__page__item boolean'>
+        <label htmlFor={id}>
+          <input
+            id={id}
+            type='checkbox'
+            checked={settings.getIn(item)}
+            onChange={handleChange}
+            disabled={!enabled}
+          />
+          {children}
+        </label>
+      </div>
     );
   }
 

--- a/app/javascript/flavours/glitch/styles/components/local_settings.scss
+++ b/app/javascript/flavours/glitch/styles/components/local_settings.scss
@@ -11,8 +11,21 @@
   max-height: 450px;
   overflow: hidden;
 
-  label {
+  label, legend {
     display: block;
+    font-size: 14px;
+  }
+
+  .boolean label, .radio_buttons label {
+    position: relative;
+    padding-left: 28px;
+    padding-top: 3px;
+
+    input {
+      position: absolute;
+      left: 0;
+      top: 0;
+    }
   }
 
   h1 {
@@ -74,7 +87,11 @@
 }
 
 .glitch.local-settings__page__item {
-  select {
-    margin-bottom: 5px;
-  }
+  margin-bottom: 2px;
+}
+
+.glitch.local-settings__page__item.string,
+.glitch.local-settings__page__item.radio_buttons {
+  margin-top: 10px;
+  margin-bottom: 10px;
 }


### PR DESCRIPTION
- Increase font size a bit
- Use radio buttons instead of select
- Pad checkboxes and radio buttons legend a bit
- Improve spacing between items
- Move “Show action buttons in collapsed toots around”

I'm slightly worried about the increased vertical space, but it's ok I guess.

This is still very cramped on mobile, especially with the tab bar not adapting (we should probably have icons instead of text), but I'm postponing that to a latter PR.

# General

## Before

![screenshot_2018-10-01 dev instance 9](https://user-images.githubusercontent.com/384364/46305219-1ced5800-c5b1-11e8-9ce8-7caac9a15824.png)

## After

![screenshot_2018-10-01 dev instance](https://user-images.githubusercontent.com/384364/46305298-5756f500-c5b1-11e8-88a2-e8071ba3a45e.png)

# Compose box options

## Before

![screenshot_2018-10-01 dev instance 10](https://user-images.githubusercontent.com/384364/46305242-3393af00-c5b1-11e8-86c7-26057dffd795.png)

## After

![screenshot_2018-10-01 dev instance 1](https://user-images.githubusercontent.com/384364/46305307-5cb43f80-c5b1-11e8-8a11-776276160d21.png)

# Content Warnings

## Before

![screenshot_2018-10-01 dev instance 11](https://user-images.githubusercontent.com/384364/46305271-48704280-c5b1-11e8-93eb-b546aff05c07.png)

## After

![screenshot_2018-10-01 dev instance 2](https://user-images.githubusercontent.com/384364/46305322-66d63e00-c5b1-11e8-8781-80b1465cc1ad.png)

# Collapsed toots

## Before

![screenshot_2018-10-01 dev instance 12](https://user-images.githubusercontent.com/384364/46305281-4e662380-c5b1-11e8-813b-e2cd6bc61547.png)

## After

![screenshot_2018-10-01 dev instance 3](https://user-images.githubusercontent.com/384364/46305330-6c338880-c5b1-11e8-98aa-307ff32d02a7.png)
