### PR TITLE
Improve support for masked (sensitive) media in account media gallery

### DIFF
--- a/app/javascript/flavours/glitch/components/permalink.js
+++ b/app/javascript/flavours/glitch/components/permalink.js
@@ -12,12 +12,20 @@ export default class Permalink extends React.PureComponent {
     href: PropTypes.string.isRequired,
     to: PropTypes.string.isRequired,
     children: PropTypes.node,
+    onInterceptClick: PropTypes.func,
   };
 
   handleClick = (e) => {
-    if (this.context.router && e.button === 0 && !(e.ctrlKey || e.metaKey)) {
-      e.preventDefault();
-      this.context.router.history.push(this.props.to);
+    if (e.button === 0 && !(e.ctrlKey || e.metaKey)) {
+      if (this.props.onInterceptClick && this.props.onInterceptClick()) {
+        e.preventDefault();
+        return;
+      }
+
+      if (this.context.router) {
+        e.preventDefault();
+        this.context.router.history.push(this.props.to);
+      }
     }
   }
 
@@ -27,6 +35,7 @@ export default class Permalink extends React.PureComponent {
       className,
       href,
       to,
+      onInterceptClick,
       ...other
     } = this.props;
 

--- a/app/javascript/flavours/glitch/features/account_gallery/components/media_item.js
+++ b/app/javascript/flavours/glitch/features/account_gallery/components/media_item.js
@@ -2,6 +2,7 @@ import React from 'react';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 import Permalink from 'flavours/glitch/components/permalink';
+import { displayMedia } from 'flavours/glitch/util/initial_state';
 
 export default class MediaItem extends ImmutablePureComponent {
 
@@ -9,8 +10,13 @@ export default class MediaItem extends ImmutablePureComponent {
     media: ImmutablePropTypes.map.isRequired,
   };
 
+  state = {
+    visible: displayMedia !== 'hide_all' && !this.props.media.getIn(['status', 'sensitive']) || displayMedia === 'show_all',
+  };
+
   render () {
     const { media } = this.props;
+    const { visible } = this.state;
     const status = media.get('status');
     const focusX = media.getIn(['meta', 'focus', 'x']);
     const focusY = media.getIn(['meta', 'focus', 'y']);
@@ -18,21 +24,28 @@ export default class MediaItem extends ImmutablePureComponent {
     const y = ((focusY / -2) + .5) * 100;
     const style = {};
 
-    let content;
+    let label, icon;
 
     if (media.get('type') === 'gifv') {
-      content = <span className='media-gallery__gifv__label'>GIF</span>;
+      label = <span className='media-gallery__gifv__label'>GIF</span>;
     }
 
-    if (!status.get('sensitive')) {
+    if (visible) {
       style.backgroundImage    = `url(${media.get('preview_url')})`;
       style.backgroundPosition = `${x}% ${y}%`;
+    } else {
+      icon = (
+        <span className='account-gallery__item__icons'>
+          <i className='fa fa-eye-slash' />
+        </span>
+      );
     }
 
     return (
       <div className='account-gallery__item'>
         <Permalink to={`/statuses/${status.get('id')}`} href={status.get('url')} style={style}>
-          {content}
+          {icon}
+          {label}
         </Permalink>
       </div>
     );

--- a/app/javascript/flavours/glitch/features/account_gallery/components/media_item.js
+++ b/app/javascript/flavours/glitch/features/account_gallery/components/media_item.js
@@ -14,6 +14,15 @@ export default class MediaItem extends ImmutablePureComponent {
     visible: displayMedia !== 'hide_all' && !this.props.media.getIn(['status', 'sensitive']) || displayMedia === 'show_all',
   };
 
+  handleClick = () => {
+    if (!this.state.visible) {
+      this.setState({ visible: true });
+      return true;
+    }
+
+    return false;
+  }
+
   render () {
     const { media } = this.props;
     const { visible } = this.state;
@@ -50,6 +59,7 @@ export default class MediaItem extends ImmutablePureComponent {
           href={status.get('url')}
           style={style}
           title={title}
+          onInterceptClick={this.handleClick}
         >
           {icon}
           {label}

--- a/app/javascript/flavours/glitch/features/account_gallery/components/media_item.js
+++ b/app/javascript/flavours/glitch/features/account_gallery/components/media_item.js
@@ -24,7 +24,7 @@ export default class MediaItem extends ImmutablePureComponent {
     const y = ((focusY / -2) + .5) * 100;
     const style = {};
 
-    let label, icon;
+    let label, icon, title;
 
     if (media.get('type') === 'gifv') {
       label = <span className='media-gallery__gifv__label'>GIF</span>;
@@ -33,17 +33,24 @@ export default class MediaItem extends ImmutablePureComponent {
     if (visible) {
       style.backgroundImage    = `url(${media.get('preview_url')})`;
       style.backgroundPosition = `${x}% ${y}%`;
+      title                    = media.get('description');
     } else {
       icon = (
         <span className='account-gallery__item__icons'>
           <i className='fa fa-eye-slash' />
         </span>
       );
+      title = status.get('spoiler_text') || media.get('description');
     }
 
     return (
       <div className='account-gallery__item'>
-        <Permalink to={`/statuses/${status.get('id')}`} href={status.get('url')} style={style}>
+        <Permalink
+          to={`/statuses/${status.get('id')}`}
+          href={status.get('url')}
+          style={style}
+          title={title}
+        >
           {icon}
           {label}
         </Permalink>

--- a/app/javascript/flavours/glitch/styles/components/accounts.scss
+++ b/app/javascript/flavours/glitch/styles/components/accounts.scss
@@ -415,7 +415,7 @@
     background-size: cover;
     background-position: center;
     position: absolute;
-    color: inherit;
+    color: $ui-primary-color;
     text-decoration: none;
     border-radius: 4px;
 
@@ -433,6 +433,14 @@
         border-radius: 4px;
       }
     }
+  }
+
+  &__icons {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    font-size: 24px;
   }
 }
 

--- a/app/javascript/flavours/glitch/styles/components/accounts.scss
+++ b/app/javascript/flavours/glitch/styles/components/accounts.scss
@@ -423,6 +423,7 @@
     &:active,
     &:focus {
       outline: 0;
+      color: $ui-secondary-color;
 
       &::before {
         content: "";

--- a/app/javascript/flavours/glitch/styles/mastodon-light/diff.scss
+++ b/app/javascript/flavours/glitch/styles/mastodon-light/diff.scss
@@ -84,7 +84,8 @@
 
 // Change the background colors of media and video spoilers
 .media-spoiler,
-.video-player__spoiler {
+.video-player__spoiler,
+.account-gallery__item a {
   background: $ui-base-color;
 }
 


### PR DESCRIPTION
- Port upstream changes honoring the `displayMedia` setting
- Port upstream changes for revealing hidden media by clicking
  Unlike upstream, this doesn't catch clicks with modifiers though
- Fix styling issue with the mastodon-light theme
- Add media description (if any) as `title`, or, if the media is hidden and the toot has a content warning, set that as `title`

# Default theme

## Before

![screenshot_2018-10-02 dev instance 2](https://user-images.githubusercontent.com/384364/46354487-04d41200-c65f-11e8-915d-94fbfeaf93ca.png)

## After

![screenshot_2018-10-02 dev instance 3](https://user-images.githubusercontent.com/384364/46354488-08679900-c65f-11e8-88fc-c4e5b20e3ad2.png)

# Mastodon-light

## Before

![screenshot_2018-10-02 dev instance 5](https://user-images.githubusercontent.com/384364/46354512-10273d80-c65f-11e8-9082-5930f0970489.png)

## After

![screenshot_2018-10-02 dev instance 4](https://user-images.githubusercontent.com/384364/46354518-13bac480-c65f-11e8-8b8b-52fb847c593b.png)
