### PR TITLE
Fix app-wide hotkeys randomly failing to work

### DIFF
--- a/app/javascript/flavours/glitch/features/ui/index.js
+++ b/app/javascript/flavours/glitch/features/ui/index.js
@@ -456,7 +456,7 @@ export default class UI extends React.Component {
     };
 
     return (
-      <HotKeys keyMap={keyMap} handlers={handlers} ref={this.setHotkeysRef}>
+      <HotKeys keyMap={keyMap} handlers={handlers} ref={this.setHotkeysRef} focused>
         <div className={className} ref={this.setRef} style={{ pointerEvents: dropdownMenuIsOpen ? 'none' : null }}>
           {navbarUnder ? null : (<TabsBar />)}
 


### PR DESCRIPTION
`HotKeys` only work if a descendant element is focused, or if it has the `focused` prop.
Our root `HotKeys` element should probably always trigger hotkeys.