### PR TITLE
Do not move CWs to toot body when toot body is empty

### DIFF
--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -21,7 +21,10 @@ class PostStatusService < BaseService
 
     media  = validate_media!(options[:media_ids])
     status = nil
-    text   = '.' if text.blank? && options[:spoiler_text].present?
+    if text.blank? && options[:spoiler_text].present?
+     text = '.'
+     text = media.find(&:video?) ? '📹' : '🖼' if media.size > 0
+    end
 
     ApplicationRecord.transaction do
       status = account.statuses.create!(text: text,

--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -21,7 +21,7 @@ class PostStatusService < BaseService
 
     media  = validate_media!(options[:media_ids])
     status = nil
-    text   = options.delete(:spoiler_text) if text.blank? && options[:spoiler_text].present?
+    text   = '.' if text.blank? && options[:spoiler_text].present?
 
     ApplicationRecord.transaction do
       status = account.statuses.create!(text: text,


### PR DESCRIPTION
Fixes #395

Instead of leaving the toot body blank, it replaces it with a single “.” in
order for the fold/unfold CW behavior to not look *too* weird on upstream
Mastodon. Note that this does not fix upstream's CW-dropping behavior, as
that is decided at the time the toot is posted, not received.