### PR TITLE
Do not rely on hover for upload form options if touch is used

### DIFF
--- a/app/javascript/flavours/glitch/features/composer/upload_form/item/index.js
+++ b/app/javascript/flavours/glitch/features/composer/upload_form/item/index.js
@@ -14,6 +14,7 @@ import IconButton from 'flavours/glitch/components/icon_button';
 //  Utils.
 import Motion from 'flavours/glitch/util/optional_motion';
 import { assignHandlers } from 'flavours/glitch/util/react_helpers';
+import { isUserTouching } from 'flavours/glitch/util/is_mobile';
 
 //  Messages.
 const messages = defineMessages({
@@ -130,7 +131,7 @@ export default class ComposerUploadFormItem extends React.PureComponent {
       hovered,
       dirtyDescription,
     } = this.state;
-    const active = hovered || focused;
+    const active = hovered || focused || isUserTouching();
     const computedClass = classNames('composer--upload_form--item', { active });
     const x = ((focusX /  2) + .5) * 100;
     const y = ((focusY / -2) + .5) * 100;


### PR DESCRIPTION
This always show the upload form option overlay (things like “Delete”, “Crop” and the input field for media description) whenever the user is known to use touch events.

Indeed, without this, the overlay will only be shown if the user manages to touch the (hidden) input field, and touching any of the hidden buttons will trigger them without prior warning.

Upstream has adopted a slightly different solution, making the whole overlay visible on click/touch, but it does not address the issue of accidentally touching the (invisible) buttons.