### PR TITLE
When searching for an emoji with multiple separators, consider the full input

### DIFF
--- a/app/javascript/flavours/glitch/util/emoji/emoji_mart_search_light.js
+++ b/app/javascript/flavours/glitch/util/emoji/emoji_mart_search_light.js
@@ -78,7 +78,7 @@ function search(value, { emojisToShowFilter, maxResults, include, exclude, custo
       allResults = [];
 
     if (values.length > 2) {
-      values = [values[0], values[1]];
+      values = [value, values[0], values[1]];
     }
 
     if (include.length || exclude.length) {


### PR DESCRIPTION
e.g., typing “blob_cat_p” used to search for “blob” and “cat”, but not
“blob_cat_p”, which means “blob_cat_patpat” is very unlikely to show up,
although it is likely what the user wanted to type in the first place.