### PR TITLE
Add configuration option to filter replies in lists

### DIFF
--- a/app/controllers/api/v1/lists_controller.rb
+++ b/app/controllers/api/v1/lists_controller.rb
@@ -38,6 +38,6 @@ class Api::V1::ListsController < Api::BaseController
   end
 
   def list_params
-    params.permit(:title)
+    params.permit(:title, :replies_policy)
   end
 end

--- a/app/javascript/flavours/glitch/actions/lists.js
+++ b/app/javascript/flavours/glitch/actions/lists.js
@@ -148,10 +148,10 @@ export const createListFail = error => ({
   error,
 });
 
-export const updateList = (id, title, shouldReset) => (dispatch, getState) => {
+export const updateList = (id, title, shouldReset, replies_policy) => (dispatch, getState) => {
   dispatch(updateListRequest(id));
 
-  api(getState).put(`/api/v1/lists/${id}`, { title }).then(({ data }) => {
+  api(getState).put(`/api/v1/lists/${id}`, { title, replies_policy }).then(({ data }) => {
     dispatch(updateListSuccess(data));
 
     if (shouldReset) {

--- a/app/javascript/flavours/glitch/features/list_timeline/index.js
+++ b/app/javascript/flavours/glitch/features/list_timeline/index.js
@@ -9,7 +9,7 @@ import { addColumn, removeColumn, moveColumn } from 'flavours/glitch/actions/col
 import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
 import { connectListStream } from 'flavours/glitch/actions/streaming';
 import { expandListTimeline } from 'flavours/glitch/actions/timelines';
-import { fetchList, deleteList } from 'flavours/glitch/actions/lists';
+import { fetchList, deleteList, updateList } from 'flavours/glitch/actions/lists';
 import { openModal } from 'flavours/glitch/actions/modal';
 import MissingIndicator from 'flavours/glitch/components/missing_indicator';
 import LoadingIndicator from 'flavours/glitch/components/loading_indicator';
@@ -17,6 +17,9 @@ import LoadingIndicator from 'flavours/glitch/components/loading_indicator';
 const messages = defineMessages({
   deleteMessage: { id: 'confirmations.delete_list.message', defaultMessage: 'Are you sure you want to permanently delete this list?' },
   deleteConfirm: { id: 'confirmations.delete_list.confirm', defaultMessage: 'Delete' },
+  all_replies:   { id: 'lists.replies_policy.all_replies', defaultMessage: 'to any followed user' },
+  no_replies:    { id: 'lists.replies_policy.no_replies', defaultMessage: 'none' },
+  list_replies:  { id: 'lists.replies_policy.list_replies', defaultMessage: 'only to list' },
 });
 
 const mapStateToProps = (state, props) => ({
@@ -111,11 +114,19 @@ export default class ListTimeline extends React.PureComponent {
     }));
   }
 
+  handleRepliesPolicyClick = () => {
+    const { dispatch, list } = this.props;
+    const { id } = this.props.params;
+    const replies_policy = {'all_replies': 'no_replies', 'no_replies': 'list_replies', 'list_replies': 'all_replies'}[list.get('replies_policy')];
+    this.props.dispatch(updateList(id, undefined, false, replies_policy));
+  }
+
   render () {
-    const { hasUnread, columnId, multiColumn, list } = this.props;
+    const { hasUnread, columnId, multiColumn, list, intl } = this.props;
     const { id } = this.props.params;
     const pinned = !!columnId;
     const title  = list ? list.get('title') : id;
+    const replies_policy = list ? list.get('replies_policy') : undefined;
 
     if (typeof list === 'undefined') {
       return (
@@ -155,6 +166,13 @@ export default class ListTimeline extends React.PureComponent {
             <button className='text-btn column-header__setting-btn' tabIndex='0' onClick={this.handleDeleteClick}>
               <i className='fa fa-trash' /> <FormattedMessage id='lists.delete' defaultMessage='Delete list' />
             </button>
+
+            { replies_policy !== undefined && (
+              <button className='text-btn column-header__setting-btn' tabIndex='0' onClick={this.handleRepliesPolicyClick}>
+                <i className='fa fa-reply' /> <FormattedMessage id='lists.replies_policy.title' defaultMessage='Show replies: {policy}' values={{ policy: intl.formatMessage(messages[replies_policy]) }} />
+              </button>
+             )
+            }
           </div>
 
           <hr />

--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -42,7 +42,8 @@ class FeedManager
   def push_to_list(list, status)
     if status.reply? && status.in_reply_to_account_id != status.account_id
       should_filter = status.in_reply_to_account_id != list.account_id
-      should_filter &&= !ListAccount.where(list_id: list.id, account_id: status.in_reply_to_account_id).exists?
+      should_filter &&= !list.show_all_replies?
+      should_filter &&= !(list.show_list_replies? && ListAccount.where(list_id: list.id, account_id: status.in_reply_to_account_id).exists?)
       return false if should_filter
     end
     return false unless add_to_feed(:list, list.id, status)

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -3,17 +3,20 @@
 #
 # Table name: lists
 #
-#  id         :bigint(8)        not null, primary key
-#  account_id :bigint(8)        not null
-#  title      :string           default(""), not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id             :bigint(8)        not null, primary key
+#  account_id     :bigint(8)        not null
+#  title          :string           default(""), not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  replies_policy :integer          default("list_replies"), not null
 #
 
 class List < ApplicationRecord
   include Paginable
 
   PER_ACCOUNT_LIMIT = 50
+
+  enum replies_policy: [:list_replies, :all_replies, :no_replies], _prefix: :show
 
   belongs_to :account, optional: true
 

--- a/app/serializers/rest/list_serializer.rb
+++ b/app/serializers/rest/list_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class REST::ListSerializer < ActiveModel::Serializer
-  attributes :id, :title
+  attributes :id, :title, :replies_policy
 
   def id
     object.id.to_s

--- a/db/migrate/20181127165847_add_show_replies_to_lists.rb
+++ b/db/migrate/20181127165847_add_show_replies_to_lists.rb
@@ -1,0 +1,23 @@
+require Rails.root.join('lib', 'mastodon', 'migration_helpers')
+
+class AddShowRepliesToLists < ActiveRecord::Migration[5.2]
+  include Mastodon::MigrationHelpers
+
+  disable_ddl_transaction!
+
+  def up
+    safety_assured do
+      add_column_with_default(
+        :lists,
+        :replies_policy,
+        :integer,
+        allow_null: false,
+        default: 0
+      )
+    end
+  end
+
+  def down
+    remove_column :lists, :replies_policy
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_27_130500) do
+ActiveRecord::Schema.define(version: 2018_11_27_165847) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -293,6 +293,7 @@ ActiveRecord::Schema.define(version: 2018_11_27_130500) do
     t.string "title", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "replies_policy", default: 0, null: false
     t.index ["account_id"], name: "index_lists_on_account_id"
   end
 

--- a/spec/lib/feed_manager_spec.rb
+++ b/spec/lib/feed_manager_spec.rb
@@ -291,13 +291,108 @@ RSpec.describe FeedManager do
   end
 
   describe '#push_to_list' do
+    let(:owner) { Fabricate(:account, username: 'owner') }
+    let(:alice) { Fabricate(:account, username: 'alice') }
+    let(:bob)   { Fabricate(:account, username: 'bob') }
+    let(:eve)   { Fabricate(:account, username: 'eve') }
+    let(:list)  { Fabricate(:list, account: owner) }
+
+    before do
+      owner.follow!(alice)
+      owner.follow!(bob)
+      owner.follow!(eve)
+
+      list.accounts << alice
+      list.accounts << bob
+    end
+
     it "does not push when the given status's reblog is already inserted" do
-      list = Fabricate(:list)
       reblog = Fabricate(:status)
       status = Fabricate(:status, reblog: reblog)
       FeedManager.instance.push_to_list(list, status)
 
       expect(FeedManager.instance.push_to_list(list, reblog)).to eq false
+    end
+
+    context 'when replies policy is set to no replies' do
+      before do
+        list.replies_policy = :no_replies
+      end
+
+      it 'pushes statuses that are not replies' do
+        status = Fabricate(:status, text: 'Hello world', account: bob)
+        expect(FeedManager.instance.push_to_list(list, status)).to eq true
+      end
+
+      it 'pushes statuses that are replies to list owner' do
+        status = Fabricate(:status, text: 'Hello world', account: owner)
+        reply  = Fabricate(:status, text: 'Nay', thread: status, account: bob)
+        expect(FeedManager.instance.push_to_list(list, reply)).to eq true
+      end
+
+      it 'does not push replies to another member of the list' do
+        status = Fabricate(:status, text: 'Hello world', account: alice)
+        reply  = Fabricate(:status, text: 'Nay', thread: status, account: bob)
+        expect(FeedManager.instance.push_to_list(list, reply)).to eq false
+      end
+    end
+
+    context 'when replies policy is set to list-only replies' do
+      before do
+        list.replies_policy = :list_replies
+      end
+
+      it 'pushes statuses that are not replies' do
+        status = Fabricate(:status, text: 'Hello world', account: bob)
+        expect(FeedManager.instance.push_to_list(list, status)).to eq true
+      end
+
+      it 'pushes statuses that are replies to list owner' do
+        status = Fabricate(:status, text: 'Hello world', account: owner)
+        reply  = Fabricate(:status, text: 'Nay', thread: status, account: bob)
+        expect(FeedManager.instance.push_to_list(list, reply)).to eq true
+      end
+
+      it 'pushes replies to another member of the list' do
+        status = Fabricate(:status, text: 'Hello world', account: alice)
+        reply  = Fabricate(:status, text: 'Nay', thread: status, account: bob)
+        expect(FeedManager.instance.push_to_list(list, reply)).to eq true
+      end
+
+      it 'does not push replies to someone not a member of the list' do
+        status = Fabricate(:status, text: 'Hello world', account: eve)
+        reply  = Fabricate(:status, text: 'Nay', thread: status, account: bob)
+        expect(FeedManager.instance.push_to_list(list, reply)).to eq false
+      end
+    end
+
+    context 'when replies policy is set to any reply' do
+      before do
+        list.replies_policy = :all_replies
+      end
+
+      it 'pushes statuses that are not replies' do
+        status = Fabricate(:status, text: 'Hello world', account: bob)
+        expect(FeedManager.instance.push_to_list(list, status)).to eq true
+      end
+
+      it 'pushes statuses that are replies to list owner' do
+        status = Fabricate(:status, text: 'Hello world', account: owner)
+        reply  = Fabricate(:status, text: 'Nay', thread: status, account: bob)
+        expect(FeedManager.instance.push_to_list(list, reply)).to eq true
+      end
+
+      it 'pushes replies to another member of the list' do
+        status = Fabricate(:status, text: 'Hello world', account: alice)
+        reply  = Fabricate(:status, text: 'Nay', thread: status, account: bob)
+        expect(FeedManager.instance.push_to_list(list, reply)).to eq true
+      end
+
+      it 'pushes replies to someone not a member of the list' do
+        status = Fabricate(:status, text: 'Hello world', account: eve)
+        reply  = Fabricate(:status, text: 'Nay', thread: status, account: bob)
+        expect(FeedManager.instance.push_to_list(list, reply)).to eq true
+      end
     end
   end
 


### PR DESCRIPTION
UI is very rudimentary, and it would be good to have the feature upstream.
Needs some more testing.

There are two possible settings:
- Don't show replies (same behavior as Mastodon 2.6)
- Show all replies to followed users (same behavior as Mastodon < 2.6)
- Show only replies to users in the list (default)

Changing is made by clicking on the link, which cycles between the settings (yeah, that's bad UI)

![screenshot_2018-11-04 dev instance 1](https://user-images.githubusercontent.com/384364/47964748-72000c00-e03e-11e8-9873-cd1176aa2bd6.png)

![screenshot_2018-11-04 dev instance](https://user-images.githubusercontent.com/384364/47964752-79bfb080-e03e-11e8-8a34-0a212fcf14b5.png)
