### PR TITLE
Reduce server load caused by anonymous viewing.

### DIFF
--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -6,15 +6,21 @@ class AboutController < ApplicationController
   before_action :set_instance_presenter, only: [:show, :more, :terms]
 
   def show
+    skip_session! unless user_signed_in?
+
     serializable_resource = ActiveModelSerializers::SerializableResource.new(InitialStatePresenter.new(initial_state_params), serializer: InitialStateSerializer)
     @initial_state_json   = serializable_resource.to_json
   end
 
   def more
+    skip_session! unless user_signed_in?
+
     render layout: 'public'
   end
 
   def terms
+    skip_session! unless user_signed_in?
+
     render layout: 'public'
   end
 

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -11,6 +11,8 @@ class AccountsController < ApplicationController
     respond_to do |format|
       format.html do
         use_pack 'public'
+        skip_session! unless user_signed_in?
+
         @body_classes      = 'with-modals'
         @pinned_statuses   = []
         @endorsed_accounts = @account.endorsed_accounts.to_a.sample(4)
@@ -31,11 +33,15 @@ class AccountsController < ApplicationController
       end
 
       format.atom do
+        skip_session!
+
         @entries = @account.stream_entries.where(hidden: false).with_includes.paginate_by_max_id(PAGE_SIZE, params[:max_id], params[:since_id])
         render xml: OStatus::AtomSerializer.render(OStatus::AtomSerializer.new.feed(@account, @entries.reject { |entry| entry.status.nil? || entry.status.local_only? }))
       end
 
       format.rss do
+        skip_session!
+
         @statuses = cache_collection(default_statuses.without_reblogs.without_replies.limit(PAGE_SIZE), Status)
         render xml: RSS::AccountSerializer.render(@account, @statuses)
       end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -229,5 +229,6 @@ class ApplicationController < ActionController::Base
 
   def skip_session!
     request.session_options[:skip] = true
+    expires_in 0, public: true
   end
 end

--- a/app/controllers/follower_accounts_controller.rb
+++ b/app/controllers/follower_accounts_controller.rb
@@ -7,6 +7,7 @@ class FollowerAccountsController < ApplicationController
     respond_to do |format|
       format.html do
         use_pack 'public'
+        skip_session! unless user_signed_in?
 
         next if @account.user_hides_network?
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -61,6 +61,8 @@ class HomeController < ApplicationController
   end
 
   def default_redirect_path
+    skip_session!
+
     if request.path.start_with?('/web')
       new_user_session_path
     elsif single_user_mode?

--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -27,6 +27,8 @@ class StatusesController < ApplicationController
     respond_to do |format|
       format.html do
         use_pack 'public'
+        skip_session! unless user_signed_in?
+
         @body_classes = 'with-modals'
 
         set_ancestors


### PR DESCRIPTION
Do not start a session if the current user is not logged in for public-facing pages.

Mark pages that don't care about sessions as publicly cacheable.

Keep the max age as 0 so proxies and browsers will still try to retrieve an updated version but can still fall back to the stale version if the site is down or too slow.

Ported from tootsuite/mastodon#9059