### PR TITLE
Add a checkbox to opt out some confirmation dialogs

### DIFF
--- a/app/javascript/flavours/glitch/containers/status_container.js
+++ b/app/javascript/flavours/glitch/containers/status_container.js
@@ -22,6 +22,7 @@ import { muteStatus, unmuteStatus, deleteStatus } from 'flavours/glitch/actions/
 import { initMuteModal } from 'flavours/glitch/actions/mutes';
 import { initReport } from 'flavours/glitch/actions/reports';
 import { openModal } from 'flavours/glitch/actions/modal';
+import { changeLocalSetting } from 'flavours/glitch/actions/local_settings';
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
 import { boostModal, favouriteModal, deleteModal } from 'flavours/glitch/util/initial_state';
 
@@ -71,10 +72,11 @@ const mapDispatchToProps = (dispatch, { intl }) => ({
   onReply (status, router) {
     dispatch((_, getState) => {
       let state = getState();
-      if (state.getIn(['compose', 'text']).trim().length !== 0) {
+      if (state.getIn(['local_settings', 'confirm_before_clearing_draft']) && state.getIn(['compose', 'text']).trim().length !== 0) {
         dispatch(openModal('CONFIRM', {
           message: intl.formatMessage(messages.replyMessage),
           confirm: intl.formatMessage(messages.replyConfirm),
+          onDoNotAsk: () => dispatch(changeLocalSetting(['confirm_before_clearing_draft'], false)),
           onConfirm: () => dispatch(replyCompose(status, router)),
         }));
       } else {

--- a/app/javascript/flavours/glitch/features/composer/index.js
+++ b/app/javascript/flavours/glitch/features/composer/index.js
@@ -30,6 +30,7 @@ import {
   closeModal,
   openModal,
 } from 'flavours/glitch/actions/modal';
+import { changeLocalSetting } from 'flavours/glitch/actions/local_settings';
 
 //  Components.
 import ComposerOptions from './options';
@@ -165,6 +166,8 @@ const mapDispatchToProps = (dispatch, { intl }) => ({
       message: intl.formatMessage(messages.missingDescriptionMessage),
       confirm: intl.formatMessage(messages.missingDescriptionConfirm),
       onConfirm: () => dispatch(submitCompose(routerHistory)),
+      onDoNotAsk: () => dispatch(changeLocalSetting(['confirm_missing_media_description'], false)),
+      onConfirm: () => dispatch(submitCompose()),
     }));
   },
   onSubmit(routerHistory) {

--- a/app/javascript/flavours/glitch/features/local_settings/page/index.js
+++ b/app/javascript/flavours/glitch/features/local_settings/page/index.js
@@ -128,6 +128,14 @@ export default class LocalSettingsPage extends React.PureComponent {
         </LocalSettingsPageItem>
         <LocalSettingsPageItem
           settings={settings}
+          item={['confirm_before_clearing_draft']}
+          id='mastodon-settings--confirm_before_clearing_draft'
+          onChange={onChange}
+        >
+          <FormattedMessage id='settings.confirm_before_clearing_draft' defaultMessage='Show confirmation dialog before clearing draft' />
+        </LocalSettingsPageItem>
+        <LocalSettingsPageItem
+          settings={settings}
           item={['side_arm']}
           id='mastodon-settings--side_arm'
           options={[

--- a/app/javascript/flavours/glitch/features/local_settings/page/index.js
+++ b/app/javascript/flavours/glitch/features/local_settings/page/index.js
@@ -132,7 +132,7 @@ export default class LocalSettingsPage extends React.PureComponent {
           id='mastodon-settings--confirm_before_clearing_draft'
           onChange={onChange}
         >
-          <FormattedMessage id='settings.confirm_before_clearing_draft' defaultMessage='Show confirmation dialog before clearing draft' />
+          <FormattedMessage id='settings.confirm_before_clearing_draft' defaultMessage='Show confirmation dialog before overwriting the message being composed' />
         </LocalSettingsPageItem>
         <LocalSettingsPageItem
           settings={settings}

--- a/app/javascript/flavours/glitch/features/status/index.js
+++ b/app/javascript/flavours/glitch/features/status/index.js
@@ -24,6 +24,7 @@ import {
   mentionCompose,
   directCompose,
 } from 'flavours/glitch/actions/compose';
+import { changeLocalSetting } from 'flavours/glitch/actions/local_settings';
 import { blockAccount } from 'flavours/glitch/actions/accounts';
 import { muteStatus, unmuteStatus, deleteStatus } from 'flavours/glitch/actions/statuses';
 import { initMuteModal } from 'flavours/glitch/actions/mutes';
@@ -98,7 +99,7 @@ const makeMapStateToProps = () => {
       ancestorsIds,
       descendantsIds,
       settings: state.get('local_settings'),
-      askReplyConfirmation: state.getIn(['compose', 'text']).trim().length !== 0,
+      askReplyConfirmation: state.getIn(['local_settings', 'confirm_before_clearing_draft']) && state.getIn(['compose', 'text']).trim().length !== 0,
     };
   };
 
@@ -196,6 +197,7 @@ export default class Status extends ImmutablePureComponent {
       dispatch(openModal('CONFIRM', {
         message: intl.formatMessage(messages.replyMessage),
         confirm: intl.formatMessage(messages.replyConfirm),
+        onDoNotAsk: () => dispatch(changeLocalSetting(['confirm_before_clearing_draft'], false)),
         onConfirm: () => dispatch(replyCompose(status, this.context.router.history)),
       }));
     } else {

--- a/app/javascript/flavours/glitch/features/ui/components/confirmation_modal.js
+++ b/app/javascript/flavours/glitch/features/ui/components/confirmation_modal.js
@@ -11,6 +11,7 @@ export default class ConfirmationModal extends React.PureComponent {
     confirm: PropTypes.string.isRequired,
     onClose: PropTypes.func.isRequired,
     onConfirm: PropTypes.func.isRequired,
+    onDoNotAsk: PropTypes.func,
     intl: PropTypes.object.isRequired,
   };
 
@@ -21,6 +22,9 @@ export default class ConfirmationModal extends React.PureComponent {
   handleClick = () => {
     this.props.onClose();
     this.props.onConfirm();
+    if (this.props.onDoNotAsk && this.doNotAskCheckbox.checked) {
+      this.props.onDoNotAsk();
+    }
   }
 
   handleCancel = () => {
@@ -31,8 +35,12 @@ export default class ConfirmationModal extends React.PureComponent {
     this.button = c;
   }
 
+  setDoNotAskRef = (c) => {
+    this.doNotAskCheckbox = c;
+  }
+
   render () {
-    const { message, confirm } = this.props;
+    const { message, confirm, onDoNotAsk } = this.props;
 
     return (
       <div className='modal-root__modal confirmation-modal'>
@@ -40,11 +48,21 @@ export default class ConfirmationModal extends React.PureComponent {
           {message}
         </div>
 
-        <div className='confirmation-modal__action-bar'>
-          <Button onClick={this.handleCancel} className='confirmation-modal__cancel-button'>
-            <FormattedMessage id='confirmation_modal.cancel' defaultMessage='Cancel' />
-          </Button>
-          <Button text={confirm} onClick={this.handleClick} ref={this.setRef} />
+        <div>
+          { onDoNotAsk && (
+            <div className='confirmation-modal__do_not_ask_again'>
+              <input type='checkbox' id='confirmation-modal__do_not_ask_again-checkbox' ref={this.setDoNotAskRef} />
+              <label for='confirmation-modal__do_not_ask_again-checkbox'>
+                <FormattedMessage id='confirmation_modal.do_not_ask_again' defaultMessage='Do not ask for confirmation again' />
+              </label>
+            </div>
+          )}
+          <div className='confirmation-modal__action-bar'>
+            <Button onClick={this.handleCancel} className='confirmation-modal__cancel-button'>
+              <FormattedMessage id='confirmation_modal.cancel' defaultMessage='Cancel' />
+            </Button>
+            <Button text={confirm} onClick={this.handleClick} ref={this.setRef} />
+          </div>
         </div>
       </div>
     );

--- a/app/javascript/flavours/glitch/reducers/local_settings.js
+++ b/app/javascript/flavours/glitch/reducers/local_settings.js
@@ -14,6 +14,7 @@ const initialState = ImmutableMap({
   show_reply_count : false,
   always_show_spoilers_field: false,
   confirm_missing_media_description: false,
+  confirm_before_clearing_draft: true,
   preselect_on_reply: true,
   inline_preview_cards: true,
   content_warnings : ImmutableMap({

--- a/app/javascript/flavours/glitch/styles/components/modal.scss
+++ b/app/javascript/flavours/glitch/styles/components/modal.scss
@@ -686,6 +686,18 @@
   }
 }
 
+.confirmation-modal__do_not_ask_again {
+  padding-left: 20px;
+  padding-right: 20px;
+  padding-bottom: 10px;
+
+  font-size: 14px;
+
+  label, input {
+    vertical-align: middle;
+  }
+}
+
 .confirmation-modal__container,
 .mute-modal__container,
 .report-modal__target {


### PR DESCRIPTION
- Add a checkbox to opt out the confirmation dialog for media without descriptions
- Add a setting to opt out the confirmation dialog for replies overwriting the current draft

Wording is, uh, suboptimal.

![screenshot_2018-11-27 dev instance 1](https://user-images.githubusercontent.com/384364/49100041-40601680-f273-11e8-8a4b-5fe60746d264.png)

![screenshot_2018-11-27 dev instance 2](https://user-images.githubusercontent.com/384364/49100058-48b85180-f273-11e8-9d90-35058f247507.png)
