### PR TITLE
Display a double reply arrow on public pages for toots that are replies

### DIFF
--- a/app/views/stream_entries/_detailed_status.html.haml
+++ b/app/views/stream_entries/_detailed_status.html.haml
@@ -44,7 +44,10 @@
         = link_to status.application.name, status.application.website, class: 'detailed-status__application', target: '_blank', rel: 'noopener'
       ·
     = link_to remote_interaction_path(status), class: 'modal-button detailed-status__link' do
-      = fa_icon('reply')
+      - if status.in_reply_to_id.nil?
+        = fa_icon('reply')
+      - else
+        = fa_icon('reply-all')
       %span.detailed-status__reblogs>= number_to_human status.replies_count, strip_insignificant_zeros: true
       = " "
     ·

--- a/app/views/stream_entries/_simple_status.html.haml
+++ b/app/views/stream_entries/_simple_status.html.haml
@@ -37,7 +37,10 @@
   .status__action-bar
     .status__action-bar__counter
       = link_to remote_interaction_path(status), class: 'status__action-bar-button icon-button modal-button', style: 'font-size: 18px; width: 23.1429px; height: 23.1429px; line-height: 23.15px;' do
-        = fa_icon 'reply fw'
+        - if status.in_reply_to_id.nil?
+          = fa_icon 'reply fw'
+        - else
+          = fa_icon 'reply-all fw'
       .status__action-bar__counter__label= obscured_counter status.replies_count
     = link_to remote_interaction_path(status), class: 'status__action-bar-button icon-button modal-button', style: 'font-size: 18px; width: 23.1429px; height: 23.1429px; line-height: 23.15px;' do
       - if status.public_visibility? || status.unlisted_visibility?


### PR DESCRIPTION
Although upstream has ditched them, reply arrows being different depending on whether a toot is a reply or not is something I find useful.

This PR proposes to display such reply arrows the same way in public pages than in the glitch-soc Web UI. This is most useful when listing an user's toots including replies.

![screenshot_2018-11-30 thib thib mastodev sitedethib com](https://user-images.githubusercontent.com/384364/49315279-67c21800-f4ed-11e8-90c6-f0df70f1210a.png)
