### PR TITLE
[Glitch] Adds follow action timestamp to notification

### DIFF
--- a/app/javascript/flavours/glitch/features/notifications/components/follow.js
+++ b/app/javascript/flavours/glitch/features/notifications/components/follow.js
@@ -81,11 +81,13 @@ export default class NotificationFollow extends ImmutablePureComponent {
               <i className='fa fa-fw fa-user-plus' />
             </div>
 
-            <FormattedMessage
-              id='notification.follow'
-              defaultMessage='{name} followed you'
-              values={{ name: link }}
-            />
+            <span title={notification.get('created_at')}>
+              <FormattedMessage
+                id='notification.follow'
+                defaultMessage='{name} followed you'
+                values={{ name: link }}
+              />
+            </span>
           </div>
 
           <AccountContainer hidden={hidden} id={account.get('id')} withNote={false} />


### PR DESCRIPTION
Port 330e320b40e975472e042730f9dfb23083f170e3 to glitch-soc

I'm actually not 100% sure about this one: it's pretty hidden, it is useful? Also, does it make accessibility any worse? I should probably look into that before merging it.