### PR TITLE
Remove form_action from CSP

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -28,7 +28,6 @@ if Rails.env.production?
     p.worker_src      :self, assets_host
     p.connect_src     :self, :blob, Rails.configuration.x.streaming_api_base_url, *data_hosts
     p.manifest_src    :self, assets_host
-    p.form_action     :self
   end
 end
 


### PR DESCRIPTION
This fixes a CSP violation when trying to authenticate through to
third-party sites, e.g. bridge.joinmastodon.org:

    Refused to send form data to 'https://bridge.joinmastodon.org/'
    because it violates the following Content Security Policy
    directive: "form-action 'self'".

Thread: https://vulpine.club/@digifox/101230933751352042

Bug introduced in: 1283e112b9d6ab1424973a03ee26b27f39119b57