### PR TITLE
Add instance option to disable followers count

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -29,6 +29,7 @@ module Admin
       preview_sensitive_media
       custom_css
       profile_directory
+      hide_followers_count
     ).freeze
 
     BOOLEAN_SETTINGS = %w(
@@ -41,6 +42,7 @@ module Admin
       show_known_fediverse_at_about_page
       preview_sensitive_media
       profile_directory
+      hide_followers_count
     ).freeze
 
     UPLOAD_SETTINGS = %w(

--- a/app/controllers/follower_accounts_controller.rb
+++ b/app/controllers/follower_accounts_controller.rb
@@ -36,22 +36,22 @@ class FollowerAccountsController < ApplicationController
   end
 
   def collection_presenter
+    options = { type: :ordered }
+    options[:size] = @account.followers_count
     if params[:page].present?
       ActivityPub::CollectionPresenter.new(
         id: account_followers_url(@account, page: params.fetch(:page, 1)),
-        type: :ordered,
-        size: @account.followers_count,
         items: follows.map { |f| ActivityPub::TagManager.instance.uri_for(f.account) },
         part_of: account_followers_url(@account),
         next: page_url(follows.next_page),
-        prev: page_url(follows.prev_page)
+        prev: page_url(follows.prev_page),
+        **options
       )
     else
       ActivityPub::CollectionPresenter.new(
         id: account_followers_url(@account),
-        type: :ordered,
-        size: @account.followers_count,
-        first: page_url(1)
+        first: page_url(1),
+        **options
       )
     end
   end

--- a/app/controllers/follower_accounts_controller.rb
+++ b/app/controllers/follower_accounts_controller.rb
@@ -37,7 +37,7 @@ class FollowerAccountsController < ApplicationController
 
   def collection_presenter
     options = { type: :ordered }
-    options[:size] = @account.followers_count
+    options[:size] = @account.followers_count unless Setting.hide_followers_count
     if params[:page].present?
       ActivityPub::CollectionPresenter.new(
         id: account_followers_url(@account, page: params.fetch(:page, 1)),

--- a/app/controllers/follower_accounts_controller.rb
+++ b/app/controllers/follower_accounts_controller.rb
@@ -37,7 +37,7 @@ class FollowerAccountsController < ApplicationController
 
   def collection_presenter
     options = { type: :ordered }
-    options[:size] = @account.followers_count unless Setting.hide_followers_count
+    options[:size] = @account.followers_count unless Setting.hide_followers_count || @account.user&.setting_hide_followers_count
     if params[:page].present?
       ActivityPub::CollectionPresenter.new(
         id: account_followers_url(@account, page: params.fetch(:page, 1)),

--- a/app/controllers/settings/preferences_controller.rb
+++ b/app/controllers/settings/preferences_controller.rb
@@ -43,6 +43,7 @@ class Settings::PreferencesController < Settings::BaseController
       :setting_system_font_ui,
       :setting_noindex,
       :setting_hide_network,
+      :setting_hide_followers_count,
       :setting_aggregate_reblogs,
       notification_emails: %i(follow follow_request reblog favourite mention digest report),
       interactions: %i(must_be_follower must_be_following)

--- a/app/helpers/stream_entries_helper.rb
+++ b/app/helpers/stream_entries_helper.rb
@@ -61,7 +61,7 @@ module StreamEntriesHelper
   end
 
   def account_description(account)
-    prepend_str = [
+    prepend_stats = [
       [
         number_to_human(account.statuses_count, strip_insignificant_zeros: true),
         I18n.t('accounts.posts', count: account.statuses_count),
@@ -71,14 +71,16 @@ module StreamEntriesHelper
         number_to_human(account.following_count, strip_insignificant_zeros: true),
         I18n.t('accounts.following', count: account.following_count),
       ].join(' '),
+    ]
 
-      [
+    unless Setting.hide_followers_count
+      prepend_stats << [
         number_to_human(account.followers_count, strip_insignificant_zeros: true),
         I18n.t('accounts.followers', count: account.followers_count),
-      ].join(' '),
-    ].join(', ')
+      ].join(' ')
+    end
 
-    [prepend_str, account.note].join(' · ')
+    [prepend_stats.join(', '), account.note].join(' · ')
   end
 
   def media_summary(status)

--- a/app/helpers/stream_entries_helper.rb
+++ b/app/helpers/stream_entries_helper.rb
@@ -73,7 +73,7 @@ module StreamEntriesHelper
       ].join(' '),
     ]
 
-    unless Setting.hide_followers_count
+    unless Setting.hide_followers_count || account.user&.setting_hide_followers_count
       prepend_stats << [
         number_to_human(account.followers_count, strip_insignificant_zeros: true),
         I18n.t('accounts.followers', count: account.followers_count),

--- a/app/helpers/stream_entries_helper.rb
+++ b/app/helpers/stream_entries_helper.rb
@@ -60,6 +60,10 @@ module StreamEntriesHelper
     end
   end
 
+  def hide_followers_count(account)
+    Setting.hide_followers_count || account.user&.setting_hide_followers_count
+  end
+
   def account_description(account)
     prepend_stats = [
       [
@@ -73,7 +77,7 @@ module StreamEntriesHelper
       ].join(' '),
     ]
 
-    unless Setting.hide_followers_count || account.user&.setting_hide_followers_count
+    unless hide_followers_count(account)
       prepend_stats << [
         number_to_human(account.followers_count, strip_insignificant_zeros: true),
         I18n.t('accounts.followers', count: account.followers_count),

--- a/app/javascript/flavours/glitch/features/account/components/action_bar.js
+++ b/app/javascript/flavours/glitch/features/account/components/action_bar.js
@@ -164,7 +164,7 @@ export default class ActionBar extends React.PureComponent {
 
             <NavLink exact activeClassName='active' className='account__action-bar__tab' to={`/accounts/${account.get('id')}/followers`}>
               <FormattedMessage id='account.followers' defaultMessage='Followers' />
-              <strong><FormattedNumber value={account.get('followers_count')} /></strong>
+              <strong>{ account.get('followers_count') < 0 ? '-' : <FormattedNumber value={account.get('followers_count')} /> }</strong>
             </NavLink>
           </div>
         </div>

--- a/app/javascript/flavours/glitch/reducers/accounts_counters.js
+++ b/app/javascript/flavours/glitch/reducers/accounts_counters.js
@@ -141,9 +141,9 @@ export default function accountsCounters(state = initialState, action) {
     if (action.alreadyFollowing) {
       return state;
     }
-    return state.updateIn([action.relationship.id, 'followers_count'], num => num + 1);
+    return state.updateIn([action.relationship.id, 'followers_count'], num => num < 0 ? num : num + 1);
   case ACCOUNT_UNFOLLOW_SUCCESS:
-    return state.updateIn([action.relationship.id, 'followers_count'], num => Math.max(0, num - 1));
+    return state.updateIn([action.relationship.id, 'followers_count'], num => num < 0 ? num : Math.max(0, num - 1));
   default:
     return state;
   }

--- a/app/lib/user_settings_decorator.rb
+++ b/app/lib/user_settings_decorator.rb
@@ -30,6 +30,7 @@ class UserSettingsDecorator
     user.settings['reduce_motion']       = reduce_motion_preference if change?('setting_reduce_motion')
     user.settings['system_font_ui']      = system_font_ui_preference if change?('setting_system_font_ui')
     user.settings['noindex']             = noindex_preference if change?('setting_noindex')
+    user.settings['hide_followers_count']= hide_followers_count_preference if change?('setting_hide_followers_count')
     user.settings['flavour']             = flavour_preference if change?('setting_flavour')
     user.settings['skin']                = skin_preference if change?('setting_skin')
     user.settings['hide_network']        = hide_network_preference if change?('setting_hide_network')
@@ -90,6 +91,10 @@ class UserSettingsDecorator
 
   def noindex_preference
     boolean_cast_setting 'setting_noindex'
+  end
+
+  def hide_followers_count_preference
+    boolean_cast_setting 'setting_hide_followers_count'
   end
 
   def flavour_preference

--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -30,6 +30,8 @@ class Form::AdminSettings
     :show_staff_badge=,
     :bootstrap_timeline_accounts,
     :bootstrap_timeline_accounts=,
+    :hide_followers_count,
+    :hide_followers_count=,
     :flavour,
     :flavour=,
     :skin,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -94,7 +94,7 @@ class User < ApplicationRecord
   has_many :session_activations, dependent: :destroy
 
   delegate :auto_play_gif, :default_sensitive, :unfollow_modal, :boost_modal, :favourite_modal, :delete_modal,
-           :reduce_motion, :system_font_ui, :noindex, :flavour, :skin, :display_media, :hide_network,
+           :reduce_motion, :system_font_ui, :noindex, :flavour, :skin, :display_media, :hide_network, :hide_followers_count,
            :expand_spoilers, :default_language, :aggregate_reblogs, to: :settings, prefix: :setting, allow_nil: false
 
   attr_reader :invite_code

--- a/app/serializers/rest/account_serializer.rb
+++ b/app/serializers/rest/account_serializer.rb
@@ -51,4 +51,8 @@ class REST::AccountSerializer < ActiveModel::Serializer
   def moved_and_not_nested?
     object.moved? && object.moved_to_account.moved_to_account_id.nil?
   end
+
+  def followers_count
+    Setting.hide_followers_count ? -1 : object.followers_count
+  end
 end

--- a/app/serializers/rest/account_serializer.rb
+++ b/app/serializers/rest/account_serializer.rb
@@ -53,6 +53,6 @@ class REST::AccountSerializer < ActiveModel::Serializer
   end
 
   def followers_count
-    Setting.hide_followers_count ? -1 : object.followers_count
+    (Setting.hide_followers_count || object.user&.setting_hide_followers_count) ? -1 : object.followers_count
   end
 end

--- a/app/views/accounts/_header.html.haml
+++ b/app/views/accounts/_header.html.haml
@@ -24,8 +24,8 @@
               %span.counter-label= t('accounts.following', count: account.following_count)
 
           .counter{ class: active_nav_class(account_followers_url(account)) }
-            = link_to account_followers_url(account), title: Setting.hide_followers_count ? nil : number_with_delimiter(account.followers_count) do
-              %span.counter-number= Setting.hide_followers_count ? '-' : (number_to_human account.followers_count, strip_insignificant_zeros: true)
+            = link_to account_followers_url(account), title: (Setting.hide_followers_count || account.user&.setting_hide_followers_count) ? nil : number_with_delimiter(account.followers_count) do
+              %span.counter-number= (Setting.hide_followers_count || account.user&.setting_hide_followers_count) ? '-' : (number_to_human account.followers_count, strip_insignificant_zeros: true)
               %span.counter-label= t('accounts.followers', count: account.followers_count)
         .spacer
         .public-account-header__tabs__tabs__buttons

--- a/app/views/accounts/_header.html.haml
+++ b/app/views/accounts/_header.html.haml
@@ -24,8 +24,8 @@
               %span.counter-label= t('accounts.following', count: account.following_count)
 
           .counter{ class: active_nav_class(account_followers_url(account)) }
-            = link_to account_followers_url(account), title: number_with_delimiter(account.followers_count) do
-              %span.counter-number= number_to_human account.followers_count, strip_insignificant_zeros: true
+            = link_to account_followers_url(account), title: Setting.hide_followers_count ? nil : number_with_delimiter(account.followers_count) do
+              %span.counter-number= Setting.hide_followers_count ? '-' : (number_to_human account.followers_count, strip_insignificant_zeros: true)
               %span.counter-label= t('accounts.followers', count: account.followers_count)
         .spacer
         .public-account-header__tabs__tabs__buttons

--- a/app/views/accounts/_header.html.haml
+++ b/app/views/accounts/_header.html.haml
@@ -24,8 +24,8 @@
               %span.counter-label= t('accounts.following', count: account.following_count)
 
           .counter{ class: active_nav_class(account_followers_url(account)) }
-            = link_to account_followers_url(account), title: (Setting.hide_followers_count || account.user&.setting_hide_followers_count) ? nil : number_with_delimiter(account.followers_count) do
-              %span.counter-number= (Setting.hide_followers_count || account.user&.setting_hide_followers_count) ? '-' : (number_to_human account.followers_count, strip_insignificant_zeros: true)
+            = link_to account_followers_url(account), title: hide_followers_count(account) ? nil : number_with_delimiter(account.followers_count) do
+              %span.counter-number= hide_followers_count(account) ? '-' : (number_to_human account.followers_count, strip_insignificant_zeros: true)
               %span.counter-label= t('accounts.followers', count: account.followers_count)
         .spacer
         .public-account-header__tabs__tabs__buttons

--- a/app/views/admin/settings/edit.html.haml
+++ b/app/views/admin/settings/edit.html.haml
@@ -65,6 +65,9 @@
   .fields-group
     = f.input :profile_directory, as: :boolean, wrapper: :with_label, label: t('admin.settings.profile_directory.title'), hint: t('admin.settings.profile_directory.desc_html')
 
+  .fields-group
+    = f.input :hide_followers_count, as: :boolean, wrapper: :with_label, label: t('admin.settings.hide_followers_count.title'), hint: t('admin.settings.hide_followers_count.desc_html')
+
   %hr.spacer/
 
   .fields-group

--- a/app/views/directories/index.html.haml
+++ b/app/views/directories/index.html.haml
@@ -28,10 +28,9 @@
                 %td.accounts-table__count.optional
                   = number_to_human account.statuses_count, strip_insignificant_zeros: true
                   %small= t('accounts.posts', count: account.statuses_count).downcase
-                - unless Setting.hide_followers_count
-                  %td.accounts-table__count.optional
-                    = number_to_human account.followers_count, strip_insignificant_zeros: true
-                    %small= t('accounts.followers', count: account.followers_count).downcase
+                %td.accounts-table__count.optional
+                  = Setting.hide_followers_count ? '-' : (number_to_human account.followers_count, strip_insignificant_zeros: true)
+                  %small= t('accounts.followers', count: account.followers_count).downcase
                 %td.accounts-table__count
                   - if account.last_status_at.present?
                     %time.time-ago{ datetime: account.last_status_at.iso8601, title: l(account.last_status_at) }= l account.last_status_at

--- a/app/views/directories/index.html.haml
+++ b/app/views/directories/index.html.haml
@@ -29,7 +29,7 @@
                   = number_to_human account.statuses_count, strip_insignificant_zeros: true
                   %small= t('accounts.posts', count: account.statuses_count).downcase
                 %td.accounts-table__count.optional
-                  = Setting.hide_followers_count ? '-' : (number_to_human account.followers_count, strip_insignificant_zeros: true)
+                  = (Setting.hide_followers_count || account.user&.setting_hide_followers_count) ? '-' : (number_to_human account.followers_count, strip_insignificant_zeros: true)
                   %small= t('accounts.followers', count: account.followers_count).downcase
                 %td.accounts-table__count
                   - if account.last_status_at.present?

--- a/app/views/directories/index.html.haml
+++ b/app/views/directories/index.html.haml
@@ -28,9 +28,10 @@
                 %td.accounts-table__count.optional
                   = number_to_human account.statuses_count, strip_insignificant_zeros: true
                   %small= t('accounts.posts', count: account.statuses_count).downcase
-                %td.accounts-table__count.optional
-                  = number_to_human account.followers_count, strip_insignificant_zeros: true
-                  %small= t('accounts.followers', count: account.followers_count).downcase
+                - unless Setting.hide_followers_count
+                  %td.accounts-table__count.optional
+                    = number_to_human account.followers_count, strip_insignificant_zeros: true
+                    %small= t('accounts.followers', count: account.followers_count).downcase
                 %td.accounts-table__count
                   - if account.last_status_at.present?
                     %time.time-ago{ datetime: account.last_status_at.iso8601, title: l(account.last_status_at) }= l account.last_status_at

--- a/app/views/directories/index.html.haml
+++ b/app/views/directories/index.html.haml
@@ -29,7 +29,7 @@
                   = number_to_human account.statuses_count, strip_insignificant_zeros: true
                   %small= t('accounts.posts', count: account.statuses_count).downcase
                 %td.accounts-table__count.optional
-                  = (Setting.hide_followers_count || account.user&.setting_hide_followers_count) ? '-' : (number_to_human account.followers_count, strip_insignificant_zeros: true)
+                  = hide_followers_count(account) ? '-' : (number_to_human account.followers_count, strip_insignificant_zeros: true)
                   %small= t('accounts.followers', count: account.followers_count).downcase
                 %td.accounts-table__count
                   - if account.last_status_at.present?

--- a/app/views/settings/preferences/show.html.haml
+++ b/app/views/settings/preferences/show.html.haml
@@ -34,6 +34,10 @@
   .fields-group
     = f.input :setting_hide_network, as: :boolean, wrapper: :with_label
 
+  - unless Setting.hide_followers_count
+    .fields-group
+      = f.input :setting_hide_followers_count, as: :boolean, wrapper: :with_label
+
   %hr#settings_web/
 
   .fields-group

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -368,6 +368,9 @@ en:
       hero:
         desc_html: Displayed on the frontpage. At least 600x100px recommended. When not set, falls back to instance thumbnail
         title: Hero image
+      hide_followers_count:
+        desc_html: Do not show followers count on user profiles
+        title: Hide followers count
       mascot:
         desc_html: Displayed on multiple pages. At least 293×205px recommended. When not set, falls back to default mascot
         title: Mascot image

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -79,6 +79,7 @@ en:
         setting_display_media_show_all: Show all
         setting_expand_spoilers: Always expand toots marked with content warnings
         setting_favourite_modal: Show confirmation dialog before favouriting (applies to Glitch flavour only)
+        setting_hide_followers_count: Hide your followers count
         setting_hide_network: Hide your network
         setting_noindex: Opt-out of search engine indexing
         setting_reduce_motion: Reduce motion in animations

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -34,6 +34,7 @@ defaults: &defaults
   reduce_motion: false
   system_font_ui: false
   noindex: false
+  hide_followers_count: false
   flavour: 'glitch'
   skin: 'default'
   aggregate_reblogs: true


### PR DESCRIPTION
- [x] Remove followers count from ActivityPub collections
- [x] Remove followers count from OStatus serializations
- [x] Remove followers count from public pages
- [x] Remove followers count from the profile directory
- [x] Remove followers count from the REST API (returns -1 instead of the actual value, treated specially in the glitch front-end)

![screenshot_2018-12-17 thib thib mastodev sitedethib com 1](https://user-images.githubusercontent.com/384364/50113202-8dffeb80-0241-11e9-985c-9097bd70ae3d.png)

EDIT: This PR now implements an instance-wide setting and a per-user setting:
- The instance-wide setting prevents followers count from *every* account to be displayed or broadcasted (this can be still computed when users don't hide their network) to anyone
- If the instance-wide setting isn't set, individual users may still decide to hide *their* followers count using a per-user setting displayed besides the “hide network” one. This doesn't hide non-hidden followers count to them.