### PR TITLE
Sandbox toot embeds in the embed modal

### DIFF
--- a/app/javascript/flavours/glitch/features/ui/components/embed_modal.js
+++ b/app/javascript/flavours/glitch/features/ui/components/embed_modal.js
@@ -74,6 +74,7 @@ export default class EmbedModal extends ImmutablePureComponent {
             className='embed-modal__iframe'
             frameBorder='0'
             ref={this.setIframeRef}
+            sandbox='allow-same-origin'
             title='preview'
           />
         </div>


### PR DESCRIPTION
It should not be necessary thanks to our Content Security Policy, but best
be sure in case a server's CSP is incorrect. Also, avoids a CSP warning about
loading remote scripts.