### PR TITLE
Hide followers count in the web UI for users who hide their own

### DIFF
--- a/app/serializers/rest/account_serializer.rb
+++ b/app/serializers/rest/account_serializer.rb
@@ -53,6 +53,6 @@ class REST::AccountSerializer < ActiveModel::Serializer
   end
 
   def followers_count
-    (Setting.hide_followers_count || object.user&.setting_hide_followers_count) ? -1 : object.followers_count
+    (Setting.hide_followers_count || object.user&.setting_hide_followers_count || current_user&.setting_hide_followers_count) ? -1 : object.followers_count
   end
 end

--- a/app/serializers/rest/mute_serializer.rb
+++ b/app/serializers/rest/mute_serializer.rb
@@ -3,13 +3,8 @@
 class REST::MuteSerializer < ActiveModel::Serializer
   include RoutingHelper
   
-  attributes :id, :account, :target_account, :created_at, :hide_notifications
+  attributes :id, :target_account, :created_at, :hide_notifications
 
-  def account
-    REST::AccountSerializer.new(object.account)
-  end
-
-  def target_account
-    REST::AccountSerializer.new(object.target_account)
-  end
+  belongs_to :account, serializer: REST::AccountSerializer
+  belongs_to :target_account, serializer: REST::AccountSerializer
 end


### PR DESCRIPTION
I'm not completely sure about making the setting do both things, but it mirrors the instance-wide setting and seems to make sense.

(I previously thought it would be hard to do, but just found out it wasn't)