### PR TITLE
Fix hashtag processing when sending toots

### DIFF
--- a/app/javascript/flavours/glitch/util/hashtag.js
+++ b/app/javascript/flavours/glitch/util/hashtag.js
@@ -2,7 +2,7 @@ export function recoverHashtags (recognizedTags, text) {
   return recognizedTags.map(tag => {
       const re = new RegExp(`(?:^|[^\/\)\w])#(${tag.name})`, 'i');
       const matched_hashtag = text.match(re);
-      return matched_hashtag ? matched_hashtag[1] : tag;
+      return matched_hashtag ? matched_hashtag[1] : null;
     }
-  );
+  ).filter(x => x !== null);
 }


### PR DESCRIPTION
This fixes crashes in pleroma when writing toots with a content warning,
since pleroma inserts a “nsfw” hashtag that isn't part of the toot's text.