### PR TITLE
[Glitch] Perform deep comparison for card data when receiving new props

### DIFF
--- a/app/javascript/flavours/glitch/features/status/components/card.js
+++ b/app/javascript/flavours/glitch/features/status/components/card.js
@@ -75,7 +75,7 @@ export default class Card extends React.PureComponent {
   };
 
   componentWillReceiveProps (nextProps) {
-    if (this.props.card !== nextProps.card) {
+    if (!Immutable.is(this.props.card, nextProps.card)) {
       this.setState({ embedded: false });
     }
   }


### PR DESCRIPTION
Prevents embedded players from resetting when interacting with the toot