### PR TITLE
Fix poll fotter layout

### DIFF
--- a/app/javascript/flavours/glitch/styles/polls.scss
+++ b/app/javascript/flavours/glitch/styles/polls.scss
@@ -144,6 +144,7 @@
 
     button,
     select {
+      width: 100%;
       flex: 1 1 50%;
     }
   }


### PR DESCRIPTION
The option of poll pops out , when the horizontal width of the screen is not enough.
I selected to size child elements using parent elements.

![スクリーンショット 2019-03-11 15 53 38](https://user-images.githubusercontent.com/8372135/54106287-fe6d7180-4418-11e9-8b4a-042ca8e228b2.png)  ![スクリーンショット 2019-03-11 15 54 37](https://user-images.githubusercontent.com/8372135/54106291-00cfcb80-4419-11e9-9327-6a02437d7111.png)
