### PR TITLE
Add paranoid mode

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -233,3 +233,9 @@ STREAMING_CLUSTER_NUM=1
 # http_proxy=http://gateway.local:8118
 # Access control for hidden service.
 # ALLOW_ACCESS_TO_HIDDEN_SERVICE=true
+
+# Paranoid mode disables fetching toots over OStatus, requires ActivityPub
+# fetches to be signed, and disables LDSigning of toots. This yields improved
+# plausible denial as well as a more effective way to enforce instance blocks,
+# at the cost of greatly decreased compatibility and much worse performances.
+# PARANOID_MODE = true

--- a/app/controllers/stream_entries_controller.rb
+++ b/app/controllers/stream_entries_controller.rb
@@ -20,6 +20,8 @@ class StreamEntriesController < ApplicationController
       end
 
       format.atom do
+        raise ActiveRecord::RecordNotFound if ENV['PARANOID_MODE'] == 'true'
+
         unless @stream_entry.hidden?
           skip_session!
           expires_in 3.minutes, public: true

--- a/app/services/process_mentions_service.rb
+++ b/app/services/process_mentions_service.rb
@@ -66,7 +66,7 @@ class ProcessMentionsService < BaseService
       serializer: ActivityPub::ActivitySerializer,
       adapter: ActivityPub::Adapter
     ).as_json
-    @activitypub_json = Oj.dump(@status.distributable? ? ActivityPub::LinkedDataSignature.new(payload).sign!(@status.account) : payload)
+    @activitypub_json = Oj.dump(@status.distributable? && ENV['PARANOID_MODE'] != 'true' ? ActivityPub::LinkedDataSignature.new(payload).sign!(@status.account) : payload)
   end
 
   def resolve_account_service

--- a/app/workers/activitypub/distribute_poll_update_worker.rb
+++ b/app/workers/activitypub/distribute_poll_update_worker.rb
@@ -54,7 +54,7 @@ class ActivityPub::DistributePollUpdateWorker
   end
 
   def payload
-    @payload ||= @status.distributable? ? signed_payload : Oj.dump(unsigned_payload)
+    @payload ||= @status.distributable? && ENV['PARANOID_MODE'] != 'true' ? signed_payload : Oj.dump(unsigned_payload)
   end
 
   def relay!

--- a/app/workers/activitypub/distribution_worker.rb
+++ b/app/workers/activitypub/distribution_worker.rb
@@ -54,7 +54,7 @@ class ActivityPub::DistributionWorker
   end
 
   def payload
-    @payload ||= @status.distributable? ? signed_payload : Oj.dump(unsigned_payload)
+    @payload ||= @status.distributable? && ENV['PARANOID_MODE'] != 'true' ? signed_payload : Oj.dump(unsigned_payload)
   end
 
   def relay!

--- a/app/workers/activitypub/reply_distribution_worker.rb
+++ b/app/workers/activitypub/reply_distribution_worker.rb
@@ -40,6 +40,6 @@ class ActivityPub::ReplyDistributionWorker
   end
 
   def payload
-    @payload ||= @status.distributable? ? signed_payload : Oj.dump(unsigned_payload)
+    @payload ||= @status.distributable? && ENV['PARANOID_MODE'] != 'true' ? signed_payload : Oj.dump(unsigned_payload)
   end
 end


### PR DESCRIPTION
Disables most of the LDSigning, disables fetching individual OStatus items,
requires authentication over ActivityPub.

The costs of doing that are probably prohibitive, but doing something like that is the only way to address https://github.com/tootsuite/mastodon/issues/10221

To my knowledge, no AP software signs fetches yet, so this would simply break boosting, thread fetching and similar stuff. This could start being useful if https://github.com/tootsuite/mastodon/pull/10457 gets merged, though