### PR TITLE
Load custom CSS rules after standard ones

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -28,14 +28,14 @@
         = javascript_pack_tag "locales/#{@theme[:flavour]}/en", integrity: true, crossorigin: 'anonymous'
     = csrf_meta_tags
 
-    - if Setting.custom_css.present?
-      = stylesheet_link_tag custom_css_path, media: 'all'
-
     = yield :header_tags
 
     -#  These must come after :header_tags to ensure our initial state has been defined.
     = render partial: 'layouts/theme', object: @core
     = render partial: 'layouts/theme', object: @theme
+
+    - if Setting.custom_css.present?
+      = stylesheet_link_tag custom_css_path, media: 'all'
 
   %body{ class: body_classes }
     = content_for?(:content) ? yield(:content) : yield


### PR DESCRIPTION
Fixes #933

Due to glitch-soc's theming system, JS and CSS files are imported in a slightly
different order, and custom CSS rules were loaded *before* everything else.

They will now be loaded *after* everything else, which is a bit different from
upstream but should work better overall.