### PR TITLE
Accept richer text from remote statuses

### DIFF
--- a/app/javascript/flavours/glitch/components/status_content.js
+++ b/app/javascript/flavours/glitch/components/status_content.js
@@ -213,6 +213,7 @@ export default class StatusContent extends React.PureComponent {
               style={directionStyle}
               tabIndex={!hidden ? 0 : null}
               dangerouslySetInnerHTML={content}
+              className='status__text'
               lang={status.get('language')}
             />
             {media}
@@ -233,6 +234,7 @@ export default class StatusContent extends React.PureComponent {
             ref={this.setRef}
             dangerouslySetInnerHTML={content}
             lang={status.get('language')}
+            className='status__text'
             tabIndex='0'
           />
           {media}
@@ -245,7 +247,7 @@ export default class StatusContent extends React.PureComponent {
           style={directionStyle}
           tabIndex='0'
         >
-          <div ref={this.setRef} dangerouslySetInnerHTML={content} lang={status.get('language')} tabIndex='0' />
+          <div ref={this.setRef} className='status__text' dangerouslySetInnerHTML={content} lang={status.get('language')} tabIndex='0' />
           {media}
         </div>
       );

--- a/app/javascript/flavours/glitch/styles/components/status.scss
+++ b/app/javascript/flavours/glitch/styles/components/status.scss
@@ -22,13 +22,40 @@
     margin: -3px 0 0;
   }
 
-  p {
+  p, pre, blockquote {
     margin-bottom: 20px;
     white-space: pre-wrap;
 
     &:last-child {
       margin-bottom: 0;
     }
+  }
+
+  h1, h2, h3, h4, h5 {
+    margin-top: 20px;
+    margin-bottom: 20px;
+  }
+
+  h1, h2 {
+    font-weight: 500;
+    font-size: 18px;
+  }
+
+  h2 {
+    font-size: 16px;
+  }
+
+  blockquote {
+    margin-left: 20px;
+    color: $dark-text-color;
+  }
+
+  b, strong {
+    font-weight: 500;
+  }
+
+  em, i {
+    font-style: italic;
   }
 
   a {

--- a/app/javascript/flavours/glitch/styles/components/status.scss
+++ b/app/javascript/flavours/glitch/styles/components/status.scss
@@ -58,6 +58,18 @@
     em, i {
       font-style: italic;
     }
+
+    ul, ol {
+      margin-left: 1em;
+    }
+
+    ul {
+      list-style-type: disc;
+    }
+
+    ol {
+      list-style-type: decimal;
+    }
   }
 
   a {

--- a/app/javascript/flavours/glitch/styles/components/status.scss
+++ b/app/javascript/flavours/glitch/styles/components/status.scss
@@ -31,31 +31,33 @@
     }
   }
 
-  h1, h2, h3, h4, h5 {
-    margin-top: 20px;
-    margin-bottom: 20px;
-  }
+  .status__text {
+    h1, h2, h3, h4, h5 {
+      margin-top: 20px;
+      margin-bottom: 20px;
+    }
 
-  h1, h2 {
-    font-weight: 500;
-    font-size: 18px;
-  }
+    h1, h2 {
+      font-weight: 500;
+      font-size: 18px;
+    }
 
-  h2 {
-    font-size: 16px;
-  }
+    h2 {
+      font-size: 16px;
+    }
 
-  blockquote {
-    margin-left: 20px;
-    color: $dark-text-color;
-  }
+    blockquote {
+      margin-left: 20px;
+      color: $dark-text-color;
+    }
 
-  b, strong {
-    font-weight: 500;
-  }
+    b, strong {
+      font-weight: 500;
+    }
 
-  em, i {
-    font-style: italic;
+    em, i {
+      font-style: italic;
+    }
   }
 
   a {

--- a/app/lib/sanitize_config.rb
+++ b/app/lib/sanitize_config.rb
@@ -20,11 +20,13 @@ class Sanitize
     end
 
     MASTODON_STRICT ||= freeze_config(
-      elements: %w(p br span a),
+      elements: %w(p br span a abbr del pre blockquote code b strong i em h1 h2 h3 h4 h5),
 
       attributes: {
-        'a'    => %w(href rel class),
-        'span' => %w(class),
+        'a'          => %w(href rel class title),
+        'span'       => %w(class),
+        'abbr'       => %w(title),
+        'blockquote' => %w(cite),
       },
 
       add_attributes: {
@@ -35,7 +37,8 @@ class Sanitize
       },
 
       protocols: {
-        'a' => { 'href' => HTTP_PROTOCOLS },
+        'a'          => { 'href' => HTTP_PROTOCOLS },
+        'blockquote' => { 'cite' => HTTP_PROTOCOLS },
       },
 
       transformers: [

--- a/app/lib/sanitize_config.rb
+++ b/app/lib/sanitize_config.rb
@@ -20,7 +20,7 @@ class Sanitize
     end
 
     MASTODON_STRICT ||= freeze_config(
-      elements: %w(p br span a abbr del pre blockquote code b strong i em h1 h2 h3 h4 h5),
+      elements: %w(p br span a abbr del pre blockquote code b strong i em h1 h2 h3 h4 h5 ul ol li),
 
       attributes: {
         'a'          => %w(href rel class title),


### PR DESCRIPTION
Support abbr, del, pre, blockquote, code, strong, b, em, i, and h1…h5
HTML elements in remote statuses, add corresponding CSS.

EDIT: compared to pleroma, it's still missing support for inline images (which I don't plan on supporting), tables and lists

![image](https://user-images.githubusercontent.com/384364/56311517-82b8c000-614e-11e9-83f7-2b654f11a52c.png)
