### PR TITLE
Allow turning keybase off instance-wide

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -30,6 +30,7 @@ module Admin
       @trending_hashtags     = TrendingTags.get(7)
       @profile_directory     = Setting.profile_directory
       @timeline_preview      = Setting.timeline_preview
+      @keybase_integration   = Setting.enable_keybase
     end
 
     private

--- a/app/controllers/settings/identity_proofs_controller.rb
+++ b/app/controllers/settings/identity_proofs_controller.rb
@@ -5,6 +5,7 @@ class Settings::IdentityProofsController < Settings::BaseController
 
   before_action :authenticate_user!
   before_action :check_required_params, only: :new
+  before_action :check_enabled, only: :new
 
   def index
     @proofs = AccountIdentityProof.where(account: current_account).order(provider: :asc, provider_username: :asc)
@@ -40,6 +41,10 @@ class Settings::IdentityProofsController < Settings::BaseController
   end
 
   private
+
+  def check_enabled
+    not_found unless Setting.enable_keybase
+  end
 
   def check_required_params
     redirect_to settings_identity_proofs_path unless [:provider, :provider_username, :username, :token].all? { |k| params[k].present? }

--- a/app/controllers/well_known/keybase_proof_config_controller.rb
+++ b/app/controllers/well_known/keybase_proof_config_controller.rb
@@ -2,8 +2,16 @@
 
 module WellKnown
   class KeybaseProofConfigController < ActionController::Base
+    before_action :check_enabled
+
     def show
       render json: {}, serializer: ProofProvider::Keybase::ConfigSerializer
+    end
+
+    private
+
+    def check_enabled
+      head 404 unless Setting.enable_keybase
     end
   end
 end

--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -27,6 +27,7 @@ class Form::AdminSettings
     custom_css
     profile_directory
     hide_followers_count
+    enable_keybase
     flavour_and_skin
     thumbnail
     hero
@@ -43,6 +44,7 @@ class Form::AdminSettings
     preview_sensitive_media
     profile_directory
     hide_followers_count
+    enable_keybase
   ).freeze
 
   UPLOAD_KEYS = %i(

--- a/app/views/admin/dashboard/index.html.haml
+++ b/app/views/admin/dashboard/index.html.haml
@@ -50,6 +50,8 @@
         %li
           = feature_hint(link_to(t('admin.dashboard.feature_timeline_preview'), edit_admin_settings_path), @timeline_preview)
         %li
+          = feature_hint(link_to(t('admin.dashboard.keybase'), edit_admin_settings_path), @timeline_preview)
+        %li
           = feature_hint(link_to(t('admin.dashboard.feature_relay'), admin_relays_path), @relay_enabled)
 
   .dashboard__widgets__versions

--- a/app/views/admin/dashboard/index.html.haml
+++ b/app/views/admin/dashboard/index.html.haml
@@ -50,7 +50,7 @@
         %li
           = feature_hint(link_to(t('admin.dashboard.feature_timeline_preview'), edit_admin_settings_path), @timeline_preview)
         %li
-          = feature_hint(link_to(t('admin.dashboard.keybase'), edit_admin_settings_path), @timeline_preview)
+          = feature_hint(link_to(t('admin.dashboard.keybase'), edit_admin_settings_path), @keybase_integration)
         %li
           = feature_hint(link_to(t('admin.dashboard.feature_relay'), admin_relays_path), @relay_enabled)
 

--- a/app/views/admin/settings/edit.html.haml
+++ b/app/views/admin/settings/edit.html.haml
@@ -69,6 +69,9 @@
   .fields-group
     = f.input :hide_followers_count, as: :boolean, wrapper: :with_label, label: t('admin.settings.hide_followers_count.title'), hint: t('admin.settings.hide_followers_count.desc_html')
 
+  .fields-group
+    = f.input :enable_keybase, as: :boolean, wrapper: :with_label, label: t('admin.settings.enable_keybase.title'), hint: t('admin.settings.enable_keybase.desc_html')
+
   %hr.spacer/
 
   .fields-group

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -252,6 +252,7 @@ en:
       feature_timeline_preview: Timeline preview
       features: Features
       hidden_service: Federation with hidden services
+      keybase: Keybase integration
       open_reports: open reports
       recent_users: Recent users
       search: Full-text search

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -398,6 +398,9 @@ en:
       custom_css:
         desc_html: Modify the look with CSS loaded on every page
         title: Custom CSS
+      enable_keybase:
+        desc_html: Allow your users to prove their identity via keybase
+        title: Enable keybase integration
       hero:
         desc_html: Displayed on the frontpage. At least 600x100px recommended. When not set, falls back to server thumbnail
         title: Hero image

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -31,6 +31,7 @@ defaults: &defaults
   system_font_ui: false
   noindex: false
   hide_followers_count: false
+  enable_keybase: true
   flavour: 'glitch'
   skin: 'default'
   aggregate_reblogs: true


### PR DESCRIPTION
This does not disable verification of remote users who have published a keybase proof, but it disables announcing a config file and creating proofs for local users.