### PR TITLE
Fix status header display in toot mobile menu

### DIFF
--- a/app/javascript/flavours/glitch/styles/components/modal.scss
+++ b/app/javascript/flavours/glitch/styles/components/modal.scss
@@ -415,14 +415,21 @@
   position: relative;
   flex-direction: column;
 
+  .status__relative-time {
+    color: $dark-text-color;
+    float: right;
+    font-size: 14px;
+    width: auto;
+    margin: initial;
+    padding: initial;
+  }
+
   .status__display-name {
     display: flex;
   }
 
   .status__avatar {
-    height: 28px;
-    left: 10px;
-    top: 10px;
+    height: 48px;
     width: 48px;
   }
 


### PR DESCRIPTION
## Before

![Screenshot_2019-04-24 Dev instance](https://user-images.githubusercontent.com/384364/56669074-e132f080-66b0-11e9-8a34-540c106f8943.png)

![Screenshot_2019-04-24 Dev instance(1)](https://user-images.githubusercontent.com/384364/56669081-e42de100-66b0-11e9-8dcb-7a88287b5c42.png)

## After

![Screenshot_2019-04-24 Dev instance(2)](https://user-images.githubusercontent.com/384364/56669091-e7c16800-66b0-11e9-94c7-6d20e018227a.png)

![Screenshot_2019-04-24 Dev instance(3)](https://user-images.githubusercontent.com/384364/56669097-eabc5880-66b0-11e9-99f2-3048e88438a2.png)
