### PR TITLE
Add site-wide options to show reblogs and replies in local/public timelines

### DIFF
--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -32,6 +32,8 @@ class Form::AdminSettings
     thumbnail
     hero
     mascot
+    show_reblogs_in_public_timelines
+    show_replies_in_public_timelines
   ).freeze
 
   BOOLEAN_KEYS = %i(
@@ -45,6 +47,8 @@ class Form::AdminSettings
     profile_directory
     hide_followers_count
     enable_keybase
+    show_reblogs_in_public_timelines
+    show_replies_in_public_timelines
   ).freeze
 
   UPLOAD_KEYS = %i(

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -327,7 +327,8 @@ class Status < ApplicationRecord
     end
 
     def as_public_timeline(account = nil, local_only = false)
-      query = timeline_scope(local_only).without_replies
+      query = timeline_scope(local_only)
+      query = query.without_replies unless Setting.show_replies_in_public_timelines
 
       apply_timeline_filters(query, account, local_only)
     end
@@ -408,9 +409,12 @@ class Status < ApplicationRecord
 
     def timeline_scope(local_only = false)
       starting_scope = local_only ? Status.local : Status
-      starting_scope
-        .with_public_visibility
-        .without_reblogs
+      starting_scope = starting_scope.with_public_visibility
+      if Setting.show_reblogs_in_public_timelines
+        starting_scope
+      else
+        starting_scope.without_reblogs
+      end
     end
 
     def apply_timeline_filters(query, account, local_only)

--- a/app/services/fan_out_on_write_service.rb
+++ b/app/services/fan_out_on_write_service.rb
@@ -21,11 +21,12 @@ class FanOutOnWriteService < BaseService
       deliver_to_lists(status)
     end
 
-    return if status.account.silenced? || !status.public_visibility? || status.reblog?
+    return if status.account.silenced? || !status.public_visibility?
+    return if status.reblog? && !Setting.show_reblogs_in_public_timelines
 
     deliver_to_hashtags(status)
 
-    return if status.reply? && status.in_reply_to_account_id != status.account_id
+    return if status.reply? && status.in_reply_to_account_id != status.account_id && !Setting.show_replies_in_public_timelines
 
     deliver_to_public(status)
     deliver_to_media(status) if status.media_attachments.any?

--- a/app/views/admin/settings/edit.html.haml
+++ b/app/views/admin/settings/edit.html.haml
@@ -72,6 +72,12 @@
   .fields-group
     = f.input :enable_keybase, as: :boolean, wrapper: :with_label, label: t('admin.settings.enable_keybase.title'), hint: t('admin.settings.enable_keybase.desc_html')
 
+  .fields-group
+    = f.input :show_reblogs_in_public_timelines, as: :boolean, wrapper: :with_label, label: t('admin.settings.show_reblogs_in_public_timelines.title'), hint: t('admin.settings.show_reblogs_in_public_timelines.desc_html')
+
+  .fields-group
+    = f.input :show_replies_in_public_timelines, as: :boolean, wrapper: :with_label, label: t('admin.settings.show_replies_in_public_timelines.title'), hint: t('admin.settings.show_replies_in_public_timelines.desc_html')
+
   %hr.spacer/
 
   .fields-group

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -438,6 +438,12 @@ en:
       show_known_fediverse_at_about_page:
         desc_html: When toggled, it will show toots from all the known fediverse on preview. Otherwise it will only show local toots.
         title: Show known fediverse on timeline preview
+      show_reblogs_in_public_timelines:
+        desc_html: Show public boosts of public toots in local and public timelines.
+        title: Show boosts in public timelines
+      show_replies_in_public_timelines:
+        desc_html: In addition to public self-replies (threads), show public replies in local and public timelines.
+        title: Show replies in public timelines
       show_staff_badge:
         desc_html: Show a staff badge on a user page
         title: Show staff badge

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -62,6 +62,8 @@ defaults: &defaults
   activity_api_enabled: true
   peers_api_enabled: true
   show_known_fediverse_at_about_page: true
+  show_reblogs_in_public_timelines: false
+  show_replies_in_public_timelines: false
 
 development:
   <<: *defaults


### PR DESCRIPTION
Fixes #1021

![image](https://user-images.githubusercontent.com/384364/56989880-cd492c00-6b93-11e9-888f-5e6b74f64f81.png)
