### PR TITLE
fix pinned columns ’s Media-only toggles

### DIFF
--- a/app/javascript/flavours/glitch/features/community_timeline/containers/column_settings_container.js
+++ b/app/javascript/flavours/glitch/features/community_timeline/containers/column_settings_container.js
@@ -1,5 +1,6 @@
 import { connect } from 'react-redux';
 import ColumnSettings from '../components/column_settings';
+import { changeColumnParams } from 'flavours/glitch/actions/columns';
 import { changeSetting } from 'flavours/glitch/actions/settings';
 
 const mapStateToProps = (state, { columnId }) => {


### PR DESCRIPTION
Media-only toggles could not be used on pinned columns.
The commit fixes this problem.

![スクリーンショット 2019-05-06 3 24 58](https://user-images.githubusercontent.com/8372135/57198632-f44a9800-6faf-11e9-98de-e7998c721fe1.png)
![スクリーンショット 2019-05-06 3 24 46](https://user-images.githubusercontent.com/8372135/57198634-fdd40000-6faf-11e9-82e8-b4abc824b876.png)
