### PR TITLE
[Work In Progress] Full Article Rendering Support

### DIFF
--- a/app/javascript/mastodon/components/status.js
+++ b/app/javascript/mastodon/components/status.js
@@ -350,9 +350,15 @@ class Status extends ImmutablePureComponent {
       toggleHidden: this.handleHotkeyToggleHidden,
     };
 
+    //console.log('!!!!',status.get('id'))
+    //if (status.get('id') === '102035409430859898') {
+    //  debugger
+    //}
+
+
     return (
       <HotKeys handlers={handlers}>
-        <div className={classNames('status__wrapper', `status__wrapper-${status.get('visibility')}`, { 'status__wrapper-reply': !!status.get('in_reply_to_id'), read: unread === false, focusable: !this.props.muted })} tabIndex={this.props.muted ? null : 0} data-featured={featured ? 'true' : null} aria-label={textForScreenReader(intl, status, rebloggedByText)} ref={this.handleRef}>
+        <div className={classNames('status__wrapper', `status__wrapper-type-${status.get('activity_pub_type') || 'none'}` , `status__wrapper-${status.get('visibility')}`, { 'status__wrapper-reply': !!status.get('in_reply_to_id'), read: unread === false, focusable: !this.props.muted })} tabIndex={this.props.muted ? null : 0} data-featured={featured ? 'true' : null} aria-label={textForScreenReader(intl, status, rebloggedByText)} ref={this.handleRef}>
           {prepend}
 
           <div className={classNames('status', `status-${status.get('visibility')}`, { 'status-reply': !!status.get('in_reply_to_id'), muted: this.props.muted, read: unread === false })} data-id={status.get('id')}>

--- a/app/javascript/mastodon/components/status_content.js
+++ b/app/javascript/mastodon/components/status_content.js
@@ -165,6 +165,12 @@ export default class StatusContent extends React.PureComponent {
       </button>
     );
 
+    const readArticleButton = (
+      <button className='status__content__read-more-button' onClick={this.props.onClick} key='read-more'>
+        <FormattedMessage id='status.read_article' defaultMessage='Read article' /><Icon id='angle-right' fixedWidth />
+      </button>
+    );
+
     if (status.get('spoiler_text').length > 0) {
       let mentionsPlaceholder = '';
 
@@ -180,19 +186,25 @@ export default class StatusContent extends React.PureComponent {
         mentionsPlaceholder = <div>{mentionLinks}</div>;
       }
 
-      return (
+      const output = [
         <div className={classNames} ref={this.setRef} tabIndex='0' style={directionStyle} onMouseDown={this.handleMouseDown} onMouseUp={this.handleMouseUp}>
           <p style={{ marginBottom: hidden && status.get('mentions').isEmpty() ? '0px' : null }}>
             <span dangerouslySetInnerHTML={spoilerContent} lang={status.get('language')} />
             {' '}
-            <button tabIndex='0' className={`status__content__spoiler-link ${hidden ? 'status__content__spoiler-link--show-more' : 'status__content__spoiler-link--show-less'}`} onClick={this.handleSpoilerClick}>{toggleText}</button>
+            {status.get('activity_pub_type') === 'Article' ? '' : <div><button tabIndex='0' className={`status__content__spoiler-link ${hidden ? 'status__content__spoiler-link--show-more' : 'status__content__spoiler-link--show-less'}`} onClick={this.handleSpoilerClick}>{toggleText}</button> <span>{media ? <i className='fa fa-eye' /> : ''}</span></div>}
           </p>
 
           {mentionsPlaceholder}
 
           <div tabIndex={!hidden ? 0 : null} className={`status__content__text ${!hidden ? 'status__content__text--visible' : ''}`} style={directionStyle} dangerouslySetInnerHTML={content} lang={status.get('language')} />
-        </div>
-      );
+        </div>,
+      ];
+
+      if (status.get('activity_pub_type') === 'Article' && !this.props.expanded) {
+        output.push(readArticleButton);
+      }
+
+      return output;
     } else if (this.props.onClick) {
       const output = [
         <div

--- a/app/javascript/mastodon/features/status/components/detailed_status.js
+++ b/app/javascript/mastodon/features/status/components/detailed_status.js
@@ -199,7 +199,7 @@ export default class DetailedStatus extends ImmutablePureComponent {
             <DisplayName account={status.get('account')} localDomain={this.props.domain} />
           </a>
 
-          <StatusContent status={status} expanded={!status.get('hidden')} onExpandedToggle={this.handleExpandedToggle} />
+          <StatusContent status={status} expanded={status.get('activity_pub_type') === 'Article' || !status.get('hidden')} onExpandedToggle={this.handleExpandedToggle} />
 
           {media}
 

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -767,6 +767,10 @@
       display: block;
     }
   }
+
+  .article-type img {
+    max-width: 95%;
+  }
 }
 
 .status__content.status__content--collapsed {

--- a/app/lib/activitypub/activity.rb
+++ b/app/lib/activitypub/activity.rb
@@ -4,8 +4,8 @@ class ActivityPub::Activity
   include JsonLdHelper
   include Redisable
 
-  SUPPORTED_TYPES = %w(Note Question).freeze
-  CONVERTED_TYPES = %w(Image Video Article Page).freeze
+  SUPPORTED_TYPES = %w(Note Question Article).freeze
+  CONVERTED_TYPES = %w(Image Video Page).freeze
 
   def initialize(json, account, **options)
     @json    = json

--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -60,7 +60,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
         account: @account,
         text: text_from_content || '',
         language: detected_language,
-        spoiler_text: converted_object_type? ? '' : (text_from_summary || ''),
+        spoiler_text: converted_object_type? ? '' : (text_from_summary || (@object['type'] == 'Article' && text_from_name) || ''),
         created_at: @object['published'],
         override_timestamps: @options[:override_timestamps],
         reply: @object['inReplyTo'].present?,
@@ -70,6 +70,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
         conversation: conversation_from_uri(@object['conversation']),
         media_attachment_ids: process_attachments.take(4).map(&:id),
         poll: process_poll,
+        activity_pub_type: @object['type']
       }
     end
   end

--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -30,6 +30,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
     @mentions = []
     @params   = {}
 
+    process_inline_images if @object['content'].present? && @object['type'] == 'Article'
     process_status_params
     process_tags
     process_audience
@@ -70,6 +71,56 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
         media_attachment_ids: process_attachments.take(4).map(&:id),
         poll: process_poll,
       }
+    end
+  end
+
+  class Handler < ::Ox::Sax
+    attr_reader :srcs
+    attr_reader :alts
+    def initialize(block)
+      @stack = []
+      @srcs = []
+      @alts = {}
+    end
+
+    def start_element(element_name)
+      @stack << [element_name, {}]
+    end
+
+    def end_element(element_name)
+      self_name, self_attributes = @stack[-1]
+      if self_name == :img && !self_attributes[:src].nil?
+        @srcs << self_attributes[:src]
+        @alts[self_attributes[:src]] = self_attributes[:alt]
+      end
+      @stack.pop
+    end
+
+    def attr(attribute_name, attribute_value)
+      _name, attributes = @stack.last
+      attributes[attribute_name] = attribute_value
+    end
+  end
+
+  def process_inline_images
+    proc = Proc.new { |name| puts name }
+    handler = Handler.new(proc)
+    Ox.sax_parse(handler, @object['content'])
+    handler.srcs.each do |src|
+      if skip_download?
+        @object['content'].gsub!(src, '')
+        next
+      end
+
+      media_attachment = MediaAttachment.create(account: @account, remote_url: src, description: handler.alts[src], focus: nil)
+      media_attachment.file_remote_url = src
+      media_attachment.save
+      if unsupported_media_type?(media_attachment.file.content_type)
+        @object['content'].gsub!(src, '')
+        media_attachment.delete
+      else
+        @object['content'].gsub!(src, media_attachment.file.url(:small))
+      end
     end
   end
 
@@ -305,6 +356,8 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
 
   def text_from_content
     return Formatter.instance.linkify([[text_from_name, text_from_summary.presence].compact.join("\n\n"), object_url || @object['id']].join(' ')) if converted_object_type?
+
+    return Formatter.instance.format_article(@object['content']) if @object['content'].present? && @object['type'] == 'Article'
 
     if @object['content'].present?
       @object['content']

--- a/app/lib/formatter.rb
+++ b/app/lib/formatter.rb
@@ -92,6 +92,7 @@ class Formatter
 
   def format_article(text)
     text = text.gsub(/>\n+</, "><")
+    text = "<span class='article-type'>#{text}</span>"
     text.html_safe # rubocop:disable Rails/OutputSafety
   end
 

--- a/app/lib/formatter.rb
+++ b/app/lib/formatter.rb
@@ -90,6 +90,11 @@ class Formatter
     html.html_safe # rubocop:disable Rails/OutputSafety
   end
 
+  def format_article(text)
+    text = text.gsub(/>\n+</, "><")
+    text.html_safe # rubocop:disable Rails/OutputSafety
+  end
+
   def linkify(text)
     html = encode_and_link_urls(text)
     html = simple_format(html, {}, sanitize: false)

--- a/app/lib/sanitize_config.rb
+++ b/app/lib/sanitize_config.rb
@@ -35,6 +35,9 @@ class Sanitize
           'rel' => 'nofollow noopener',
           'target' => '_blank',
         },
+        'span' => {
+          'class' => 'article-type',
+        },
       },
 
       protocols: {

--- a/app/lib/sanitize_config.rb
+++ b/app/lib/sanitize_config.rb
@@ -20,13 +20,14 @@ class Sanitize
     end
 
     MASTODON_STRICT ||= freeze_config(
-      elements: %w(p br span a abbr del pre blockquote code b strong u sub i em h1 h2 h3 h4 h5 ul ol li),
+      elements: %w(p br span a abbr del pre blockquote code b strong u sub i em h1 h2 h3 h4 h5 ul ol li img),
 
       attributes: {
         'a'          => %w(href rel class title),
         'span'       => %w(class),
         'abbr'       => %w(title),
         'blockquote' => %w(cite),
+        'img'        => %w(src alt),
       },
 
       add_attributes: {

--- a/app/serializers/rest/status_serializer.rb
+++ b/app/serializers/rest/status_serializer.rb
@@ -4,7 +4,7 @@ class REST::StatusSerializer < ActiveModel::Serializer
   attributes :id, :created_at, :in_reply_to_id, :in_reply_to_account_id,
              :sensitive, :spoiler_text, :visibility, :language,
              :uri, :url, :replies_count, :reblogs_count,
-             :favourites_count
+             :favourites_count, :activity_pub_type
 
   attribute :favourited, if: :current_user?
   attribute :reblogged, if: :current_user?
@@ -61,6 +61,10 @@ class REST::StatusSerializer < ActiveModel::Serializer
 
   def uri
     OStatus::TagManager.instance.uri_for(object)
+  end
+
+  def activity_pub_type
+    object.activity_pub_type.to_s
   end
 
   def content

--- a/db/migrate/20190513171721_add_activitypub_type_to_statuses.rb
+++ b/db/migrate/20190513171721_add_activitypub_type_to_statuses.rb
@@ -1,0 +1,5 @@
+class AddActivityPubTypeToStatuses < ActiveRecord::Migration[5.2]
+  def change
+    add_column :statuses, :activity_pub_type, :string
+  end
+end


### PR DESCRIPTION
Mostly I want to get people's opinion on this feature I've added to my fork at [friendcamp/mastodon](https://github.com/friendcamp/mastodon/). I would like feedback on this both in terms of the implementation of the feature for users, the technical implementation, and also whether Glitch would want this.

### The end result

The idea is to provide a "read article" link similar to "read more" when Mastodon receives an AP object of `Article` type. So if you subscribe directly to a blog on write.as or similar, you can read the full article in Mastodon.

How it appears in timelines and on profiles:

<img width="336" alt="image" src="https://user-images.githubusercontent.com/266454/57641489-fab9b080-7569-11e9-93e4-badecd0125e1.png">

How it appears when you click to see the full article on a phone:

![image](https://user-images.githubusercontent.com/266454/57641641-600da180-756a-11e9-9c97-07d9e289735d.png)

Here's how the full article renders (looooong screenshot so not embedded)

[very long screenshot](https://user-images.githubusercontent.com/266454/57641620-4cfad180-756a-11e9-9e43-3d39fbb6c42a.png)

### Tech notes

This is my first time adding a column to a table in Rails. I'm probably doing something wrong in terms of database design. My implementation generally feels a little "hacky" and I'm sure there are more elegant solutions. I'm happy to implement these if someone will suggest to me what they are.
