### PR TITLE
Use glitch-soc's poll component instead of upstream's

### DIFF
--- a/app/javascript/flavours/glitch/containers/poll_container.js
+++ b/app/javascript/flavours/glitch/containers/poll_container.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import Poll from 'mastodon/components/poll';
+import Poll from 'flavours/glitch/components/poll';
 
 const mapStateToProps = (state, { pollId }) => ({
   poll: state.getIn(['polls', pollId]),


### PR DESCRIPTION
The poll container code was loading vanilla mastodon's component instead of glitch-soc.
Upstream has recently made changes that do not make sense in glitch-soc, so the two components now behave differently, causing glitch-soc to display alphabetic letters in place of poll options.

This should fix it.