### PR TITLE
Add `from_account` to notifications API

### DIFF
--- a/app/controllers/api/v1/notifications_controller.rb
+++ b/app/controllers/api/v1/notifications_controller.rb
@@ -53,7 +53,7 @@ class Api::V1::NotificationsController < Api::BaseController
   end
 
   def browserable_account_notifications
-    current_account.notifications.browserable(exclude_types)
+    current_account.notifications.browserable(exclude_types, from_account)
   end
 
   def target_statuses_from_notifications
@@ -88,6 +88,10 @@ class Api::V1::NotificationsController < Api::BaseController
     val = params.permit(exclude_types: [])[:exclude_types] || []
     val = [val] unless val.is_a?(Enumerable)
     val
+  end
+
+  def from_account
+      params[:from_account]
   end
 
   def pagination_params(core_params)

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -41,9 +41,17 @@ class Notification < ApplicationRecord
   validates :account_id, uniqueness: { scope: [:activity_type, :activity_id] }
   validates :activity_type, inclusion: { in: TYPE_CLASS_MAP.values }
 
-  scope :browserable, ->(exclude_types = []) {
+  scope :browserable, ->(exclude_types = [], from_account = nil) {
     types = TYPE_CLASS_MAP.values - activity_types_from_types(exclude_types + [:follow_request])
-    where(activity_type: types)
+    return where(activity_type: types) if from_account.nil?
+    username, domain = from_account.split('@')
+    if TagManager.instance.local_domain?(domain) then
+      account = Account.find_local(username)
+    else
+      account = Account.find_remote(username, domain)
+    end
+    return where(activity_type: types) if account.nil?
+    where(activity_type: types, from_account_id: account.id)
   }
 
   cache_associated :from_account, status: STATUS_INCLUDES, mention: [status: STATUS_INCLUDES], favourite: [:account, status: STATUS_INCLUDES], follow: :account, poll: [status: STATUS_INCLUDES]

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -50,8 +50,7 @@ class Notification < ApplicationRecord
     else
       account = Account.find_remote(username, domain)
     end
-    return where(activity_type: types) if account.nil?
-    where(activity_type: types, from_account_id: account.id)
+    where(activity_type: types, from_account_id: account&.id)
   }
 
   cache_associated :from_account, status: STATUS_INCLUDES, mention: [status: STATUS_INCLUDES], favourite: [:account, status: STATUS_INCLUDES], follow: :account, poll: [status: STATUS_INCLUDES]

--- a/spec/controllers/api/v1/notifications_controller_spec.rb
+++ b/spec/controllers/api/v1/notifications_controller_spec.rb
@@ -110,6 +110,40 @@ RSpec.describe Api::V1::NotificationsController, type: :controller do
       it 'excludes reblog' do
         expect(assigns(:notifications).map(&:activity)).to_not include(@reblog_of_first_status)
       end
+
+      it 'excludes follow' do
+        expect(assigns(:notifications).map(&:activity)).to_not include(@follow)
+      end
+    end
+
+    describe 'from nonexistent user' do
+      before do
+        get :index, params: { from_account: 'david' }
+      end
+
+      it 'returns http success' do
+        expect(response).to have_http_status(200)
+      end
+
+      it 'excludes favourite' do
+        expect(assigns(:notifications).map(&:activity)).to_not include(@favourite)
+      end
+
+      it 'excludes second favourite' do
+        expect(assigns(:notifications).map(&:activity)).to_not include(@second_favourite)
+      end
+
+      it 'excludes mention' do
+        expect(assigns(:notifications).map(&:activity)).to_not include(@mention_from_status)
+      end
+
+      it 'excludes reblog' do
+        expect(assigns(:notifications).map(&:activity)).to_not include(@reblog_of_first_status)
+      end
+
+      it 'excludes follow' do
+        expect(assigns(:notifications).map(&:activity)).to_not include(@follow)
+      end
     end
 
     describe 'with excluded mentions' do

--- a/spec/controllers/api/v1/notifications_controller_spec.rb
+++ b/spec/controllers/api/v1/notifications_controller_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Api::V1::NotificationsController, type: :controller do
   let(:user)  { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
   let(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
   let(:other) { Fabricate(:user, account: Fabricate(:account, username: 'bob')) }
+  let(:third) { Fabricate(:user, account: Fabricate(:account, username: 'carol')) }
 
   before do
     allow(controller).to receive(:doorkeeper_token) { token }
@@ -55,6 +56,7 @@ RSpec.describe Api::V1::NotificationsController, type: :controller do
       mentioning_status = PostStatusService.new.call(other.account, text: 'Hello @alice')
       @mention_from_status = mentioning_status.mentions.first
       @favourite = FavouriteService.new.call(other.account, first_status)
+      @second_favourite = FavouriteService.new.call(third.account, first_status)
       @follow = FollowService.new.call(other.account, 'alice')
     end
 
@@ -84,6 +86,32 @@ RSpec.describe Api::V1::NotificationsController, type: :controller do
       end
     end
 
+    describe 'from specified user' do
+      before do
+        get :index, params: { from_account: 'carol' }
+      end
+
+      it 'returns http success' do
+        expect(response).to have_http_status(200)
+      end
+
+      it 'includes favourite' do
+        expect(assigns(:notifications).map(&:activity)).to include(@second_favourite)
+      end
+
+      it 'excludes favourite' do
+        expect(assigns(:notifications).map(&:activity)).to_not include(@favourite)
+      end
+
+      it 'excludes mention' do
+        expect(assigns(:notifications).map(&:activity)).to_not include(@mention_from_status)
+      end
+
+      it 'excludes reblog' do
+        expect(assigns(:notifications).map(&:activity)).to_not include(@reblog_of_first_status)
+      end
+    end
+
     describe 'with excluded mentions' do
       before do
         get :index, params: { exclude_types: ['mention'] }
@@ -103,6 +131,10 @@ RSpec.describe Api::V1::NotificationsController, type: :controller do
 
       it 'includes favourite' do
         expect(assigns(:notifications).map(&:activity)).to include(@favourite)
+      end
+
+      it 'includes third favourite' do
+        expect(assigns(:notifications).map(&:activity)).to include(@second_favourite)
       end
 
       it 'includes follow' do


### PR DESCRIPTION
This adds the ability to filter notifications by the account they originated from. Currently there is no UI for this, it only adds the ability to the API.