### PR TITLE
Make headers font size proportional

### DIFF
--- a/app/javascript/flavours/glitch/styles/components/status.scss
+++ b/app/javascript/flavours/glitch/styles/components/status.scss
@@ -40,11 +40,11 @@
 
     h1, h2 {
       font-weight: 700;
-      font-size: 18px;
+      font-size: 1.2em;
     }
 
     h2 {
-      font-size: 16px;
+      font-size: 1.1em;
     }
 
     h3, h4, h5 {


### PR DESCRIPTION
Headers were smaller than text in detailed statuses