### PR TITLE
Allow rel=tag in status text

### DIFF
--- a/app/lib/sanitize_config.rb
+++ b/app/lib/sanitize_config.rb
@@ -31,7 +31,7 @@ class Sanitize
 
       add_attributes: {
         'a' => {
-          'rel' => 'nofollow noopener',
+          'rel' => 'nofollow noopener tag',
           'target' => '_blank',
         },
       },


### PR DESCRIPTION
Fixes tag links in local Markdown or HTML-authored statuses