### PR TITLE
Translate incoming remote img tags by a link

### DIFF
--- a/app/lib/sanitize_config.rb
+++ b/app/lib/sanitize_config.rb
@@ -19,6 +19,17 @@ class Sanitize
       node['class'] = class_list.join(' ')
     end
 
+    IMG_TAG_TRANSFORMER = lambda do |env|
+      node = env[:node]
+
+      return unless env[:node_name] == 'img'
+
+      node.name = 'a'
+
+      node['href'] = node['src']
+      node.content = "[🖼 #{node['alt'] || node['href']}]"
+    end
+
     MASTODON_STRICT ||= freeze_config(
       elements: %w(p br span a abbr del pre blockquote code b strong u sub i em h1 h2 h3 h4 h5 ul ol li),
 
@@ -43,6 +54,7 @@ class Sanitize
 
       transformers: [
         CLASS_WHITELIST_TRANSFORMER,
+        IMG_TAG_TRANSFORMER,
       ]
     )
 

--- a/app/lib/sanitize_config.rb
+++ b/app/lib/sanitize_config.rb
@@ -27,7 +27,15 @@ class Sanitize
       node.name = 'a'
 
       node['href'] = node['src']
-      node.content = "[🖼 #{node['alt'] || node['href']}]"
+      if node['alt'].present?
+        node.content = "[🖼  #{node['alt']}]"
+      else
+        url = node['href']
+        prefix = url.match(/\Ahttps?:\/\/(www\.)?/).to_s
+        text   = url[prefix.length, 30]
+        text   = text + "…" if url[prefix.length..-1].length > 30
+        node.content = "[🖼  #{text}]"
+      end
     end
 
     MASTODON_STRICT ||= freeze_config(


### PR DESCRIPTION
## Toot authored from pleroma, displayed there

![image](https://user-images.githubusercontent.com/384364/58386734-43f70f00-8004-11e9-8ad0-c47469f221c4.png)

## On glitch-soc without the patch

![image](https://user-images.githubusercontent.com/384364/58386741-5f621a00-8004-11e9-945f-ae7b548a9e51.png)

## On glitch-soc with the patch

![image](https://user-images.githubusercontent.com/384364/58386743-76087100-8004-11e9-8cca-8d2e100c6f03.png)