### PR TITLE
Raise exception when attempting to serialize local-only statuses

### DIFF
--- a/app/serializers/activitypub/note_serializer.rb
+++ b/app/serializers/activitypub/note_serializer.rb
@@ -25,6 +25,7 @@ class ActivityPub::NoteSerializer < ActivityPub::Serializer
   attribute :closed, if: :poll_and_expired?
 
   def id
+    raise Mastodon::NotPermittedError, 'Local-only statuses should not be serialized' if object.local_only?
     ActivityPub::TagManager.instance.uri_for(object)
   end
 


### PR DESCRIPTION
There have been issues with local-only toots leaking in the past. While I think they are all fixed, it doesn't hurt to have some safety net. Raising in the ActivityPub serializer should avoid that.