### PR TITLE
Fix some prop-types issues

### DIFF
--- a/app/javascript/flavours/glitch/components/autosuggest_input.js
+++ b/app/javascript/flavours/glitch/components/autosuggest_input.js
@@ -49,7 +49,7 @@ export default class AutosuggestInput extends ImmutablePureComponent {
     autoFocus: PropTypes.bool,
     className: PropTypes.string,
     id: PropTypes.string,
-    searchTokens: PropTypes.list,
+    searchTokens: PropTypes.arrayOf(PropTypes.string),
     maxLength: PropTypes.number,
   };
 

--- a/app/javascript/flavours/glitch/features/compose/components/reply_indicator.js
+++ b/app/javascript/flavours/glitch/features/compose/components/reply_indicator.js
@@ -26,7 +26,7 @@ export default @injectIntl
 class ReplyIndicator extends ImmutablePureComponent {
 
   static propTypes = {
-    status: ImmutablePropTypes.map.isRequired,
+    status: ImmutablePropTypes.map,
     intl: PropTypes.object.isRequired,
     onCancel: PropTypes.func,
   };


### PR DESCRIPTION
Patches some prop types errors.

* `PropTypes.list` doesn't exist, probably a typo. Switched to whatever upstream is using for that prop.
* `isRequired` fails under `null`, which is normal. `status` can be `null` in `<ReplyIndicator>`, simply remove `isRequired`.