### PR TITLE
Add env variable to control search limit

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -3,7 +3,7 @@
 class Api::V1::SearchController < Api::BaseController
   include Authorization
 
-  RESULTS_LIMIT = 20
+  RESULTS_LIMIT = (ENV['MAX_SEARCH_RESULTS'] || 20).to_i
 
   before_action -> { doorkeeper_authorize! :read, :'read:search' }
   before_action :require_user!

--- a/db/migrate/20171009222537_create_keyword_mutes.rb
+++ b/db/migrate/20171009222537_create_keyword_mutes.rb
@@ -7,6 +7,6 @@ class CreateKeywordMutes < ActiveRecord::Migration[5.1]
       t.timestamps
     end
 
-    add_foreign_key :keyword_mutes, :accounts, on_delete: :cascade
+    safety_assured { add_foreign_key :keyword_mutes, :accounts, on_delete: :cascade }
   end
 end

--- a/db/migrate/20180410220657_create_bookmarks.rb
+++ b/db/migrate/20180410220657_create_bookmarks.rb
@@ -7,8 +7,8 @@ class CreateBookmarks < ActiveRecord::Migration[5.1]
       t.timestamps
     end
 
-    add_foreign_key :bookmarks, :accounts, column: :account_id, on_delete: :cascade
-    add_foreign_key :bookmarks, :statuses, column: :status_id, on_delete: :cascade
+    safety_assured { add_foreign_key :bookmarks, :accounts, column: :account_id, on_delete: :cascade }
+    safety_assured { add_foreign_key :bookmarks, :statuses, column: :status_id, on_delete: :cascade }
     add_index :bookmarks, [:account_id, :status_id], unique: true
   end
 end


### PR DESCRIPTION
I changed the default search limit to allow a variable called MAX_SEARCH_RESULTS in the .env.production file to change the maximum search results limit since my instances usually run either 100 or 150 results maximum and itd be nice to not have to change that back every update.