### PR TITLE
Added env variables for max image and video size.

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -162,9 +162,9 @@ STREAMING_CLUSTER_NUM=1
 
 # Maximum image and video upload sizes
 # Units are in bytes
-# 1024 bytes equals 1 megabyte
-# MAX_IMAGE_SIZE=8192
-# MAX_VIDEO_SIZE=40960
+# 1048576 bytes equals 1 megabyte
+# MAX_IMAGE_SIZE=8388608
+# MAX_VIDEO_SIZE=41943040
 
 # LDAP authentication (optional)
 # LDAP_ENABLED=true

--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -101,8 +101,8 @@ class MediaAttachment < ApplicationRecord
     },
   }.freeze
 
-  IMAGE_LIMIT = 8.megabytes
-  VIDEO_LIMIT = 40.megabytes
+  IMAGE_LIMIT = (ENV['MAX_IMAGE_SIZE'] || 8.megabytes).to_i
+  VIDEO_LIMIT = (ENV['MAX_VIDEO_SIZE'] || 40.megabytes).to_i
 
   belongs_to :account,          inverse_of: :media_attachments, optional: true
   belongs_to :status,           inverse_of: :media_attachments, optional: true


### PR DESCRIPTION
I changed the IMAGE_LIMIT and VIDEO_LIMIT variables to read from the env, or use default if not set in the env, to make it easier to change this on an instance by instance basis and make it persistent across updates.