### PR TITLE
Add audio length var to env sample

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -175,6 +175,9 @@ STREAMING_CLUSTER_NUM=1
 # MAX_IMAGE_SIZE=8388608
 # MAX_VIDEO_SIZE=41943040
 
+# Maximum length of audio uploads in seconds
+# MAX_AUDIO_LENGTH=60
+
 # LDAP authentication (optional)
 # LDAP_ENABLED=true
 # LDAP_HOST=localhost


### PR DESCRIPTION
Added MAX_AUDIO_LENGTH var and documented in .env.production.sample which is an already implemented variable from a while back.