### PR TITLE
Fix display of alt-text when a media attachment is not available

### DIFF
--- a/app/javascript/flavours/glitch/styles/components/media.scss
+++ b/app/javascript/flavours/glitch/styles/components/media.scss
@@ -117,7 +117,6 @@
   display: block;
   text-decoration: none;
   color: $secondary-text-color;
-  line-height: 0;
   position: relative;
   z-index: 1;
 


### PR DESCRIPTION
Not perfect, but still an improvement.

## Before

![image](https://user-images.githubusercontent.com/384364/59029972-f4b0aa00-885f-11e9-96e9-586a0cbf8987.png)

## After

![image](https://user-images.githubusercontent.com/384364/59030061-2fb2dd80-8860-11e9-8979-fb6cb950ea4f.png)
