### PR TITLE
Fix composer buttons overflowing the composer box in single-column

### DIFF
--- a/app/javascript/flavours/glitch/styles/components/composer.scss
+++ b/app/javascript/flavours/glitch/styles/components/composer.scss
@@ -586,6 +586,7 @@
   white-space: nowrap;
   overflow: hidden;
   justify-content: flex-end;
+  flex: 0 0 auto;
 
   & > .count {
     display: inline-block;


### PR DESCRIPTION
Fix this:
![image](https://user-images.githubusercontent.com/384364/59564740-bcbd1a00-904a-11e9-99b2-95418f8df326.png)
