### PR TITLE
Make single-column stretch to full width when below smallest mobile breakpoint

### DIFF
--- a/app/javascript/flavours/glitch/styles/components/single_column.scss
+++ b/app/javascript/flavours/glitch/styles/components/single_column.scss
@@ -206,6 +206,10 @@
   .columns-area__panels__pane--compositional {
     display: none;
   }
+
+  .columns-area__panels__main {
+    max-width: 100%;
+  }
 }
 
 @media screen and (min-width: 600px + (285px * 1) + (10px * 1)) {


### PR DESCRIPTION
I'm actually not too sure about this one…

## Before

![image](https://user-images.githubusercontent.com/384364/59568563-9b752180-907c-11e9-82cf-5f021131df6e.png)

## After

![image](https://user-images.githubusercontent.com/384364/59568587-fc9cf500-907c-11e9-8e1b-43ea0e036785.png)
