### PR TITLE
Change plaintext icon in composer options

### DIFF
--- a/app/javascript/flavours/glitch/features/compose/components/options.js
+++ b/app/javascript/flavours/glitch/features/compose/components/options.js
@@ -232,7 +232,7 @@ class ComposerOptions extends ImmutablePureComponent {
 
     const contentTypeItems = {
       plain: {
-        icon: 'align-left',
+        icon: 'file-text',
         name: 'text/plain',
         text: <FormattedMessage {...messages.plain} />,
       },


### PR DESCRIPTION
Suggested here https://witches.live/@anna/102289364073058882 (took `file-text` instead of `file-text`, it is more consistent with the other mostly-filled icons)

## Before

![image](https://user-images.githubusercontent.com/384364/59693277-ead76100-91e6-11e9-837b-0f0d1d2b1da7.png)

## After

![image](https://user-images.githubusercontent.com/384364/59693220-d98e5480-91e6-11e9-87fb-e5c78b636a79.png)
