### PR TITLE
Improve status icons

### DIFF
--- a/app/javascript/flavours/glitch/components/status_icons.js
+++ b/app/javascript/flavours/glitch/components/status_icons.js
@@ -13,12 +13,12 @@ const messages = defineMessages({
   collapse: { id: 'status.collapse', defaultMessage: 'Collapse' },
   uncollapse: { id: 'status.uncollapse', defaultMessage: 'Uncollapse' },
   inReplyTo: { id: 'status.in_reply_to', defaultMessage: 'This toot is a reply' },
-  previewCard: { id: 'status.has_preview_card', defaultMessage: 'This toot features an attached preview card' },
-  pictures: { id: 'status.has_pictures', defaultMessage: 'This toot features attached pictures' },
+  previewCard: { id: 'status.has_preview_card', defaultMessage: 'Features an attached preview card' },
+  pictures: { id: 'status.has_pictures', defaultMessage: 'Features attached pictures' },
   poll: { id: 'status.is_poll', defaultMessage: 'This toot is a poll' },
-  video: { id: 'status.has_video', defaultMessage: 'This toot features attached videos' },
-  audio: { id: 'status.has_audio', defaultMessage: 'This toot features attached audio files' },
-  localOnly: { id: 'status.local_only', defaultMessage: 'This toot is only visible from youre instance' },
+  video: { id: 'status.has_video', defaultMessage: 'Features attached videos' },
+  audio: { id: 'status.has_audio', defaultMessage: 'Features attached audio files' },
+  localOnly: { id: 'status.local_only', defaultMessage: 'Only visible from your instance' },
 });
 
 @injectIntl

--- a/app/javascript/flavours/glitch/components/status_icons.js
+++ b/app/javascript/flavours/glitch/components/status_icons.js
@@ -18,6 +18,7 @@ const messages = defineMessages({
   poll: { id: 'status.is_poll', defaultMessage: 'This toot is a poll' },
   video: { id: 'status.has_video', defaultMessage: 'This toot features attached videos' },
   audio: { id: 'status.has_audio', defaultMessage: 'This toot features attached audio files' },
+  localOnly: { id: 'status.local_only', defaultMessage: 'This toot is only visible from youre instance' },
 });
 
 @injectIntl
@@ -79,6 +80,12 @@ export default class StatusIcons extends React.PureComponent {
             title={intl.formatMessage(messages.inReplyTo)}
           />
         ) : null}
+        {status.get('local_only') &&
+          <i
+            className={`fa fa-fw fa-home`}
+            aria-hidden='true'
+            title={intl.formatMessage(messages.localOnly)}
+          />}
         {mediaIcon ? (
           <i
             className={`fa fa-fw fa-${mediaIcon} status__media-icon`}

--- a/app/javascript/flavours/glitch/components/status_icons.js
+++ b/app/javascript/flavours/glitch/components/status_icons.js
@@ -12,6 +12,12 @@ import VisibilityIcon from './status_visibility_icon';
 const messages = defineMessages({
   collapse: { id: 'status.collapse', defaultMessage: 'Collapse' },
   uncollapse: { id: 'status.uncollapse', defaultMessage: 'Uncollapse' },
+  inReplyTo: { id: 'status.in_reply_to', defaultMessage: 'This toot is a reply' },
+  previewCard: { id: 'status.has_preview_card', defaultMessage: 'This toot features an attached preview card' },
+  pictures: { id: 'status.has_pictures', defaultMessage: 'This toot features attached pictures' },
+  poll: { id: 'status.is_poll', defaultMessage: 'This toot is a poll' },
+  video: { id: 'status.has_video', defaultMessage: 'This toot features attached videos' },
+  audio: { id: 'status.has_audio', defaultMessage: 'This toot features attached audio files' },
 });
 
 @injectIntl
@@ -36,6 +42,23 @@ export default class StatusIcons extends React.PureComponent {
     }
   }
 
+  mediaIconTitleText () {
+    const { intl, mediaIcon } = this.props;
+
+    switch (mediaIcon) {
+      case 'link':
+        return intl.formatMessages(message.previewCard);
+      case 'picture-o':
+        return intl.formatMessage(messages.pictures);
+      case 'tasks':
+        return intl.formatMessage(messages.poll);
+      case 'video-camera':
+        return intl.formatMessage(messages.video);
+      case 'music':
+        return intl.formatMessage(messages.audio);
+    }
+  }
+
   //  Rendering.
   render () {
     const {
@@ -53,12 +76,14 @@ export default class StatusIcons extends React.PureComponent {
           <i
             className={`fa fa-fw fa-comment status__reply-icon`}
             aria-hidden='true'
+            title={intl.formatMessage(messages.inReplyTo)}
           />
         ) : null}
         {mediaIcon ? (
           <i
             className={`fa fa-fw fa-${mediaIcon} status__media-icon`}
             aria-hidden='true'
+            title={this.mediaIconTitleText()}
           />
         ) : null}
         {!directMessage && <VisibilityIcon visibility={status.get('visibility')} />}


### PR DESCRIPTION
## Add icon for local-only toots

I have seen people posting toots they thought were local-only but weren't because they had other characters after the eye emoji, or the eye emoji wasn't the correct one. This should address that issue. Will also be useful when/if we get rid of the eye emoji behavior entirely.

This is how a local-only toot with the most possible status icons looks like:
![image](https://user-images.githubusercontent.com/384364/61298150-016cda00-a7de-11e9-8d05-fcf5940069e2.png)

## Add tooltips to the status icons

Status icons (especially the one for replies) may be confusing, adding tooltips should help.
Here are how they read:
- “This toot is a reply”
- “Features an attached preview card”
- “Features attached pictures”
- “Features attached videos”
- “Features attached audio files”
- “This toot is a poll”
- “Only visible from your instance”