### PR TITLE
Add options to highlight misleading links in statuses text

### DIFF
--- a/app/javascript/flavours/glitch/components/status.js
+++ b/app/javascript/flavours/glitch/components/status.js
@@ -699,6 +699,7 @@ class Status extends ImmutablePureComponent {
             onExpandedToggle={this.handleExpandedToggle}
             parseClick={parseClick}
             disabled={!router}
+            linkRewriting={settings.get('link_rewriting')}
           />
           {!isCollapsed || !(muted || !settings.getIn(['collapsed', 'show_action_bar'])) ? (
             <StatusActionBar

--- a/app/javascript/flavours/glitch/components/status.js
+++ b/app/javascript/flavours/glitch/components/status.js
@@ -699,7 +699,7 @@ class Status extends ImmutablePureComponent {
             onExpandedToggle={this.handleExpandedToggle}
             parseClick={parseClick}
             disabled={!router}
-            linkRewriting={settings.get('link_rewriting')}
+            tagLinks={settings.get('tag_misleading_links')}
           />
           {!isCollapsed || !(muted || !settings.getIn(['collapsed', 'show_action_bar'])) ? (
             <StatusActionBar

--- a/app/javascript/flavours/glitch/components/status_content.js
+++ b/app/javascript/flavours/glitch/components/status_content.js
@@ -54,7 +54,7 @@ const isLinkMisleading = (link, checkUrlLike = true) => {
   const targetURL = new URL(link.href);
 
   // The following may not work with international domain names
-  if (linkText === targetURL.origin || linkText === targetURL.host || 'www.' + linkText === targetURL.host || linkText.startsWith(targetURL.origin + '/') || linkText.startsWith(targetURL.host + '/')) {
+  if (linkText === targetURL.origin || linkText === targetURL.host || 'www.' + linkText === targetURL.host || linkText.startsWith(targetURL.origin + '/') || linkText.startsWith(targetURL.host + '/') || ('www.' + linkText).startsWith(targetURL.host + '/')) {
     return false;
   }
 
@@ -62,7 +62,7 @@ const isLinkMisleading = (link, checkUrlLike = true) => {
   const hostname = decodeIDNA(targetURL.hostname);
   const host = targetURL.host.replace(targetURL.hostname, hostname);
   const origin = targetURL.origin.replace(targetURL.host, host);
-  if (linkText === origin || linkText === host || linkText.startsWith(origin + '/') || linkText.startsWith(host + '/')) {
+  if (linkText === origin || linkText === host || 'www.' + linkText === host || linkText.startsWith(origin + '/') || linkText.startsWith(host + '/') || ('www.' + linkText).startsWith(host + '/')) {
     return false;
   }
 

--- a/app/javascript/flavours/glitch/components/status_content.js
+++ b/app/javascript/flavours/glitch/components/status_content.js
@@ -65,10 +65,11 @@ const isLinkMisleading = (link, checkUrlLike = true) => {
   }
 
   // The link hasn't been recognized, maybe it features an international domain name
-  const hostname = decodeIDNA(targetURL.hostname);
+  const hostname = decodeIDNA(targetURL.hostname).normalize('NFKC');
   const host = targetURL.host.replace(targetURL.hostname, hostname);
   const origin = targetURL.origin.replace(targetURL.host, host);
-  if (textMatchesTarget(linkText, origin, host)) {
+  const text = linkText.normalize('NFKC');
+  if (textMatchesTarget(text, origin, host) || textMatchesTarget(text.toLowerCase(), origin, host)) {
     return false;
   }
 

--- a/app/javascript/flavours/glitch/components/status_content.js
+++ b/app/javascript/flavours/glitch/components/status_content.js
@@ -280,6 +280,7 @@ export default class StatusContent extends React.PureComponent {
       mediaIcon,
       parseClick,
       disabled,
+      linkRewriting,
     } = this.props;
 
     const hidden = this.props.onExpandedToggle ? !this.props.expanded : this.state.hidden;
@@ -354,6 +355,7 @@ export default class StatusContent extends React.PureComponent {
           <div className={`status__content__spoiler ${!hidden ? 'status__content__spoiler--visible' : ''}`}>
             <div
               ref={this.setContentsRef}
+              key={`contents-${linkRewriting}`}
               style={directionStyle}
               tabIndex={!hidden ? 0 : null}
               dangerouslySetInnerHTML={content}
@@ -377,6 +379,7 @@ export default class StatusContent extends React.PureComponent {
         >
           <div
             ref={this.setContentsRef}
+            key={`contents-${linkRewriting}`}
             dangerouslySetInnerHTML={content}
             lang={status.get('language')}
             className='status__content__text'
@@ -393,7 +396,7 @@ export default class StatusContent extends React.PureComponent {
           tabIndex='0'
           ref={this.setRef}
         >
-          <div ref={this.setContentsRef} className='status__content__text' dangerouslySetInnerHTML={content} lang={status.get('language')} tabIndex='0' />
+          <div ref={this.setContentsRef} key={`contents-${linkRewriting}`} className='status__content__text' dangerouslySetInnerHTML={content} lang={status.get('language')} tabIndex='0' />
           {media}
         </div>
       );

--- a/app/javascript/flavours/glitch/components/status_content.js
+++ b/app/javascript/flavours/glitch/components/status_content.js
@@ -25,6 +25,12 @@ const dot_confusables = '.\u002e\u0660\u06f0\u0701\u0702\u2024\ua4f8\ua60e\u10a5
 
 const linkRegex = new RegExp(`^\\s*(([${h_confusables}][${t_confusables}][${t_confusables}][${p_confusables}][${s_confusables}]?[${column_confusables}][${slash_confusables}][${slash_confusables}]))?[^:/\\n ]+([${dot_confusables}][^:/\\n ]+)+`);
 
+const textMatchesTarget = (text, origin, host) => {
+  return (text === origin || text === host
+          || text.startsWith(origin + '/') || text.startsWith(host + '/')
+          || 'www.' + text === host || ('www.' + text).startsWith(host + '/'));
+}
+
 // If `checkUrlLike` is true, consider only URL-like link texts to be misleading
 const isLinkMisleading = (link, checkUrlLike = true) => {
   let linkTextParts = [];
@@ -54,7 +60,7 @@ const isLinkMisleading = (link, checkUrlLike = true) => {
   const targetURL = new URL(link.href);
 
   // The following may not work with international domain names
-  if (linkText === targetURL.origin || linkText === targetURL.host || 'www.' + linkText === targetURL.host || linkText.startsWith(targetURL.origin + '/') || linkText.startsWith(targetURL.host + '/') || ('www.' + linkText).startsWith(targetURL.host + '/')) {
+  if (textMatchesTarget(linkText, targetURL.origin, targetURL.host) || textMatchesTarget(linkText.toLowerCase(), targetURL.origin, targetURL.host)) {
     return false;
   }
 
@@ -62,7 +68,7 @@ const isLinkMisleading = (link, checkUrlLike = true) => {
   const hostname = decodeIDNA(targetURL.hostname);
   const host = targetURL.host.replace(targetURL.hostname, hostname);
   const origin = targetURL.origin.replace(targetURL.host, host);
-  if (linkText === origin || linkText === host || 'www.' + linkText === host || linkText.startsWith(origin + '/') || linkText.startsWith(host + '/') || ('www.' + linkText).startsWith(host + '/')) {
+  if (textMatchesTarget(linkText, origin, host)) {
     return false;
   }
 

--- a/app/javascript/flavours/glitch/components/status_content.js
+++ b/app/javascript/flavours/glitch/components/status_content.js
@@ -8,31 +8,13 @@ import classnames from 'classnames';
 import { autoPlayGif } from 'flavours/glitch/util/initial_state';
 import { decode as decodeIDNA } from 'flavours/glitch/util/idna';
 
-// Regex matching what "looks like a link", that is, something that starts with
-// an optional "http://" or "https://" scheme and then what could look like a
-// domain main, that is, at least two sequences of characters not including spaces
-// and separated by "." or an homoglyph. The idea is not to match valid URLs or
-// domain names, but what could be confused for a valid URL or domain name,
-// especially to the untrained eye.
-
-const h_confusables = 'h\u13c2\u1d58d\u1d4f1\u1d691\u0068\uff48\u1d525\u210e\u1d489\u1d629\u0570\u1d4bd\u1d65d\u1d421\u1d5c1\u1d5f5\u04bb\u1d559';
-const t_confusables = 't\u1d42d\u1d5cd\u1d531\u1d565\u1d4c9\u1d669\u1d4fd\u1d69d\u0074\u1d461\u1d601\u1d495\u1d635\u1d599';
-const p_confusables = 'p\u0440\u03c1\u1d52d\u1d631\u1d665\u1d429\uff50\u1d6e0\u1d45d\u1d561\u1d595\u1d71a\u1d699\u1d78e\u2ca3\u1d754\u1d6d2\u1d491\u1d7c8\u1d746\u1d4c5\u1d70c\u1d5c9\u0070\u1d780\u03f1\u1d5fd\u2374\u1d7ba\u1d4f9';
-const s_confusables = 's\u1d530\u118c1\u1d494\u1d634\u1d4c8\u1d668\uabaa\u1d42c\u1d5cc\u1d460\u1d600\ua731\u0073\uff53\u1d564\u0455\u1d598\u1d4fc\u1d69c\u10448\u01bd';
-const column_confusables = ':\u0903\u0a83\u0703\u1803\u05c3\u0704\u0589\u1809\ua789\u16ec\ufe30\u02d0\u2236\u02f8\u003a\uff1a\u205a\ua4fd';
-const slash_confusables = '/\u2041\u2f03\u2044\u2cc6\u27cb\u30ce\u002f\u2571\u31d3\u3033\u1735\u2215\u29f8\u1d23a\u4e3f';
-const dot_confusables = '.\u002e\u0660\u06f0\u0701\u0702\u2024\ua4f8\ua60e\u10a50\u1d16d';
-
-const linkRegex = new RegExp(`^\\s*(([${h_confusables}][${t_confusables}][${t_confusables}][${p_confusables}][${s_confusables}]?[${column_confusables}][${slash_confusables}][${slash_confusables}]))?[^:/\\n ]+([${dot_confusables}][^:/\\n ]+)+`);
-
 const textMatchesTarget = (text, origin, host) => {
   return (text === origin || text === host
           || text.startsWith(origin + '/') || text.startsWith(host + '/')
           || 'www.' + text === host || ('www.' + text).startsWith(host + '/'));
 }
 
-// If `checkUrlLike` is true, consider only URL-like link texts to be misleading
-const isLinkMisleading = (link, checkUrlLike = true) => {
+const isLinkMisleading = (link) => {
   let linkTextParts = [];
 
   // Reconstruct visible text, as we do not have much control over how links
@@ -69,12 +51,7 @@ const isLinkMisleading = (link, checkUrlLike = true) => {
   const host = targetURL.host.replace(targetURL.hostname, hostname);
   const origin = targetURL.origin.replace(targetURL.host, host);
   const text = linkText.normalize('NFKC');
-  if (textMatchesTarget(text, origin, host) || textMatchesTarget(text.toLowerCase(), origin, host)) {
-    return false;
-  }
-
-  // If the link text looks like an URL or auto-generated link, it is misleading
-  return !checkUrlLike || linkRegex.test(linkText);
+  return !(textMatchesTarget(text, origin, host) || textMatchesTarget(text.toLowerCase(), origin, host));
 };
 
 export default class StatusContent extends React.PureComponent {
@@ -89,11 +66,11 @@ export default class StatusContent extends React.PureComponent {
     parseClick: PropTypes.func,
     disabled: PropTypes.bool,
     onUpdate: PropTypes.func,
-    linkRewriting: PropTypes.string,
+    tagLinks: PropTypes.bool,
   };
 
   static defaultProps = {
-    linkRewriting: 'tag',
+    tagLinks: true,
   };
 
   state = {
@@ -102,7 +79,7 @@ export default class StatusContent extends React.PureComponent {
 
   _updateStatusLinks () {
     const node = this.contentsNode;
-    const { linkRewriting } = this.props;
+    const { tagLinks } = this.props;
 
     if (!node) {
       return;
@@ -129,35 +106,7 @@ export default class StatusContent extends React.PureComponent {
         link.setAttribute('title', link.href);
         link.classList.add('unhandled-link');
 
-        if (linkRewriting === 'rewrite' && isLinkMisleading(link)) {
-          // Rewrite misleading links entirely
-
-          while (link.firstChild) {
-            link.removeChild(link.firstChild);
-          }
-
-          const prefix = (link.href.match(/https?:\/\/(www\.)?/) || [''])[0];
-          const text   = link.href.substr(prefix.length, 30);
-          const suffix = link.href.substr(prefix.length + 30);
-          const cutoff = !!suffix;
-
-          const prefixTag = document.createElement('span');
-          prefixTag.classList.add('invisible');
-          prefixTag.textContent = prefix;
-          link.appendChild(prefixTag);
-
-          const textTag = document.createElement('span');
-          if (cutoff) {
-            textTag.classList.add('ellipsis');
-          }
-          textTag.textContent = text;
-          link.appendChild(textTag);
-
-          const suffixTag = document.createElement('span');
-          suffixTag.classList.add('invisible');
-          suffixTag.textContent = suffix;
-          link.appendChild(suffixTag);
-        } else if (linkRewriting === 'tag' && isLinkMisleading(link, false)) {
+        if (tagLinks && isLinkMisleading(link)) {
           // Add a tag besides the link to display its origin
 
           const tag = document.createElement('span');
@@ -287,7 +236,7 @@ export default class StatusContent extends React.PureComponent {
       mediaIcon,
       parseClick,
       disabled,
-      linkRewriting,
+      tagLinks,
     } = this.props;
 
     const hidden = this.props.onExpandedToggle ? !this.props.expanded : this.state.hidden;
@@ -362,7 +311,7 @@ export default class StatusContent extends React.PureComponent {
           <div className={`status__content__spoiler ${!hidden ? 'status__content__spoiler--visible' : ''}`}>
             <div
               ref={this.setContentsRef}
-              key={`contents-${linkRewriting}`}
+              key={`contents-${tagLinks}`}
               style={directionStyle}
               tabIndex={!hidden ? 0 : null}
               dangerouslySetInnerHTML={content}
@@ -386,7 +335,7 @@ export default class StatusContent extends React.PureComponent {
         >
           <div
             ref={this.setContentsRef}
-            key={`contents-${linkRewriting}`}
+            key={`contents-${tagLinks}`}
             dangerouslySetInnerHTML={content}
             lang={status.get('language')}
             className='status__content__text'
@@ -403,7 +352,7 @@ export default class StatusContent extends React.PureComponent {
           tabIndex='0'
           ref={this.setRef}
         >
-          <div ref={this.setContentsRef} key={`contents-${linkRewriting}`} className='status__content__text' dangerouslySetInnerHTML={content} lang={status.get('language')} tabIndex='0' />
+          <div ref={this.setContentsRef} key={`contents-${tagLinks}`} className='status__content__text' dangerouslySetInnerHTML={content} lang={status.get('language')} tabIndex='0' />
           {media}
         </div>
       );

--- a/app/javascript/flavours/glitch/features/local_settings/page/index.js
+++ b/app/javascript/flavours/glitch/features/local_settings/page/index.js
@@ -25,9 +25,6 @@ const messages = defineMessages({
   filters_upstream: { id: 'settings.filtering_behavior.upstream', defaultMessage: 'Show "filtered" like vanilla Mastodon' },
   filters_hide: { id: 'settings.filtering_behavior.hide', defaultMessage: 'Show "filtered" and add a button to display why' },
   filters_cw: { id: 'settings.filtering_behavior.cw', defaultMessage: 'Still display the post, and add filtered words to content warning' },
-  link_rewriting_none: { id: 'settings.link_rewriting.none', defaultMessage: 'Do not rewrite links' },
-  link_rewriting_rewrite: { id: 'settings.link_rewriting.rewrite', defaultMessage: 'Rewrite links that may be misleading' },
-  link_rewriting_tag: { id: 'settings.link_rewriting.tag', defaultMessage: 'Tag links with their target host unless it is already explicit' },
 });
 
 @injectIntl
@@ -71,16 +68,12 @@ export default class LocalSettingsPage extends React.PureComponent {
         </LocalSettingsPageItem>
         <LocalSettingsPageItem
           settings={settings}
-          item={['link_rewriting']}
-          id='mastodon-settings--link_rewriting'
-          options={[
-            { value: 'none', message: intl.formatMessage(messages.link_rewriting_none) },
-            { value: 'rewrite', message: intl.formatMessage(messages.link_rewriting_rewrite) },
-            { value: 'tag', message: intl.formatMessage(messages.link_rewriting_tag) },
-          ]}
+          item={['tag_misleading_links']}
+          id='mastodon-settings--tag_misleading_links'
           onChange={onChange}
         >
-          <FormattedMessage id='settings.link_rewriting' defaultMessage='Link rewriting' />
+          <FormattedMessage id='settings.tag_misleading_links' defaultMessage='Tag misleading links' />
+          <span className='hint'><FormattedMessage id='settings.tag_misleading_links.hint' defaultMessage="Add a visual indication with the link target host to every link not mentioning it explicitly" /></span>
         </LocalSettingsPageItem>
         <section>
           <h2><FormattedMessage id='settings.notifications_opts' defaultMessage='Notifications options' /></h2>

--- a/app/javascript/flavours/glitch/features/local_settings/page/index.js
+++ b/app/javascript/flavours/glitch/features/local_settings/page/index.js
@@ -25,6 +25,9 @@ const messages = defineMessages({
   filters_upstream: { id: 'settings.filtering_behavior.upstream', defaultMessage: 'Show "filtered" like vanilla Mastodon' },
   filters_hide: { id: 'settings.filtering_behavior.hide', defaultMessage: 'Show "filtered" and add a button to display why' },
   filters_cw: { id: 'settings.filtering_behavior.cw', defaultMessage: 'Still display the post, and add filtered words to content warning' },
+  link_rewriting_none: { id: 'settings.link_rewriting.none', defaultMessage: 'Do not rewrite links' },
+  link_rewriting_rewrite: { id: 'settings.link_rewriting.rewrite', defaultMessage: 'Rewrite links that may be misleading' },
+  link_rewriting_tag: { id: 'settings.link_rewriting.tag', defaultMessage: 'Tag links with their target host unless it is already explicit' },
 });
 
 @injectIntl
@@ -65,6 +68,19 @@ export default class LocalSettingsPage extends React.PureComponent {
           onChange={onChange}
         >
           <FormattedMessage id='settings.confirm_boost_missing_media_description' defaultMessage='Show confirmation dialog before boosting toots lacking media descriptions' />
+        </LocalSettingsPageItem>
+        <LocalSettingsPageItem
+          settings={settings}
+          item={['link_rewriting']}
+          id='mastodon-settings--link_rewriting'
+          options={[
+            { value: 'none', message: intl.formatMessage(messages.link_rewriting_none) },
+            { value: 'rewrite', message: intl.formatMessage(messages.link_rewriting_rewrite) },
+            { value: 'tag', message: intl.formatMessage(messages.link_rewriting_tag) },
+          ]}
+          onChange={onChange}
+        >
+          <FormattedMessage id='settings.link_rewriting' defaultMessage='Link rewriting' />
         </LocalSettingsPageItem>
         <section>
           <h2><FormattedMessage id='settings.notifications_opts' defaultMessage='Notifications options' /></h2>

--- a/app/javascript/flavours/glitch/features/status/components/card.js
+++ b/app/javascript/flavours/glitch/features/status/components/card.js
@@ -4,15 +4,7 @@ import Immutable from 'immutable';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import punycode from 'punycode';
 import classnames from 'classnames';
-
-const IDNA_PREFIX = 'xn--';
-
-const decodeIDNA = domain => {
-  return domain
-    .split('.')
-    .map(part => part.indexOf(IDNA_PREFIX) === 0 ? punycode.decode(part.slice(IDNA_PREFIX.length)) : part)
-    .join('.');
-};
+import { decode as decodeIDNA } from 'flavours/glitch/util/idna';
 
 const getHostname = url => {
   const parser = document.createElement('a');

--- a/app/javascript/flavours/glitch/features/status/components/detailed_status.js
+++ b/app/javascript/flavours/glitch/features/status/components/detailed_status.js
@@ -241,7 +241,7 @@ export default class DetailedStatus extends ImmutablePureComponent {
             onExpandedToggle={onToggleHidden}
             parseClick={this.parseClick}
             onUpdate={this.handleChildUpdate}
-            linkRewriting={settings.get('link_rewriting')}
+            tagLinks={settings.get('tag_misleading_links')}
             disabled
           />
 

--- a/app/javascript/flavours/glitch/features/status/components/detailed_status.js
+++ b/app/javascript/flavours/glitch/features/status/components/detailed_status.js
@@ -241,6 +241,7 @@ export default class DetailedStatus extends ImmutablePureComponent {
             onExpandedToggle={onToggleHidden}
             parseClick={this.parseClick}
             onUpdate={this.handleChildUpdate}
+            linkRewriting={settings.get('link_rewriting')}
             disabled
           />
 

--- a/app/javascript/flavours/glitch/reducers/local_settings.js
+++ b/app/javascript/flavours/glitch/reducers/local_settings.js
@@ -22,6 +22,7 @@ const initialState = ImmutableMap({
   hicolor_privacy_icons: false,
   show_content_type_choice: false,
   filtering_behavior: 'hide',
+  link_rewriting: 'tag',
   content_warnings : ImmutableMap({
     auto_unfold : false,
     filter      : null,

--- a/app/javascript/flavours/glitch/reducers/local_settings.js
+++ b/app/javascript/flavours/glitch/reducers/local_settings.js
@@ -22,7 +22,7 @@ const initialState = ImmutableMap({
   hicolor_privacy_icons: false,
   show_content_type_choice: false,
   filtering_behavior: 'hide',
-  link_rewriting: 'tag',
+  tag_misleading_links: true,
   content_warnings : ImmutableMap({
     auto_unfold : false,
     filter      : null,

--- a/app/javascript/flavours/glitch/styles/components/status.scss
+++ b/app/javascript/flavours/glitch/styles/components/status.scss
@@ -138,6 +138,7 @@
 
     .link-origin-tag {
       color: $gold-star;
+      font-size: 0.8em;
     }
   }
 

--- a/app/javascript/flavours/glitch/styles/components/status.scss
+++ b/app/javascript/flavours/glitch/styles/components/status.scss
@@ -135,6 +135,10 @@
 
   a.unhandled-link {
     color: lighten($ui-highlight-color, 8%);
+
+    .link-origin-tag {
+      color: $gold-star;
+    }
   }
 
   .status__content__spoiler-link {

--- a/app/javascript/flavours/glitch/util/idna.js
+++ b/app/javascript/flavours/glitch/util/idna.js
@@ -1,0 +1,10 @@
+import punycode from 'punycode';
+
+const IDNA_PREFIX = 'xn--';
+
+export const decode = domain => {
+  return domain
+    .split('.')
+    .map(part => part.indexOf(IDNA_PREFIX) === 0 ? punycode.decode(part.slice(IDNA_PREFIX.length)) : part)
+    .join('.');
+};


### PR DESCRIPTION
This adds a bunch of options to fix #1162

## What it does not attempt to do

- Extract any information from the target (that is, it does not help with link shorteners and other redirects)
- Help in any way with spotting homograph attacks on International Domain Names
- Warn against any list of known phishing or other malicious URLs

## Link tagging options

![image](https://user-images.githubusercontent.com/384364/62313154-553f1a80-b490-11e9-9c5d-5e88e4a6c94d.png)

### Disabled

Present the statuses unmodified (besides basic server-side sanitizing), as is currently done.

![image](https://user-images.githubusercontent.com/384364/62298104-ac35f700-b472-11e9-9080-e27c3286d739.png)

### Enabled

Add a colorful tag besides any link which does not match its target domain, without rewriting the link text itself. This is the default in this PR.

![image](https://user-images.githubusercontent.com/384364/62313084-1e690480-b490-11e9-8b94-7391f7ff40b9.png)