### PR TITLE
Change filter logic to keep filtered toots, but not mark them as unread

### DIFF
--- a/app/javascript/flavours/glitch/reducers/timelines.js
+++ b/app/javascript/flavours/glitch/reducers/timelines.js
@@ -60,7 +60,7 @@ const expandNormalizedTimeline = (state, timeline, statuses, next, isPartial, is
   }));
 };
 
-const updateTimeline = (state, timeline, status, usePendingItems) => {
+const updateTimeline = (state, timeline, status, usePendingItems, filtered) => {
   const top = state.getIn([timeline, 'top']);
 
   if (usePendingItems || !state.getIn([timeline, 'pendingItems']).isEmpty()) {
@@ -68,7 +68,13 @@ const updateTimeline = (state, timeline, status, usePendingItems) => {
       return state;
     }
 
-    return state.update(timeline, initialTimeline, map => map.update('pendingItems', list => list.unshift(status.get('id'))).update('unread', unread => unread + 1));
+    state = state.update(timeline, initialTimeline, map => map.update('pendingItems', list => list.unshift(status.get('id'))));
+
+    if (!filtered) {
+      state = state.update('unread', unread => unread + 1);
+    }
+
+    return state;
   }
 
   const ids        = state.getIn([timeline, 'items'], ImmutableList());
@@ -82,7 +88,7 @@ const updateTimeline = (state, timeline, status, usePendingItems) => {
   let newIds = ids;
 
   return state.update(timeline, initialTimeline, map => map.withMutations(mMap => {
-    if (!top) mMap.set('unread', unread + 1);
+    if (!top && !filtered) mMap.set('unread', unread + 1);
     if (top && ids.size > 40) newIds = newIds.take(20);
     mMap.set('items', newIds.unshift(status.get('id')));
   }));
@@ -147,7 +153,7 @@ export default function timelines(state = initialState, action) {
   case TIMELINE_EXPAND_SUCCESS:
     return expandNormalizedTimeline(state, action.timeline, fromJS(action.statuses), action.next, action.partial, action.isLoadingRecent, action.usePendingItems);
   case TIMELINE_UPDATE:
-    return updateTimeline(state, action.timeline, fromJS(action.status), action.usePendingItems);
+    return updateTimeline(state, action.timeline, fromJS(action.status), action.usePendingItems, action.filtered);
   case TIMELINE_DELETE:
     return deleteStatus(state, action.id, action.accountId, action.references, action.reblogOf);
   case TIMELINE_CLEAR:


### PR DESCRIPTION
Keeping them in the TL fixes the front-end not being able to properly keep
track of pagination. Furthermore, filtered toots are not counted as unread
content, whether they are dropped or not.