### PR TITLE
Add support for xmpp: and magnet: URIs to misleading link detection code

### DIFF
--- a/app/javascript/flavours/glitch/components/status_content.js
+++ b/app/javascript/flavours/glitch/components/status_content.js
@@ -42,6 +42,14 @@ const isLinkMisleading = (link) => {
   const linkText = linkTextParts.join('');
   const targetURL = new URL(link.href);
 
+  if (targetURL.protocol === 'magnet:') {
+    return !linkText.startsWith('magnet:');
+  }
+
+  if (targetURL.protocol === 'xmpp:') {
+    return !(linkText === targetURL.href || 'xmpp:' + linkText === targetURL.href);
+  }
+
   // The following may not work with international domain names
   if (textMatchesTarget(linkText, targetURL.origin, targetURL.host) || textMatchesTarget(linkText.toLowerCase(), targetURL.origin, targetURL.host)) {
     return false;
@@ -120,9 +128,19 @@ export default class StatusContent extends React.PureComponent {
           if (tagLinks && isLinkMisleading(link)) {
             // Add a tag besides the link to display its origin
 
+            const url = new URL(link.href);
             const tag = document.createElement('span');
             tag.classList.add('link-origin-tag');
-            tag.textContent = `[${new URL(link.href).host}]`;
+            switch (url.protocol) {
+            case 'xmpp:':
+              tag.textContent = `[${url.href}]`;
+              break;
+            case 'magnet:':
+              tag.textContent = '(magnet)';
+              break;
+            default:
+              tag.textContent = `[${url.host}]`;
+            }
             link.insertAdjacentText('beforeend', ' ');
             link.insertAdjacentElement('beforeend', tag);
           }


### PR DESCRIPTION
- magnet links that do not start with “magnet:” are tagged with “(magnet)”
- xmpp links that do not match exactly the target (with optionally “xmpp:” stripped) are tagged with “[<uri>]”