### PR TITLE
Use timeline markers to get accurate notification count

### DIFF
--- a/app/javascript/flavours/glitch/actions/markers.js
+++ b/app/javascript/flavours/glitch/actions/markers.js
@@ -1,3 +1,9 @@
+import api from 'flavours/glitch/util/api';
+
+export const MARKERS_FETCH_REQUEST = 'MARKERS_FETCH_REQUEST';
+export const MARKERS_FETCH_SUCCESS = 'MARKERS_FETCH_SUCCESS';
+export const MARKERS_FETCH_FAIL    = 'MARKERS_FETCH_FAIL';
+
 export const submitMarkers = () => (dispatch, getState) => {
   const accessToken = getState().getIn(['meta', 'access_token'], '');
   const params      = {};
@@ -27,4 +33,40 @@ export const submitMarkers = () => (dispatch, getState) => {
   client.setRequestHeader('Content-Type', 'application/json');
   client.setRequestHeader('Authorization', `Bearer ${accessToken}`);
   client.send(JSON.stringify(params));
+};
+
+export const fetchMarkers = () => (dispatch, getState) => {
+    const params = { timeline: ['notifications'] };
+
+    dispatch(fetchMarkersRequest());
+
+    api(getState).get('/api/v1/markers', { params }).then(response => {
+      dispatch(fetchMarkersSuccess(response.data));
+    }).catch(error => {
+      dispatch(fetchMarkersFail(error));
+    });
+};
+
+export function fetchMarkersRequest() {
+  return {
+    type: MARKERS_FETCH_REQUEST,
+    skipLoading: true,
+  };
+};
+
+export function fetchMarkersSuccess(markers) {
+  return {
+    type: MARKERS_FETCH_SUCCESS,
+    markers,
+    skipLoading: true,
+  };
+};
+
+export function fetchMarkersFail(error) {
+  return {
+    type: MARKERS_FETCH_FAIL,
+    error,
+    skipLoading: true,
+    skipAlert: true,
+  };
 };

--- a/app/javascript/flavours/glitch/actions/markers.js
+++ b/app/javascript/flavours/glitch/actions/markers.js
@@ -9,7 +9,7 @@ export const submitMarkers = () => (dispatch, getState) => {
   const params      = {};
 
   const lastHomeId         = getState().getIn(['timelines', 'home', 'items', 0]);
-  const lastNotificationId = getState().getIn(['notifications', 'items', 0, 'id']);
+  const lastNotificationId = getState().getIn(['notifications', 'lastReadId']);
 
   if (lastHomeId) {
     params.home = {
@@ -17,7 +17,7 @@ export const submitMarkers = () => (dispatch, getState) => {
     };
   }
 
-  if (lastNotificationId) {
+  if (lastNotificationId && lastNotificationId !== '0') {
     params.notifications = {
       last_read_id: lastNotificationId,
     };

--- a/app/javascript/flavours/glitch/features/ui/index.js
+++ b/app/javascript/flavours/glitch/features/ui/index.js
@@ -12,7 +12,7 @@ import { expandHomeTimeline } from 'flavours/glitch/actions/timelines';
 import { expandNotifications, notificationsSetVisibility } from 'flavours/glitch/actions/notifications';
 import { fetchFilters } from 'flavours/glitch/actions/filters';
 import { clearHeight } from 'flavours/glitch/actions/height_cache';
-import { submitMarkers } from 'flavours/glitch/actions/markers';
+import { submitMarkers, fetchMarkers } from 'flavours/glitch/actions/markers';
 import { WrappedSwitch, WrappedRoute } from 'flavours/glitch/util/react_router_helpers';
 import UploadArea from './components/upload_area';
 import PermaLink from 'flavours/glitch/components/permalink';
@@ -388,6 +388,7 @@ class UI extends React.Component {
 
     this.favicon = new Favico({ animation:"none" });
 
+    this.props.dispatch(fetchMarkers());
     this.props.dispatch(expandHomeTimeline());
     this.props.dispatch(expandNotifications());
     setTimeout(() => this.props.dispatch(fetchFilters()), 500);


### PR DESCRIPTION
Up to now, notifications received when the notification column wasn't mounted were considered unread, even if they were the first notifications.

This PR makes use of timeline markers introduced a few versions of Mastodon ago to get the last seen notification on load.