### PR TITLE
Move glitch-specific ruby-side locales to their own files

### DIFF
--- a/config/initializers/locale.rb
+++ b/config/initializers/locale.rb
@@ -4,3 +4,4 @@ I18n.load_path += Dir[Rails.root.join('app', 'javascript', 'flavours', '*', 'nam
 I18n.load_path += Dir[Rails.root.join('app', 'javascript', 'flavours', '*', 'names', '*.{rb,yml}').to_s]
 I18n.load_path += Dir[Rails.root.join('app', 'javascript', 'skins', '*', '*', 'names.{rb,yml}').to_s]
 I18n.load_path += Dir[Rails.root.join('app', 'javascript', 'skins', '*', '*', 'names', '*.{rb,yml}').to_s]
+I18n.load_path += Dir[Rails.root.join('config', 'locales-glitch', '*.{rb,yml}').to_s]

--- a/config/locales-glitch/en.yml
+++ b/config/locales-glitch/en.yml
@@ -1,0 +1,22 @@
+---
+en:
+  admin:
+    dashboard:
+      keybase: Keybase integration
+    settings:
+      enable_keybase:
+        desc_html: Allow your users to prove their identity via keybase
+        title: Enable keybase integration
+      hide_followers_count:
+        desc_html: Do not show followers count on user profiles
+        title: Hide followers count
+      show_reblogs_in_public_timelines:
+        desc_html: Show public boosts of public toots in local and public timelines.
+        title: Show boosts in public timelines
+      show_replies_in_public_timelines:
+        desc_html: In addition to public self-replies (threads), show public replies in local and public timelines.
+        title: Show replies in public timelines
+  generic:
+    use_this: Use this
+  settings:
+    flavours: Flavours

--- a/config/locales-glitch/ja.yml
+++ b/config/locales-glitch/ja.yml
@@ -1,0 +1,6 @@
+---
+ja:
+  generic:
+    use_this: これを使う
+  settings:
+    flavours: フレーバー

--- a/config/locales-glitch/pl.yml
+++ b/config/locales-glitch/pl.yml
@@ -1,0 +1,6 @@
+---
+pl:
+  generic:
+    use_this: Użyj tego
+  settings:
+    flavours: Odmiany

--- a/config/locales-glitch/simple_form.en.yml
+++ b/config/locales-glitch/simple_form.en.yml
@@ -1,0 +1,20 @@
+---
+en:
+  simple_form:
+    hints:
+      defaults:
+        setting_default_content_type_html: When writing toots, assume they are written in raw HTML, unless specified otherwise
+        setting_default_content_type_markdown: When writing toots, assume they are using Markdown for rich text formatting, unless specified otherwise
+        setting_default_content_type_plain: When writing toots, assume they are plain text with no special formatting, unless specified otherwise (default Mastodon behavior)
+        setting_default_language: The language of your toots can be detected automatically, but it's not always accurate
+        setting_skin: Reskins the selected Mastodon flavour
+    labels:
+      defaults:
+        setting_default_content_type: Default format for toots
+        setting_default_content_type_html: HTML
+        setting_default_content_type_markdown: Markdown
+        setting_default_content_type_plain: Plain text
+        setting_favourite_modal: Show confirmation dialog before favouriting (applies to Glitch flavour only)
+        setting_hide_followers_count: Hide your followers count
+        setting_skin: Skin
+        setting_system_emoji_font: Use system's default font for emojis (applies to Glitch flavour only)

--- a/config/locales-glitch/simple_form.ja.yml
+++ b/config/locales-glitch/simple_form.ja.yml
@@ -1,0 +1,6 @@
+---
+ja:
+  simple_form:
+    labels:
+      defaults:
+        setting_favourite_modal: お気に入りをする前に確認ダイアログを表示する

--- a/config/locales-glitch/simple_form.pl.yml
+++ b/config/locales-glitch/simple_form.pl.yml
@@ -1,0 +1,10 @@
+---
+pl:
+  simple_form:
+    hints:
+      defaults:
+        setting_skin: Zmienia wygląd używanej odmiany Mastodona
+    labels:
+      defaults:
+        setting_favourite_modal: Pytaj o potwierdzenie przed dodaniem do ulubionych
+        setting_skin: Motyw

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -332,7 +332,6 @@ en:
       feature_timeline_preview: Timeline preview
       features: Features
       hidden_service: Federation with hidden services
-      keybase: Keybase integration
       open_reports: open reports
       pending_tags: hashtags waiting for review
       pending_users: users waiting for review
@@ -514,15 +513,9 @@ en:
         title: Show rationale
       enable_bootstrap_timeline_accounts:
         title: Enable default follows for new users
-      enable_keybase:
-        desc_html: Allow your users to prove their identity via keybase
-        title: Enable keybase integration
       hero:
         desc_html: Displayed on the frontpage. At least 600x100px recommended. When not set, falls back to server thumbnail
         title: Hero image
-      hide_followers_count:
-        desc_html: Do not show followers count on user profiles
-        title: Hide followers count
       mascot:
         desc_html: Displayed on multiple pages. At least 293×205px recommended. When not set, falls back to default mascot
         title: Mascot image
@@ -554,12 +547,6 @@ en:
       show_known_fediverse_at_about_page:
         desc_html: When disabled, restricts the public timeline linked from the landing page to showing only local content
         title: Include federated content on unauthenticated public timeline page
-      show_reblogs_in_public_timelines:
-        desc_html: Show public boosts of public toots in local and public timelines.
-        title: Show boosts in public timelines
-      show_replies_in_public_timelines:
-        desc_html: In addition to public self-replies (threads), show public replies in local and public timelines.
-        title: Show replies in public timelines
       show_staff_badge:
         desc_html: Show a staff badge on a user page
         title: Show staff badge
@@ -842,7 +829,6 @@ en:
     no_batch_actions_available: No batch actions available on this page
     order_by: Order by
     save_changes: Save changes
-    use_this: Use this
     validation_errors:
       one: Something isn't quite right yet! Please review the error below
       other: Something isn't quite right yet! Please review %{count} errors below
@@ -1109,7 +1095,6 @@ en:
     edit_profile: Edit profile
     export: Data export
     featured_tags: Featured hashtags
-    flavours: Flavours
     identity_proofs: Identity proofs
     import: Import
     import_and_export: Import and export

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -821,7 +821,6 @@ ja:
     no_batch_actions_available: このページに一括操作はありません
     order_by: 並び順
     save_changes: 変更を保存
-    use_this: これを使う
     validation_errors:
       other: エラーが発生しました！ 以下の%{count}個のエラーを確認してください
   html_validator:
@@ -1083,7 +1082,6 @@ ja:
     edit_profile: プロフィールを編集
     export: データのエクスポート
     featured_tags: 注目のハッシュタグ
-    flavours: フレーバー
     identity_proofs: Identity proofs
     import: データのインポート
     import_and_export: インポート・エクスポート

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -845,7 +845,6 @@ pl:
     no_batch_actions_available: Brak akcji wsadowych dostępnych na tej stronie
     order_by: Uporządkuj według
     save_changes: Zapisz zmiany
-    use_this: Użyj tego
     validation_errors:
       few: Coś jest wciąż nie tak! Przejrzyj %{count} poniższe błędy
       many: Coś jest wciąż nie tak! Przejrzyj %{count} poniższych błędów
@@ -1117,7 +1116,6 @@ pl:
     edit_profile: Edytuj profil
     export: Eksportowanie danych
     featured_tags: Wyróżnione hashtagi
-    flavours: Odmiany
     identity_proofs: Dowody tożsamości
     import: Importowanie danych
     import_and_export: Import i eksport

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -41,10 +41,6 @@ en:
         phrase: Will be matched regardless of casing in text or content warning of a toot
         scopes: Which APIs the application will be allowed to access. If you select a top-level scope, you don't need to select individual ones.
         setting_aggregate_reblogs: Do not show new boosts for toots that have been recently boosted (only affects newly-received boosts)
-        setting_default_content_type_html: When writing toots, assume they are written in raw HTML, unless specified otherwise
-        setting_default_content_type_markdown: When writing toots, assume they are using Markdown for rich text formatting, unless specified otherwise
-        setting_default_content_type_plain: When writing toots, assume they are plain text with no special formatting, unless specified otherwise (default Mastodon behavior)
-        setting_default_language: The language of your toots can be detected automatically, but it's not always accurate
         setting_default_sensitive: Sensitive media is hidden by default and can be revealed with a click
         setting_display_media_default: Hide media marked as sensitive
         setting_display_media_hide_all: Always hide media
@@ -52,7 +48,6 @@ en:
         setting_hide_network: Who you follow and who follows you will not be shown on your profile
         setting_noindex: Affects your public profile and status pages
         setting_show_application: The application you use to toot will be displayed in the detailed view of your toots
-        setting_skin: Reskins the selected Mastodon flavour
         setting_use_blurhash: Gradients are based on the colors of the hidden visuals but obfuscate any details
         setting_use_pending_items: Hide timeline updates behind a click instead of automatically scrolling the feed
         username: Your username will be unique on %{domain}
@@ -136,10 +131,6 @@ en:
         setting_auto_play_gif: Auto-play animated GIFs
         setting_boost_modal: Show confirmation dialog before boosting
         setting_crop_images: Crop images in non-expanded toots to 16x9
-        setting_default_content_type: Default format for toots
-        setting_default_content_type_html: HTML
-        setting_default_content_type_markdown: Markdown
-        setting_default_content_type_plain: Plain text
         setting_default_language: Posting language
         setting_default_privacy: Posting privacy
         setting_default_sensitive: Always mark media as sensitive
@@ -149,14 +140,10 @@ en:
         setting_display_media_hide_all: Hide all
         setting_display_media_show_all: Show all
         setting_expand_spoilers: Always expand toots marked with content warnings
-        setting_favourite_modal: Show confirmation dialog before favouriting (applies to Glitch flavour only)
-        setting_hide_followers_count: Hide your followers count
         setting_hide_network: Hide your network
         setting_noindex: Opt-out of search engine indexing
         setting_reduce_motion: Reduce motion in animations
         setting_show_application: Disclose application used to send toots
-        setting_skin: Skin
-        setting_system_emoji_font: Use system's default font for emojis (applies to Glitch flavour only)
         setting_system_font_ui: Use system's default font
         setting_theme: Site theme
         setting_trends: Show today's trends

--- a/config/locales/simple_form.ja.yml
+++ b/config/locales/simple_form.ja.yml
@@ -140,7 +140,6 @@ ja:
         setting_display_media_hide_all: 非表示
         setting_display_media_show_all: 表示
         setting_expand_spoilers: 閲覧注意としてマークされたトゥートを常に展開する
-        setting_favourite_modal: お気に入りをする前に確認ダイアログを表示する
         setting_hide_network: 繋がりを隠す
         setting_noindex: 検索エンジンによるインデックスを拒否する
         setting_reduce_motion: アニメーションの動きを減らす

--- a/config/locales/simple_form.pl.yml
+++ b/config/locales/simple_form.pl.yml
@@ -48,7 +48,6 @@ pl:
         setting_hide_network: Informacje o tym, kto Cię śledzi i kogo śledzisz nie będą widoczne
         setting_noindex: Wpływa na widoczność strony profilu i Twoich wpisów
         setting_show_application: W informacjach o wpisie będzie widoczna informacja o aplikacji, z której został wysłany
-        setting_skin: Zmienia wygląd używanej odmiany Mastodona
         setting_use_blurhash: Gradienty są oparte na kolorach ukrywanej zawartości, ale uniewidaczniają wszystkie szczegóły
         setting_use_pending_items: Ukryj aktualizacje osi czasu za kliknięciem, zamiast automatycznego przewijania strumienia
         username: Twoja nazwa użytkownika będzie niepowtarzalna na %{domain}
@@ -141,12 +140,10 @@ pl:
         setting_display_media_hide_all: Ukryj wszystko
         setting_display_media_show_all: Pokaż wszystko
         setting_expand_spoilers: Zawsze rozwijaj wpisy oznaczone ostrzeżeniem o zawartości
-        setting_favourite_modal: Pytaj o potwierdzenie przed dodaniem do ulubionych
         setting_hide_network: Ukryj swoją sieć
         setting_noindex: Nie indeksuj mojego profilu w wyszukiwarkach internetowych
         setting_reduce_motion: Ogranicz ruch w animacjach
         setting_show_application: Informuj o aplikacji z której wysłano wpisy
-        setting_skin: Motyw
         setting_system_font_ui: Używaj domyślnej czcionki systemu
         setting_theme: Motyw strony
         setting_trends: Pokazuj dzisiejsze „Na czasie”


### PR DESCRIPTION
Hopefully, that will help us translate glitch-soc, by, for instance, plugging weblate or crowdin.

This is just a very small part of glitch-soc strings, though, as the bulk of it is in javascript and I have no idea yet on how to adapt the tooling to the hacks we have to inherit from upstream's translations.