### PR TITLE
Add server-wide setting to add content warning to outgoing toots

### DIFF
--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -41,6 +41,7 @@ class Form::AdminSettings
     show_domain_blocks
     show_domain_blocks_rationale
     noindex
+    outgoing_spoilers
   ).freeze
 
   BOOLEAN_KEYS = %i(

--- a/app/serializers/activitypub/note_serializer.rb
+++ b/app/serializers/activitypub/note_serializer.rb
@@ -35,11 +35,11 @@ class ActivityPub::NoteSerializer < ActivityPub::Serializer
   end
 
   def summary
-    object.spoiler_text.presence || Setting.outgoing_spoilers.presence
+    object.spoiler_text.presence || (instance_options[:allow_local_only] ? nil : Setting.outgoing_spoilers.presence)
   end
 
   def sensitive
-    object.sensitive || Setting.outgoing_spoilers.present?
+    object.sensitive || (!instance_options[:allow_local_only] && Setting.outgoing_spoilers.present?)
   end
 
   def content

--- a/app/serializers/activitypub/note_serializer.rb
+++ b/app/serializers/activitypub/note_serializer.rb
@@ -35,7 +35,11 @@ class ActivityPub::NoteSerializer < ActivityPub::Serializer
   end
 
   def summary
-    object.spoiler_text.presence
+    object.spoiler_text.presence || Setting.outgoing_spoilers.presence
+  end
+
+  def sensitive
+    object.sensitive || Setting.outgoing_spoilers.present?
   end
 
   def content

--- a/app/views/admin/settings/edit.html.haml
+++ b/app/views/admin/settings/edit.html.haml
@@ -109,6 +109,9 @@
       = f.input :show_domain_blocks_rationale, wrapper: :with_label, collection: %i(disabled users all), label: t('admin.settings.domain_blocks_rationale.title'), label_method: lambda { |value| t("admin.settings.domain_blocks.#{value}") }, include_blank: false, collection_wrapper_tag: 'ul', item_wrapper_tag: 'li'
 
   .fields-group
+    = f.input :outgoing_spoilers, wrapper: :with_label, label: t('admin.settings.outgoing_spoilers.title'), hint: t('admin.settings.outgoing_spoilers.desc_html')
+
+  .fields-group
     = f.input :site_extended_description, wrapper: :with_block_label, as: :text, label: t('admin.settings.site_description_extended.title'), hint: t('admin.settings.site_description_extended.desc_html'), input_html: { rows: 8 } unless whitelist_mode?
     = f.input :closed_registrations_message, as: :text, wrapper: :with_block_label, label: t('admin.settings.registrations.closed_message.title'), hint: t('admin.settings.registrations.closed_message.desc_html'), input_html: { rows: 8 }
     = f.input :site_terms, wrapper: :with_block_label, as: :text, label: t('admin.settings.site_terms.title'), hint: t('admin.settings.site_terms.desc_html'), input_html: { rows: 8 }

--- a/config/locales-glitch/en.yml
+++ b/config/locales-glitch/en.yml
@@ -7,6 +7,9 @@ en:
       enable_keybase:
         desc_html: Allow your users to prove their identity via keybase
         title: Enable keybase integration
+      outgoing_spoilers:
+        desc_html: When federating toots, add this content warning to toots that do not have one. It is useful if your server is specialized in content other servers might want to have under a Content Warning. Media will also be marked as sensitive.
+        title: Content warning for outgoing toots
       hide_followers_count:
         desc_html: Do not show followers count on user profiles
         title: Hide followers count

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -77,6 +77,7 @@ defaults: &defaults
   spam_check_enabled: true
   show_domain_blocks: 'disabled'
   show_domain_blocks_rationale: 'disabled'
+  outgoing_spoilers: ''
 
 development:
   <<: *defaults


### PR DESCRIPTION
Add an option that adds a content warning to every toot that gets serialized over ActivityPub if they don't already have one. Also marks the media as sensitive.

This is useful for instances that are specialized in subjects that would generally require adding content warnings in most places (e.g. porn, food, …)

![image](https://user-images.githubusercontent.com/384364/83331479-02dcaf00-a297-11ea-830e-1d4982bc86a2.png)

Note that this is done at serializing time, so the settings will be reflected at the moment a toot is fetched or sent out, not when it was authored. This means a toot may change CW depending on when it was fetched.