### PR TITLE
Add support for “start” and “reversed” attributes to ol element

### DIFF
--- a/app/lib/sanitize_config.rb
+++ b/app/lib/sanitize_config.rb
@@ -91,6 +91,7 @@ class Sanitize
         'abbr'       => %w(title),
         'blockquote' => %w(cite),
         'ol'         => %w(start reversed),
+        'li'         => %w(value),
       },
 
       add_attributes: {

--- a/app/lib/sanitize_config.rb
+++ b/app/lib/sanitize_config.rb
@@ -90,6 +90,7 @@ class Sanitize
         'span'       => %w(class),
         'abbr'       => %w(title),
         'blockquote' => %w(cite),
+        'ol'         => %w(start reversed),
       },
 
       add_attributes: {

--- a/spec/lib/sanitize_config_spec.rb
+++ b/spec/lib/sanitize_config_spec.rb
@@ -13,6 +13,10 @@ describe Sanitize::Config do
       expect(Sanitize.fragment('<p>Check out:</p><ul><li>Foo</li><li>Bar</li></ul>', subject)).to eq '<p>Check out:</p><ul><li>Foo</li><li>Bar</li></ul>'
     end
 
+    it 'keeps start and reversed attributes of ol' do
+      expect(Sanitize.fragment('<p>Check out:</p><ol start="3" reversed=""><li>Foo</li><li>Bar</li></ol>', subject)).to eq '<p>Check out:</p><ol start="3" reversed=""><li>Foo</li><li>Bar</li></ol>'
+    end
+
     it 'removes a without href' do
       expect(Sanitize.fragment('<a>Test</a>', subject)).to eq 'Test'
     end


### PR DESCRIPTION
Fixes #1367