### PR TITLE
Update design of account notes

### DIFF
--- a/app/javascript/flavours/glitch/features/account/components/account_note.js
+++ b/app/javascript/flavours/glitch/features/account/components/account_note.js
@@ -63,6 +63,14 @@ class Header extends ImmutablePureComponent {
           </button>
         </div>
       );
+    } else {
+      action_buttons = (
+        <div className='account__header__account-note__buttons'>
+          <button className='text-btn' tabIndex='0' onClick={this.props.onEditAccountNote} disabled={isSubmitting}>
+            <Icon id='pencil' size={15} /> <FormattedMessage id='account_note.edit' defaultMessage='Edit' />
+          </button>
+        </div>
+      );
     }
 
     let note_container = null;
@@ -85,17 +93,10 @@ class Header extends ImmutablePureComponent {
     return (
       <div className='account__header__account-note'>
         <div className='account__header__account-note__header'>
-          <strong><FormattedMessage id='account.account_note_header' defaultMessage='Your note for @{name}' values={{ name: account.get('username') }} /></strong>
-          {!isEditing && (
-            <div>
-              <button className='text-btn' tabIndex='0' onClick={this.props.onEditAccountNote} disabled={isSubmitting}>
-                <Icon id='pencil' size={15} /> <FormattedMessage id='account_note.edit' defaultMessage='Edit' />
-              </button>
-            </div>
-          )}
+          <strong><FormattedMessage id='account.account_note_header' defaultMessage='Note' /></strong>
+          {action_buttons}
         </div>
         {note_container}
-        {action_buttons}
       </div>
     );
   }

--- a/app/javascript/flavours/glitch/features/account/components/account_note.js
+++ b/app/javascript/flavours/glitch/features/account/components/account_note.js
@@ -7,7 +7,7 @@ import Icon from 'flavours/glitch/components/icon';
 import Textarea from 'react-textarea-autosize';
 
 const messages = defineMessages({
-  placeholder: { id: 'account_note.placeholder', defaultMessage: 'No comment provided' },
+  placeholder: { id: 'account_note.glitch_placeholder', defaultMessage: 'No comment provided' },
 });
 
 export default @injectIntl

--- a/app/javascript/flavours/glitch/features/account/components/header.js
+++ b/app/javascript/flavours/glitch/features/account/components/header.js
@@ -177,7 +177,7 @@ class Header extends ImmutablePureComponent {
       menu.push(null);
     }
 
-    if (accountNote === null) {
+    if (accountNote === null || accountNote === '') {
       menu.push({ text: intl.formatMessage(messages.add_account_note, { name: account.get('username') }), action: this.props.onEditAccountNote });
     }
 

--- a/app/javascript/flavours/glitch/styles/components/accounts.scss
+++ b/app/javascript/flavours/glitch/styles/components/accounts.scss
@@ -714,42 +714,44 @@
   }
 
   &__account-note {
-    margin: 5px;
-    padding: 10px;
-    background: $ui-highlight-color;
-    color: $primary-text-color;
+    margin: 0 -5px;
+    padding: 10px 15px;
     display: flex;
     flex-direction: column;
-    border-radius: 4px;
     font-size: 14px;
     font-weight: 400;
+    border-top: 1px solid lighten($ui-base-color, 12%);
+    border-bottom: 1px solid lighten($ui-base-color, 12%);
 
     &__header {
       display: flex;
       flex-direction: row;
       justify-content: space-between;
+      margin-bottom: 5px;
+      color: $darker-text-color;
     }
 
     &__content {
       white-space: pre-wrap;
-      margin-top: 5px;
+      padding: 10px 0;
     }
 
     &__buttons {
       display: flex;
       flex-direction: row;
       justify-content: flex-end;
-      margin-top: 5px;
+      flex: 1 0;
 
       .flex-spacer {
-        flex: 0 0 20px;
+        flex: 0 0 15px;
         background: transparent;
       }
     }
 
     strong {
-      font-size: 15px;
+      font-size: 12px;
       font-weight: 500;
+      text-transform: uppercase;
     }
 
     button:hover span {
@@ -759,18 +761,24 @@
     textarea {
       display: block;
       box-sizing: border-box;
-      width: 100%;
+      width: calc(100% + 20px);
       margin: 0;
       margin-top: 5px;
-      color: $inverted-text-color;
-      background: $simple-background-color;
+      color: $secondary-text-color;
+      background: $ui-base-color;
       padding: 10px;
+      margin: 0 -10px;
       font-family: inherit;
       font-size: 14px;
       resize: none;
       border: 0;
       outline: 0;
       border-radius: 4px;
+
+      &::placeholder {
+        color: $dark-text-color;
+        opacity: 1;
+      }
     }
   }
 }


### PR DESCRIPTION
Inspired by upstream, but keeping the button flow, as I think it is less error-prone. Also putting notes on the top, and not between two pieces of info defined by the user.

## Before

![Peek 07-07-2020 18-02](https://user-images.githubusercontent.com/384364/86809349-14765b00-c07c-11ea-8c77-ae1769e40810.gif)

## After

![Peek 07-07-2020 18-37](https://user-images.githubusercontent.com/384364/86813790-e34c5980-c080-11ea-87be-34dbc22933a6.gif)

## Upstream

![Peek 07-07-2020 18-03](https://user-images.githubusercontent.com/384364/86809493-3a9bfb00-c07c-11ea-9273-73b8fd0a3316.gif)
