### PR TITLE
Implement direct message assertions

### DIFF
--- a/app/lib/activitypub/adapter.rb
+++ b/app/lib/activitypub/adapter.rb
@@ -7,6 +7,7 @@ class ActivityPub::Adapter < ActiveModelSerializers::Adapter::Base
   }.freeze
 
   CONTEXT_EXTENSION_MAP = {
+    direct_message: { 'litepub': 'http://litepub.social/ns#', 'directMessage': 'litepub:directMessage' },
     manually_approves_followers: { 'manuallyApprovesFollowers' => 'as:manuallyApprovesFollowers' },
     sensitive: { 'sensitive' => 'as:sensitive' },
     hashtag: { 'Hashtag' => 'as:Hashtag' },

--- a/app/serializers/activitypub/note_serializer.rb
+++ b/app/serializers/activitypub/note_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ActivityPub::NoteSerializer < ActivityPub::Serializer
-  context_extensions :atom_uri, :conversation, :sensitive, :voters_count
+  context_extensions :atom_uri, :conversation, :sensitive, :voters_count, :direct_message
 
   attributes :id, :type, :summary,
              :in_reply_to, :published, :url,
@@ -11,6 +11,8 @@ class ActivityPub::NoteSerializer < ActivityPub::Serializer
 
   attribute :content
   attribute :content_map, if: :language?
+
+  attribute :direct_message, if: :non_public?
 
   has_many :media_attachments, key: :attachment
   has_many :virtual_tags, key: :tag
@@ -40,6 +42,14 @@ class ActivityPub::NoteSerializer < ActivityPub::Serializer
 
   def sensitive
     object.sensitive || (!instance_options[:allow_local_only] && Setting.outgoing_spoilers.present?)
+  end
+
+  def direct_message
+    object.direct_visibility?
+  end
+
+  def non_public?
+    !object.distributable?
   end
 
   def content

--- a/spec/lib/activitypub/activity/create_spec.rb
+++ b/spec/lib/activitypub/activity/create_spec.rb
@@ -146,6 +146,31 @@ RSpec.describe ActivityPub::Activity::Create do
         end
       end
 
+      context 'limited when direct message assertion is false' do
+        let(:recipient) { Fabricate(:account) }
+
+        let(:object_json) do
+          {
+            id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
+            type: 'Note',
+            content: 'Lorem ipsum',
+            directMessage: false,
+            to: ActivityPub::TagManager.instance.uri_for(recipient),
+            tag: {
+              type: 'Mention',
+              href: ActivityPub::TagManager.instance.uri_for(recipient),
+            },
+          }
+        end
+
+        it 'creates status' do
+          status = sender.statuses.first
+
+          expect(status).to_not be_nil
+          expect(status.visibility).to eq 'limited'
+        end
+      end
+
       context 'direct' do
         let(:recipient) { Fabricate(:account) }
 
@@ -159,6 +184,27 @@ RSpec.describe ActivityPub::Activity::Create do
               type: 'Mention',
               href: ActivityPub::TagManager.instance.uri_for(recipient),
             },
+          }
+        end
+
+        it 'creates status' do
+          status = sender.statuses.first
+
+          expect(status).to_not be_nil
+          expect(status.visibility).to eq 'direct'
+        end
+      end
+
+      context 'direct when direct message assertion is true' do
+        let(:recipient) { Fabricate(:account) }
+
+        let(:object_json) do
+          {
+            id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
+            type: 'Note',
+            content: 'Lorem ipsum',
+            to: ActivityPub::TagManager.instance.uri_for(recipient),
+            directMessage: true,
           }
         end
 


### PR DESCRIPTION
This PR implements handling the `directMessage` flag on incoming objects as well as setting it to the result of `object.direct_visibility?` on outgoing objects.

This makes it possible for Mastodon and other platforms to unambiguously tell apart direct messages from objects addressed to a limited-audience.

Additionally, several platforms including Friendica, Hubzilla, and Zap **require** `directMessage` to be set on objects intended to be direct messages in order to deliver them to the private mail or messaging system for the recipient rather than to their feed(s) as a limited-audience post.

The Monsterpit implementation, used in this PR, compromises between the current behavior of Mastodon and of other implementations by only inferring that an object without the `directMessage` flag present is a direct message if there is only one explicit mention (excluding of the author, which may be included by some implementations), as direct messages should have a 1:1 relationship unless the platform specified otherwise.

This allows for safely handling objects from various non-Mastodon platforms (including our own forks, like Creature Cafe) that rely on this behavior without sacrificing Mastodon compatibility.