### PR TITLE
bugfix: underline on hover in 'user followed you' notification

### DIFF
--- a/app/javascript/flavours/glitch/styles/components/status.scss
+++ b/app/javascript/flavours/glitch/styles/components/status.scss
@@ -695,7 +695,6 @@ a.status__display-name,
 }
 
 .account__display-name strong {
-  display: block;
   overflow: hidden;
   text-overflow: ellipsis;
 }


### PR DESCRIPTION
For some reason, the `display-name__html` in a follow notification is set to `display: block` which makes it 1px shorter than the `inline` version used by regular statuses. This 1px difference makes the hover underline not show up on the display name.

This does not apply to vanilla Mastodon.