### PR TITLE
Fix styling of display names and account handles, make it closer to upstream

### DIFF
--- a/app/javascript/flavours/glitch/styles/components/index.scss
+++ b/app/javascript/flavours/glitch/styles/components/index.scss
@@ -360,23 +360,7 @@
   }
 
   strong {
-    height: 18px;
-    font-size: 16px;
-    font-weight: 500;
-    line-height: 18px;
-    text-overflow: ellipsis;
-    overflow: hidden;
-    white-space: nowrap;
-  }
-
-  span {
     display: block;
-    height: 18px;
-    font-size: 15px;
-    line-height: 18px;
-    text-overflow: ellipsis;
-    overflow: hidden;
-    white-space: nowrap;
   }
 
   > a:hover {

--- a/app/javascript/flavours/glitch/styles/statuses.scss
+++ b/app/javascript/flavours/glitch/styles/statuses.scss
@@ -222,10 +222,6 @@
       padding: 6px 0;
       padding-right: 25px;
       margin: initial;
-
-      .display-name strong {
-        display: inline;
-      }
     }
 
     .status__avatar {


### PR DESCRIPTION
Reduce CSS duplication, use upstream styling as much as possible, change font sizes in the process.

## Before

![Screenshot_2020-08-13 Mastodon](https://user-images.githubusercontent.com/384364/90112588-7ba8be80-dd50-11ea-9b01-141c3f56f0c8.png)

## After

![Screenshot_2020-08-13 Mastodon(2)](https://user-images.githubusercontent.com/384364/90112605-819e9f80-dd50-11ea-87f7-cb352fa4797b.png)