### PR TITLE
Fix IP blocks crash

### DIFF
--- a/app/views/admin/ip_blocks/index.html.haml
+++ b/app/views/admin/ip_blocks/index.html.haml
@@ -1,9 +1,6 @@
 - content_for :page_title do
   = t('admin.ip_blocks.title')
 
-- content_for :header_tags do
-  = javascript_pack_tag 'admin', integrity: true, async: true, crossorigin: 'anonymous'
-
 - if can?(:create, :ip_block)
   - content_for :heading_actions do
     = link_to t('admin.ip_blocks.add_new'), new_admin_ip_block_path, class: 'button'


### PR DESCRIPTION
This would fix the following below, but I think it's rather hacky so please shout at me if you don't like it

```
[web-7d7f967d98-9q76t] [dbbdaf7f6032d489969ee5ee51846330] method=GET path=/admin/ip_blocks format=html controller=Admin::IpBlocksController action=index status=500 error='ActionView::Template::Error: Webpacker can't find admin.js in /opt/mastodon/public/packs/manifest.json.
```