### PR TITLE
Fix “Show boosts/replies in public timelines” only affecting streaming

### DIFF
--- a/app/controllers/api/v1/timelines/public_controller.rb
+++ b/app/controllers/api/v1/timelines/public_controller.rb
@@ -38,7 +38,9 @@ class Api::V1::Timelines::PublicController < Api::BaseController
       local: truthy_param?(:local),
       remote: truthy_param?(:remote),
       only_media: truthy_param?(:only_media),
-      allow_local_only: truthy_param?(:allow_local_only)
+      allow_local_only: truthy_param?(:allow_local_only),
+      with_replies: Setting.show_replies_in_public_timelines,
+      with_reblogs: Setting.show_reblogs_in_public_timelines,
     )
   end
 


### PR DESCRIPTION
Fixes #1456