### PR TITLE
Fix media not being marked sensitive when outgoing CW is set

### DIFF
--- a/app/serializers/activitypub/note_serializer.rb
+++ b/app/serializers/activitypub/note_serializer.rb
@@ -40,10 +40,6 @@ class ActivityPub::NoteSerializer < ActivityPub::Serializer
     object.spoiler_text.presence || (instance_options[:allow_local_only] ? nil : Setting.outgoing_spoilers.presence)
   end
 
-  def sensitive
-    object.sensitive || (!instance_options[:allow_local_only] && Setting.outgoing_spoilers.present?)
-  end
-
   def direct_message
     object.direct_visibility?
   end
@@ -111,7 +107,7 @@ class ActivityPub::NoteSerializer < ActivityPub::Serializer
   end
 
   def sensitive
-    object.account.sensitized? || object.sensitive
+    object.account.sensitized? || object.sensitive || (!instance_options[:allow_local_only] && Setting.outgoing_spoilers.present?)
   end
 
   def virtual_tags


### PR DESCRIPTION
Fixes #1461

Fixes a regression from a recent merge