### PR TITLE
Add favourite modal to light theme CSS

### DIFF
--- a/app/javascript/flavours/glitch/styles/mastodon-light/diff.scss
+++ b/app/javascript/flavours/glitch/styles/mastodon-light/diff.scss
@@ -224,6 +224,7 @@
 // Change the background colors of modals
 .actions-modal,
 .boost-modal,
+.favourite-modal,
 .confirmation-modal,
 .mute-modal,
 .block-modal,
@@ -246,6 +247,7 @@
 }
 
 .boost-modal__action-bar,
+.favourite-modal__action-bar,
 .confirmation-modal__action-bar,
 .mute-modal__action-bar,
 .block-modal__action-bar,


### PR DESCRIPTION
User noticed that this modal's text was changed for light theme, but the background wasn't.