### PR TITLE
Add environment variables to control custom emoji size limits

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -269,3 +269,10 @@ MAX_POLL_OPTION_CHARS=100
 # Maximum search results to display
 # Only relevant when elasticsearch is installed
 # MAX_SEARCH_RESULTS=20
+
+# Maximum custom emoji file sizes
+# If undefined or smaller than MAX_EMOJI_SIZE, the value
+# of MAX_EMOJI_SIZE will be used for MAX_REMOTE_EMOJI_SIZE
+# Units are in bytes
+MAX_EMOJI_SIZE=51200
+MAX_REMOTE_EMOJI_SIZE=204800


### PR DESCRIPTION
Fixes #1524

This adds to environment variables, `MAX_EMOJI_SIZE` and `MAX_REMOTE_EMOJI_SIZE`, respectively defaulting to 50KB (like upstream Mastodon) and 200KB (in order to transparently handle most emoji from other implementations by default).

It doesn't change the “PNG up to 50KB” `image_hint` yet, not sure how it should be changed as upstream's isn't configurable