### PR TITLE
Add Reply-To header for new pending account emails

### DIFF
--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -21,7 +21,7 @@ class AdminMailer < ApplicationMailer
     @instance = Rails.configuration.x.local_domain
 
     locale_for_account(@me) do
-      mail to: @me.user_email, subject: I18n.t('admin_mailer.new_pending_account.subject', instance: @instance, username: @account.username)
+      mail to: @me.user_email, reply_to: user.email, subject: I18n.t('admin_mailer.new_pending_account.subject', instance: @instance, username: @account.username)
     end
   end
 


### PR DESCRIPTION
When I deny someone's application, I usually send them an email explaining why. This PR facilitates that. I have tested these changes.