### PR TITLE
allow configuring the HSTS header

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -276,3 +276,8 @@ MAX_POLL_OPTION_CHARS=100
 # Units are in bytes
 MAX_EMOJI_SIZE=51200
 MAX_REMOTE_EMOJI_SIZE=204800
+
+# Whether to use HTTP Strict Transport Security.
+# true and false toggle the default behavior.
+# Any other value is used for the header as-is.
+# HSTS=true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -121,9 +121,14 @@ Rails.application.configure do
     'X-XSS-Protection'        => '1; mode=block',
     'Permissions-Policy'      => 'interest-cohort=()',
     'Referrer-Policy'         => 'same-origin',
-    'Strict-Transport-Security' => 'max-age=63072000; includeSubDomains; preload',
     'X-Clacks-Overhead' => 'GNU Natalie Nguyen'
   }
+
+  if (hsts = ENV.fetch('HSTS', 'true')) == 'true'
+    config.action_dispatch.default_headers['Strict-Transport-Security'] = 'max-age=63072000; includeSubDomains; preload'
+  elsif hsts != 'false'
+    config.action_dispatch.default_headers['Strict-Transport-Security'] = hsts
+  end
 
   config.x.otp_secret = ENV.fetch('OTP_SECRET')
 end


### PR DESCRIPTION
Per https://hstspreload.org, preloading should be opt-in. On my site I don't want includeSubDomains because I plan to run a lot of services and I'm not 100% confident I'm going to use HTTPS for all of them. Additionally, Mastodon supports hosting on a Tor onion and these typically do not use HTTPS.