### PR TITLE
Implement infinity home timeline

### DIFF
--- a/app/models/home_feed.rb
+++ b/app/models/home_feed.rb
@@ -19,9 +19,8 @@ class HomeFeed < Feed
     statuses = from_redis(limit, max_id, since_id, min_id)
 
     return statuses if statuses.size >= limit
-    return statuses if min_id.blank? && since_id.blank?
 
-    redis_min_id = from_redis(1, nil, nil, 0).first&.id
+    redis_min_id = from_redis(1, nil, nil, 0).first&.id if min_id.present? || since_id.present?
     redis_sufficient = redis_min_id && (
       (min_id.present? && min_id >= redis_min_id) ||
       (since_id.present? && since_id >= redis_min_id)

--- a/app/models/home_feed.rb
+++ b/app/models/home_feed.rb
@@ -28,9 +28,9 @@ class HomeFeed < Feed
       ))
     )
 
-    if not redis_sufficient
+    unless redis_sufficient
       remaining_limit = limit - statuses.size
-      max_id = statuses.last.id if !statuses.empty?
+      max_id = statuses.last.id unless statuses.empty?
       statuses += from_database(remaining_limit, max_id, since_id, min_id)
     end
 

--- a/app/models/home_feed.rb
+++ b/app/models/home_feed.rb
@@ -16,16 +16,15 @@ class HomeFeed < Feed
     since_id = since_id.to_i if since_id.present?
     min_id   = min_id.to_i if min_id.present?
 
-    redis_min_id = from_redis(1, nil, nil, 0).first&.id
-
     statuses = from_redis(limit, max_id, since_id, min_id)
 
-    redis_sufficient = (
-      (statuses.size >= limit) ||
-      (redis_min_id && (
-        (min_id.present? && min_id >= redis_min_id) ||
-        (since_id.present? && since_id >= redis_min_id)
-      ))
+    return statuses if statuses.size >= limit
+    return statuses if min_id.blank? && since_id.blank?
+
+    redis_min_id = from_redis(1, nil, nil, 0).first&.id
+    redis_sufficient = redis_min_id && (
+      (min_id.present? && min_id >= redis_min_id) ||
+      (since_id.present? && since_id >= redis_min_id)
     )
 
     unless redis_sufficient
@@ -40,8 +39,11 @@ class HomeFeed < Feed
   protected
 
   def from_database(limit, max_id, since_id, min_id)
+    # Note that this query will not contains direct messages
     Status
-      .as_home_timeline(@account, limit, max_id, since_id, min_id)
+      .where(account: [account] + account.following)
+      .where(visibility: [:public, :unlisted, :private])
+      .to_a_paginated_by_id(limit, min_id: min_id, max_id: max_id, since_id: since_id)
       .reject { |status| FeedManager.instance.filter?(:home, status, @account) }
       .sort_by { |status| -status.id }
   end

--- a/app/models/home_feed.rb
+++ b/app/models/home_feed.rb
@@ -40,7 +40,7 @@ class HomeFeed < Feed
   def from_database(limit, max_id, since_id, min_id)
     # Note that this query will not contains direct messages
     Status
-      .where(account: [account] + account.following)
+      .where(account: [@account] + @account.following)
       .where(visibility: [:public, :unlisted, :private])
       .to_a_paginated_by_id(limit, min_id: min_id, max_id: max_id, since_id: since_id)
       .reject { |status| FeedManager.instance.filter?(:home, status, @account) }

--- a/app/models/home_feed.rb
+++ b/app/models/home_feed.rb
@@ -9,4 +9,21 @@ class HomeFeed < Feed
   def regenerating?
     redis.exists?("account:#{@account.id}:regeneration")
   end
+
+  def get(limit, max_id = nil, since_id = nil, min_id = nil)
+    limit    = limit.to_i
+    max_id   = max_id.to_i if max_id.present?
+    since_id = since_id.to_i if since_id.present?
+    min_id   = min_id.to_i if min_id.present?
+
+    statuses = from_redis(limit, max_id, since_id, min_id)
+    statuses += from_database(limit - statuses.size, statuses.last&.id || max_id, since_id) if statuses.size < limit
+    statuses
+  end
+
+  def from_database(limit, max_id, since_id)
+    Status
+      .as_home_timeline(@account, limit, max_id, since_id)
+      .reject { |status| FeedManager.instance.filter?(:home, status, @account) }
+  end
 end

--- a/app/models/home_feed.rb
+++ b/app/models/home_feed.rb
@@ -16,14 +16,33 @@ class HomeFeed < Feed
     since_id = since_id.to_i if since_id.present?
     min_id   = min_id.to_i if min_id.present?
 
-    statuses = from_redis(limit, max_id, since_id, min_id)
-    statuses += from_database(limit - statuses.size, statuses.last&.id || max_id, since_id) if statuses.size < limit
+    if min_id.present? and (redis_min_id.nil? or redis_min_id > min_id)
+      # Redis doesn't have enough data for this min_id, so fetch it from only the database
+      statuses = from_database(limit, max_id, since_id, min_id)
+    else
+      statuses = from_redis(limit, max_id, since_id, min_id)
+
+      if statuses.size < limit
+        remaining_limit = limit - statuses.size
+        max_id = statuses.last.id if statuses.size > 0
+
+        statuses += from_database(limit, max_id, since_id, min_id)
+      end
+    end
+
     statuses
   end
 
-  def from_database(limit, max_id, since_id)
+  protected
+
+  def redis_min_id
+    from_redis(1, nil, nil, 0).first&.id
+  end
+
+  def from_database(limit, max_id, since_id, min_id)
     Status
-      .as_home_timeline(@account, limit, max_id, since_id)
+      .as_home_timeline(@account, limit, max_id, since_id, min_id)
       .reject { |status| FeedManager.instance.filter?(:home, status, @account) }
+      .sort_by{ |status| -status.id }
   end
 end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -335,17 +335,6 @@ class Status < ApplicationRecord
       where(language: nil).or where(language: account.chosen_languages)
     end
 
-    def as_home_timeline(account, limit = 20, max_id = nil, since_id = nil, min_id = nil)
-      selected = where(account: [account] + account.following)
-                 .where(visibility: [:public, :unlisted, :private])
-                 .limit(limit)
-      if min_id.present?
-        selected.paginate_by_min_id(limit, min_id)
-      else
-        selected.paginate_by_max_id(limit, max_id, since_id)
-      end
-    end
-
     def as_direct_timeline(account, limit = 20, max_id = nil, since_id = nil, cache_ids = false)
       # direct timeline is mix of direct message from_me and to_me.
       # 2 queries are executed with pagination.

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -335,6 +335,13 @@ class Status < ApplicationRecord
       where(language: nil).or where(language: account.chosen_languages)
     end
 
+    def as_home_timeline(account, limit = 20, max_id = nil, since_id = nil)
+      where(account: [account] + account.following)
+        .where(visibility: [:public, :unlisted, :private])
+        .limit(limit)
+        .paginate_by_max_id(limit, max_id, since_id)
+    end
+
     def as_direct_timeline(account, limit = 20, max_id = nil, since_id = nil, cache_ids = false)
       # direct timeline is mix of direct message from_me and to_me.
       # 2 queries are executed with pagination.

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -335,11 +335,15 @@ class Status < ApplicationRecord
       where(language: nil).or where(language: account.chosen_languages)
     end
 
-    def as_home_timeline(account, limit = 20, max_id = nil, since_id = nil)
-      where(account: [account] + account.following)
+    def as_home_timeline(account, limit = 20, max_id = nil, since_id = nil, min_id = nil)
+      selected = where(account: [account] + account.following)
         .where(visibility: [:public, :unlisted, :private])
         .limit(limit)
-        .paginate_by_max_id(limit, max_id, since_id)
+      if min_id.present?
+        selected.paginate_by_min_id(limit, min_id)
+      else
+        selected.paginate_by_max_id(limit, max_id, since_id)
+      end
     end
 
     def as_direct_timeline(account, limit = 20, max_id = nil, since_id = nil, cache_ids = false)

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -337,8 +337,8 @@ class Status < ApplicationRecord
 
     def as_home_timeline(account, limit = 20, max_id = nil, since_id = nil, min_id = nil)
       selected = where(account: [account] + account.following)
-        .where(visibility: [:public, :unlisted, :private])
-        .limit(limit)
+                 .where(visibility: [:public, :unlisted, :private])
+                 .limit(limit)
       if min_id.present?
         selected.paginate_by_min_id(limit, min_id)
       else

--- a/spec/models/home_feed_spec.rb
+++ b/spec/models/home_feed_spec.rb
@@ -27,6 +27,11 @@ RSpec.describe HomeFeed, type: :model do
         expect(results.map(&:id)).to eq [3, 2, 1]
         expect(results.first.attributes.keys).to eq %w(id updated_at)
       end
+
+      it 'with min_id present' do
+        results = subject.get(3, nil, nil, 0)
+        expect(results.map(&:id)).to eq [3, 2, 1]
+      end
     end
 
     context 'when feed is being generated' do
@@ -38,6 +43,11 @@ RSpec.describe HomeFeed, type: :model do
         results = subject.get(3)
 
         expect(results.map(&:id)).to eq [10, 3, 2]
+      end
+
+      it 'with min_id present' do
+        results = subject.get(3, nil, nil, 0)
+        expect(results.map(&:id)).to eq [3, 2, 1]
       end
     end
   end

--- a/spec/models/home_feed_spec.rb
+++ b/spec/models/home_feed_spec.rb
@@ -21,10 +21,10 @@ RSpec.describe HomeFeed, type: :model do
         )
       end
 
-      it 'gets statuses with ids in the range from redis' do
+      it 'gets statuses with ids in the range from redis with database' do
         results = subject.get(3)
 
-        expect(results.map(&:id)).to eq [3, 2]
+        expect(results.map(&:id)).to eq [3, 2, 1]
         expect(results.first.attributes.keys).to eq %w(id updated_at)
       end
     end
@@ -34,10 +34,10 @@ RSpec.describe HomeFeed, type: :model do
         Redis.current.set("account:#{account.id}:regeneration", true)
       end
 
-      it 'returns nothing' do
+      it 'returns from database' do
         results = subject.get(3)
 
-        expect(results.map(&:id)).to eq []
+        expect(results.map(&:id)).to eq [10, 3, 2]
       end
     end
   end


### PR DESCRIPTION
Currently, Mastodon limits home timeline size to 400. And cannot load over this limit.
it could be small for all night feed  or someone having much followings

This PR makes home timeline can be fetched without limit.
But still use redis cache to store newest 400 posts.