### PR TITLE
Fix clicking on account name in “[xxx] boosted” text leading to broken path

### DIFF
--- a/app/javascript/flavours/glitch/components/status_prepend.js
+++ b/app/javascript/flavours/glitch/components/status_prepend.js
@@ -17,7 +17,7 @@ export default class StatusPrepend extends React.PureComponent {
 
   handleClick = (e) => {
     const { account, parseClick } = this.props;
-    parseClick(e, `/${account.get('acct')}`);
+    parseClick(e, `/@${account.get('acct')}`);
   }
 
   Message = () => {


### PR DESCRIPTION
Regression from port of recent upstream changes