### PR TITLE
Push docker builds to ghcr instead instead of Mastodon's docker hub

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -14,14 +14,15 @@ jobs:
       - uses: docker/setup-buildx-action@v1
       - uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: docker/metadata-action@v3
         id: meta
         with:
-          images: tootsuite/mastodon
+          images: ghcr.io/${{ github.repository_owner }}/mastodon
           flavor: |
-            latest=auto
+            latest=true
           tags: |
             type=edge,branch=main
             type=semver,pattern={{ raw }}
@@ -30,5 +31,5 @@ jobs:
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
-          cache-from: type=registry,ref=tootsuite/mastodon:latest
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/mastodon:latest
           cache-to: type=inline


### PR DESCRIPTION
This reverts commit 4b616c4f0a2158883034cd756391bd70265b787d.