### PR TITLE
Remove reference to dev.glitch.social from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [circleci]: https://circleci.com/gh/glitch-soc/mastodon
 [code_climate]: https://codeclimate.com/github/glitch-soc/mastodon
 
-So here's the deal: we all work on this code, and then it runs on dev.glitch.social and anyone who uses that does so absolutely at their own risk. can you dig it?
+So here's the deal: we all work on this code, and anyone who uses that does so absolutely at their own risk. can you dig it?
 
 - You can view documentation for this project at [glitch-soc.github.io/docs/](https://glitch-soc.github.io/docs/).
 - And contributing guidelines are available [here](CONTRIBUTING.md) and [here](https://glitch-soc.github.io/docs/contributing/).


### PR DESCRIPTION
Fixes #1584

It's been down for a while.