### PR TITLE
Improve explanations around the hCaptcha feature

### DIFF
--- a/app/views/auth/confirmations/captcha.html.haml
+++ b/app/views/auth/confirmations/captcha.html.haml
@@ -1,8 +1,11 @@
 - content_for :page_title do
-  = t('auth.confirm_captcha')
+  = t('auth.captcha_confirmation.title')
 
 = form_tag auth_captcha_confirmation_url, method: 'POST', class: 'simple_form' do
   = hidden_field_tag :confirmation_token, params[:confirmation_token]
+
+  .field-group
+    %p.hint= t('auth.captcha_confirmation.hint_html')
 
   .field-group
     = render_captcha

--- a/config/locales-glitch/en.yml
+++ b/config/locales-glitch/en.yml
@@ -22,7 +22,7 @@ en:
         title: Show replies in public timelines
   auth:
     captcha_confirmation:
-      hint_html: Just one more step! To confirm your account, this server requires you to solve a CAPTCHA. Contact the server administrator if you have questions or need assistance with confirming your account.
+      hint_html: Just one more step! To confirm your account, this server requires you to solve a CAPTCHA. You can <a href="/about/more">contact the server administrator</a> if you have questions or need assistance with confirming your account.
       title: User verification
   generic:
     use_this: Use this

--- a/config/locales-glitch/en.yml
+++ b/config/locales-glitch/en.yml
@@ -3,8 +3,8 @@ en:
   admin:
     settings:
       captcha_enabled:
-        desc_html: Enable hCaptcha integration, requiring new users to solve a challenge when confirming their email address. This requires third-party scripts from hCaptcha to be embedded in the email verification page, which may have security and privacy concerns. Users that have been invited through a limited-use invite will not need to solve a CAPTCHA challenge.
-        title: Require new users to go through a CAPTCHA to confirm their account
+        desc_html: This relies on external scripts from hCaptcha, which may be a security and privacy concern. In addition, <strong>this can make the registration process significantly less accessible to some (especially disabled) people</strong>. For these reasons, please consider alternative measures such as approval-based or invite-based registration.<br>Users that have been invited through a limited-use invite will not need to solve a CAPTCHA
+        title: Require new users to solve a CAPTCHA to confirm their account
       enable_keybase:
         desc_html: Allow your users to prove their identity via keybase
         title: Enable keybase integration

--- a/config/locales-glitch/en.yml
+++ b/config/locales-glitch/en.yml
@@ -21,7 +21,9 @@ en:
         desc_html: In addition to public self-replies (threads), show public replies in local and public timelines.
         title: Show replies in public timelines
   auth:
-    confirm_captcha: User verification
+    captcha_confirmation:
+      hint_html: Just one more step! To confirm your account, this server requires you to solve a CAPTCHA. Contact the server administrator if you have questions or need assistance with confirming your account.
+      title: User verification
   generic:
     use_this: Use this
   settings:


### PR DESCRIPTION
Reworded the admin setting description, adding a bit about accessibility issues:
![image](https://user-images.githubusercontent.com/384364/151162864-d31f6fcd-d27e-4b72-b38f-933158cfa279.png)

Added some explanation on the confirmation page:
![image](https://user-images.githubusercontent.com/384364/151162811-21691bae-7b4b-4198-8fb4-1d1ec3046523.png)