### PR TITLE
Make the settings button go to settings when opened in a new tab

### DIFF
--- a/app/javascript/flavours/glitch/features/compose/components/header.js
+++ b/app/javascript/flavours/glitch/features/compose/components/header.js
@@ -119,7 +119,7 @@ class Header extends ImmutablePureComponent {
         <a
           aria-label={intl.formatMessage(messages.settings)}
           onClick={onSettingsClick}
-          href='#'
+          href='/settings/preferences'
           title={intl.formatMessage(messages.settings)}
         ><Icon id='cogs' /></a>
         <a


### PR DESCRIPTION
In vanilla mastodon, using the advanced web view, the cog icon is effectively just a link. Left clicking it brings you to /settings/preferences, and middle clicking it does the same in a new tab.

Glitch-soc's cog icon is a special button, and clicking it opens the app preferences modal containing a link to /settings/preferences. This PR does not change that, the normal button behaviour is intact.

However, currently, middle clicking the button to open a new tab simply opens a new /web tab. It's not exactly helpful. This PR restores the vanilla behaviour, where middle clicking the button opens /settings/preferences. This is a convenient shortcut to what would otherwise be two clicks away, and also prevents the current (confusing) behaviour.