### PR TITLE
Fix blank screen when trying to copy emoji with a too large file size

### DIFF
--- a/app/controllers/admin/custom_emojis_controller.rb
+++ b/app/controllers/admin/custom_emojis_controller.rb
@@ -35,6 +35,9 @@ module Admin
       flash[:alert] = I18n.t('admin.accounts.no_account_selected')
     rescue Mastodon::NotPermittedError
       flash[:alert] = I18n.t('admin.custom_emojis.not_permitted')
+    rescue ActiveRecord::RecordInvalid => e
+      error_message = action_from_button == 'copy' ? 'admin.custom_emojis.batch_copy_error' : 'admin.custom_emojis.batch_error'
+      flash[:alert] = I18n.t(error_message, message: e.message)
     ensure
       redirect_to admin_custom_emojis_path(filter_params)
     end

--- a/config/locales-glitch/en.yml
+++ b/config/locales-glitch/en.yml
@@ -1,6 +1,9 @@
 ---
 en:
   admin:
+    custom_emojis:
+      batch_copy_error: 'An error occurred when copying some of the selected emoji: %{message}'
+      batch_error: 'An error occurred: %{message}'
     settings:
       captcha_enabled:
         desc_html: This relies on external scripts from hCaptcha, which may be a security and privacy concern. In addition, <strong>this can make the registration process significantly less accessible to some (especially disabled) people</strong>. For these reasons, please consider alternative measures such as approval-based or invite-based registration.<br>Users that have been invited through a limited-use invite will not need to solve a CAPTCHA


### PR DESCRIPTION
Fixes #1714