### PR TITLE
fix typo in `<sub>` CSS styles

### DIFF
--- a/app/javascript/flavours/glitch/styles/components/composer.scss
+++ b/app/javascript/flavours/glitch/styles/components/composer.scss
@@ -206,7 +206,7 @@
 
     sub {
       font-size: smaller;
-      text-align: sub;
+      vertical-align: sub;
     }
 
     ul, ol {

--- a/app/javascript/flavours/glitch/styles/components/composer.scss
+++ b/app/javascript/flavours/glitch/styles/components/composer.scss
@@ -209,6 +209,11 @@
       vertical-align: sub;
     }
 
+    sup {
+      font-size: smaller;
+      vertical-align: super;
+    }
+
     ul, ol {
       margin-left: 1em;
 

--- a/app/javascript/flavours/glitch/styles/components/status.scss
+++ b/app/javascript/flavours/glitch/styles/components/status.scss
@@ -125,7 +125,7 @@
 
     sub {
       font-size: smaller;
-      text-align: sub;
+      vertical-align: sub;
     }
 
     sup {


### PR DESCRIPTION
There is a small typo in the styles for the `<sub>` element: it uses `text-align` where it should use `vertical-align`, like `<sup>` does.  This fixes that.  It also adds a style for `<sup>` to the composer, which seems to have been missing.