### PR TITLE
Remove “I don't like it” option from report modal

### DIFF
--- a/app/javascript/flavours/glitch/features/report/category.js
+++ b/app/javascript/flavours/glitch/features/report/category.js
@@ -64,12 +64,10 @@ class Category extends React.PureComponent {
     const { category, startedFrom, rules, intl } = this.props;
 
     const options = rules.size > 0 ? [
-      'dislike',
       'spam',
       'violation',
       'other',
     ] : [
-      'dislike',
       'spam',
       'other',
     ];


### PR DESCRIPTION
When a user clicks the “report” button, they usually want to actually make a report, which the “I don't like it” option does not do, and instead only reminds them of the “mute”, “block” (and “unfollow”) options. But those options are always alongside the “report” one, so I feel this report option is not useful, and instead just makes the flow a bit confusing and discouraging.