### PR TITLE
Fix incorrect upload size limit hint at /admin/custom_emojis/new

### DIFF
--- a/app/views/admin/custom_emojis/new.html.haml
+++ b/app/views/admin/custom_emojis/new.html.haml
@@ -7,7 +7,7 @@
   .fields-group
     = f.input :shortcode, wrapper: :with_label, label: t('admin.custom_emojis.shortcode'), hint: t('admin.custom_emojis.shortcode_hint')
   .fields-group
-    = f.input :image, wrapper: :with_label, input_html: { accept: CustomEmoji::IMAGE_MIME_TYPES.join(' ') }, hint: t('admin.custom_emojis.image_hint', size: number_to_human_size(CustomEmoji::LIMIT))
+    = f.input :image, wrapper: :with_label, input_html: { accept: CustomEmoji::IMAGE_MIME_TYPES.join(' ') }, hint: t('admin.custom_emojis.image_hint', size: number_to_human_size(CustomEmoji::LOCAL_LIMIT))
 
   .actions
     = f.button :button, t('admin.custom_emojis.upload'), type: :submit


### PR DESCRIPTION
Currently, with glitch-soc, at the path `/admin/custom_emojis/new`, with default production values, the hint for the image input will say "PNG or GIF up to 200 KB". When you upload something that's larger than 50 KB, the default local upload limit, it will say: "must be less than 50 KB". See screenshot below:

![image](https://user-images.githubusercontent.com/23276523/166967959-c72de604-1bfa-4854-a749-6b86e7013340.png)

Instead of reporting the issue separately, I went ahead and made this rather simple PR after testing it on my own instance beforehand.