### PR TITLE
Use slightly more margin between post buttons (under compose box)

### DIFF
--- a/app/javascript/flavours/glitch/styles/components/composer.scss
+++ b/app/javascript/flavours/glitch/styles/components/composer.scss
@@ -634,7 +634,7 @@
 
   & > .side_arm {
     display: inline-block;
-    margin: 0 2px;
+    margin: 0 5px;
     padding: 7px 0;
     width: 36px;
     text-align: center;


### PR DESCRIPTION
Before/after:
![image](https://user-images.githubusercontent.com/2446451/180797894-12d5941b-87bb-4372-a7ab-ccab77a9b972.png) ![image](https://user-images.githubusercontent.com/2446451/180798019-23810624-3902-42ac-81d5-581aa7931e83.png)

It looks a bit more natural (10px made the buttons look too distant from each other).