### PR TITLE
Add tag id to API response

### DIFF
--- a/app/serializers/rest/tag_serializer.rb
+++ b/app/serializers/rest/tag_serializer.rb
@@ -3,9 +3,13 @@
 class REST::TagSerializer < ActiveModel::Serializer
   include RoutingHelper
 
-  attributes :name, :url, :history
+  attributes :id, :name, :url, :history
 
   attribute :following, if: :current_user?
+
+  def id
+    object.id.to_s
+  end
 
   def url
     tag_url(object)


### PR DESCRIPTION
This fixes the broken trending hashtag links in the admin dashboard.

I'm not sure if this is the best way to do things, or if exposing the ID of a tag is a Bad Idea. 

I think this dashboard used to use the FeaturedTag Serializer from [mastodon/mastodon#11778](https://github.com/mastodon/mastodon/pull/11778), so it's very possible this is an upstream issue. Regardless, this would fix #1821.