### PR TITLE
Fix error when accessing /filters/:id/statuses on glitch-soc

### DIFF
--- a/app/controllers/filters/statuses_controller.rb
+++ b/app/controllers/filters/statuses_controller.rb
@@ -6,6 +6,7 @@ class Filters::StatusesController < ApplicationController
   before_action :authenticate_user!
   before_action :set_filter
   before_action :set_status_filters
+  before_action :set_pack
   before_action :set_body_classes
 
   PER_PAGE = 20
@@ -24,6 +25,10 @@ class Filters::StatusesController < ApplicationController
   end
 
   private
+
+  def set_pack
+    use_pack 'admin'
+  end
 
   def set_filter
     @filter = current_account.custom_filters.find(params[:filter_id])

--- a/app/views/filters/statuses/index.html.haml
+++ b/app/views/filters/statuses/index.html.haml
@@ -1,6 +1,3 @@
-- content_for :header_tags do
-  = javascript_pack_tag 'admin', async: true, crossorigin: 'anonymous'
-
 - content_for :page_title do
   = t('filters.statuses.index.title')
   \-


### PR DESCRIPTION
I failed to account for glitch-soc's theming system when merging from upstream.