### PR TITLE
Fix audio always being re-encoded even for passthrough-eligible media

### DIFF
--- a/lib/paperclip/transcoder.rb
+++ b/lib/paperclip/transcoder.rb
@@ -40,8 +40,10 @@ module Paperclip
         @output_options['f']       = 'image2'
         @output_options['vframes'] = 1
       when 'mp4'
-        @output_options['acodec'] = 'aac'
-        @output_options['strict'] = 'experimental'
+        unless eligible_to_passthrough?(metadata)
+          @output_options['acodec'] = 'aac'
+          @output_options['strict'] = 'experimental'
+        end
 
         if high_vfr?(metadata) && !eligible_to_passthrough?(metadata)
           @output_options['vsync'] = 'vfr'


### PR DESCRIPTION
The FFmpeg built-in AAC encoder has *atrocious* quality and should be avoided. I've tested this change on my instance.

Re-encoding the perfectly fine FDK-AAC audio in a video upload into a crumpled mess is *very* rude.

## Before
<pre>
sidekiq_1    | Command :: ffmpeg -nostdin -i '/tmp/[snip].mp4'
    -loglevel 'fatal' -map_metadata '-1' -c:v 'copy' -c:a 'copy' <b>-acodec 'aac' -strict 'experimental'</b>
   -y '/tmp/[snip].mp4'
</pre>
:rotating_light: This overrides the previous `-c:a 'copy'` - `-c:a` is the modern syntax for `acodec`.

## After
```
sidekiq_1    | Command :: ffmpeg -nostdin -i '/tmp/[snip].mp4'
   -loglevel 'fatal' -map_metadata '-1' -c:v 'copy' -c:a 'copy'
    -y '/tmp/[snip].mp4'
```
:heavy_check_mark: Audio is actually copied.

----

This also saves a lot of time (and generation loss) when federating media from other instances. Remuxing is a very fast operation compared to re-encoding, and other Mastodon instances will always emit passthrough-eligible media.