### PR TITLE
Glitch soc/improve composer toolbar spacings

### DIFF
--- a/app/javascript/flavours/glitch/styles/components/composer.scss
+++ b/app/javascript/flavours/glitch/styles/components/composer.scss
@@ -528,7 +528,8 @@
   display: flex;
   flex: 0 0 auto;
 
-  & > * {
+  & .icon-button,
+  & .text-icon-button {
     display: inline-block;
     box-sizing: content-box;
     padding: 0 3px;


### PR DESCRIPTION
Before/After:
![Screenshot_20220907_180112](https://user-images.githubusercontent.com/2446451/188925497-11b0924f-b6e4-4e58-a057-39cacb8cd06a.png)
![Screenshot_20220907_175956](https://user-images.githubusercontent.com/2446451/188925498-ad148f76-f408-455c-953d-4744f2d0136d.png)

It’s a lot more like upstream Mastodon: all buttons have the same size, no visible space between buttons, and CW and the langue label should always be aligned (though that’s hard to test).