### PR TITLE
Clarify language RE secondary toot button

### DIFF
--- a/app/javascript/flavours/glitch/features/local_settings/page/index.js
+++ b/app/javascript/flavours/glitch/features/local_settings/page/index.js
@@ -20,7 +20,7 @@ const messages = defineMessages({
   layout_mobile: { id: 'layout.single', defaultMessage: 'Mobile' },
   layout_mobile_hint: { id: 'layout.hint.single', defaultMessage: 'Use single-column layout regardless of the “Enable advanced web interface” setting or screen size.' },
   side_arm_none: { id: 'settings.side_arm.none', defaultMessage: 'None' },
-  side_arm_keep: { id: 'settings.side_arm_reply_mode.keep', defaultMessage: 'Keep secondary toot button to set privacy' },
+  side_arm_keep: { id: 'settings.side_arm_reply_mode.keep', defaultMessage: 'Keep its set privacy' },
   side_arm_copy: { id: 'settings.side_arm_reply_mode.copy', defaultMessage: 'Copy privacy setting of the toot being replied to' },
   side_arm_restrict: { id: 'settings.side_arm_reply_mode.restrict', defaultMessage: 'Restrict privacy setting to that of the toot being replied to' },
   regexp: { id: 'settings.content_warnings.regexp', defaultMessage: 'Regular expression' },
@@ -292,7 +292,7 @@ class LocalSettingsPage extends React.PureComponent {
           ]}
           onChange={onChange}
         >
-          <FormattedMessage id='settings.side_arm_reply_mode' defaultMessage='When replying to a toot:' />
+          <FormattedMessage id='settings.side_arm_reply_mode' defaultMessage='When replying to a toot, the secondary toot button should:' />
         </LocalSettingsPageItem>
       </div>
     ),

--- a/app/javascript/flavours/glitch/locales/es.js
+++ b/app/javascript/flavours/glitch/locales/es.js
@@ -93,7 +93,7 @@ const messages = {
   'settings.side_arm_reply_mode.copy': 'Copiar opción de privacidad del toot al que estás respondiendo',
   'settings.side_arm_reply_mode.keep': 'Conservar opción de privacidad',
   'settings.side_arm_reply_mode.restrict': 'Restringir la opción de privacidad a la misma del toot al que estás respondiendo',
-  'settings.side_arm_reply_mode': 'Al responder a un toot:',
+  'settings.side_arm_reply_mode': 'Al responder a un toot, el botón de toot secundario debe:',
   'settings.side_arm.none': 'Ninguno',
   'settings.side_arm': 'Botón secundario:',
   'settings.swipe_to_change_columns': 'Permitir deslizar para cambiar columnas (Sólo en móvil)',


### PR DESCRIPTION
I did not change any of the translations I didn't feel qualified to, sorry. For what it's worth, I checked them with Google Translate and all of the translations except for `settings.side_arm_reply_mode` seemed to continue to make sense following this change.

Fixes #1850 