### PR TITLE
Remove/update old "tootsuite" references, except those needed for Docker

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -17,7 +17,7 @@
 LOCAL_DOMAIN=example.com
 
 # Use this only if you need to run mastodon on a different domain than the one used for federation.
-# You can read more about this option on https://github.com/tootsuite/documentation/blob/master/Running-Mastodon/Serving_a_different_domain.md
+# You can read more about this option on https://docs.joinmastodon.org/admin/config/#web-domain
 # DO *NOT* USE THIS UNLESS YOU KNOW *EXACTLY* WHAT YOU ARE DOING.
 # WEB_DOMAIN=mastodon.example.com
 
@@ -247,7 +247,7 @@ SMTP_FROM_ADDRESS=notifications@example.com
 # ---------------
 # Various ways to customize Mastodon's behavior
 # ---------------
- 
+
 # Maximum allowed character count
 MAX_TOOT_CHARS=500
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ See the guidelines below.
 
  - - -
 
-You should also try to follow the guidelines set out in the original `CONTRIBUTING.md` from `tootsuite/mastodon`, reproduced below.
+You should also try to follow the guidelines set out in the original `CONTRIBUTING.md` from `mastodon/mastodon`, reproduced below.
 
 <blockquote>
 

--- a/app/javascript/flavours/glitch/components/intersection_observer_article.js
+++ b/app/javascript/flavours/glitch/components/intersection_observer_article.js
@@ -94,7 +94,7 @@ export default class IntersectionObserverArticle extends React.Component {
     // When the browser gets a chance, test if we're still not intersecting,
     // and if so, set our isHidden to true to trigger an unrender. The point of
     // this is to save DOM nodes and avoid using up too much memory.
-    // See: https://github.com/tootsuite/mastodon/issues/2900
+    // See: https://github.com/mastodon/mastodon/issues/2900
     this.setState((prevState) => ({ isHidden: !prevState.isIntersecting }));
   }
 

--- a/app/javascript/flavours/glitch/features/ui/components/link_footer.js
+++ b/app/javascript/flavours/glitch/features/ui/components/link_footer.js
@@ -43,7 +43,7 @@ class LinkFooter extends React.PureComponent {
     e.stopPropagation();
 
     this.props.onLogout();
- 
+
     return false;
   }
 
@@ -68,7 +68,7 @@ class LinkFooter extends React.PureComponent {
             defaultMessage='Glitchsoc is open source software, a friendly fork of {Mastodon}. You can contribute or report issues on GitHub at {github}.'
             values={{
               github: <span><a href={source_url} rel='noopener noreferrer' target='_blank'>{repository}</a> (v{version})</span>,
-              Mastodon: <a href='https://github.com/tootsuite/mastodon' rel='noopener noreferrer' target='_blank'>Mastodon</a> }}
+              Mastodon: <a href='https://github.com/mastodon/mastodon' rel='noopener noreferrer' target='_blank'>Mastodon</a> }}
           />
         </p>
       </div>

--- a/app/javascript/flavours/glitch/features/ui/components/onboarding_modal.js
+++ b/app/javascript/flavours/glitch/features/ui/components/onboarding_modal.js
@@ -148,7 +148,7 @@ const PageSix = ({ admin, domain }) => {
           values={{
             domain,
             fork: <a href='https://en.wikipedia.org/wiki/Fork_(software_development)' target='_blank' rel='noopener'>fork</a>,
-            Mastodon: <a href='https://github.com/tootsuite/mastodon' target='_blank' rel='noopener'>Mastodon</a>,
+            Mastodon: <a href='https://github.com/mastodon/mastodon' target='_blank' rel='noopener'>Mastodon</a>,
             github: <a href={source_url} target='_blank' rel='noopener'>GitHub</a>,
           }}
         />

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -24,7 +24,7 @@ mastodon:
     removeMedia:
       enabled: true
       schedule: "0 0 * * 0"
-  # available locales: https://github.com/tootsuite/mastodon/blob/master/config/application.rb#L43
+  # available locales: https://github.com/mastodon/mastodon/blob/main/config/application.rb#L71
   locale: en
   local_domain: mastodon.local
   # Use of WEB_DOMAIN requires careful consideration: https://docs.joinmastodon.org/admin/config/#federation
@@ -261,7 +261,7 @@ externalAuth:
     #   search: "., -"
     #   replace: _
 
-# https://github.com/tootsuite/mastodon/blob/master/Dockerfile#L88
+# https://github.com/mastodon/mastodon/blob/main/Dockerfile#L75
 #
 # if you manually change the UID/GID environment variables, ensure these values
 # match:

--- a/db/migrate/20170918125918_ids_to_bigints.rb
+++ b/db/migrate/20170918125918_ids_to_bigints.rb
@@ -80,7 +80,7 @@ class IdsToBigints < ActiveRecord::Migration[5.1]
       say 'This migration has some sections that can be safely interrupted'
       say 'and restarted later, and will tell you when those are occurring.'
       say ''
-      say 'For more information, see https://github.com/tootsuite/mastodon/pull/5088'
+      say 'For more information, see https://github.com/mastodon/mastodon/pull/5088'
 
       10.downto(1) do |i|
         say "Continuing in #{i} second#{i == 1 ? '' : 's'}...", true


### PR DESCRIPTION
May potentially need rebase against https://github.com/mastodon/mastodon/pull/19327 if merged there too, but glitch-soc has some extra "tootsuite" leftovers.