### PR TITLE
Use `DEFAULT_FIELDS_SIZE`/`MAX_PROFILE_FIELDS` value in settings form hint

### DIFF
--- a/app/views/settings/profiles/show.html.haml
+++ b/app/views/settings/profiles/show.html.haml
@@ -40,8 +40,8 @@
   .fields-row
     .fields-row__column.fields-group.fields-row__column-6
       .input.with_block_label
-        %label= t('simple_form.labels.defaults.fields')
-        %span.hint= t('simple_form.hints.defaults.fields')
+        %label= t('simple_form.labels.defaults.fields', count: Account::DEFAULT_FIELDS_SIZE)
+        %span.hint= t('simple_form.hints.defaults.fields', count: Account::DEFAULT_FIELDS_SIZE)
 
         = f.simple_fields_for :fields do |fields_f|
           .row

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -39,7 +39,7 @@ en:
         digest: Only sent after a long period of inactivity and only if you have received any personal messages in your absence
         discoverable: Allow your account to be discovered by strangers through recommendations, trends and other features
         email: You will be sent a confirmation e-mail
-        fields: You can have up to 4 items displayed as a table on your profile
+        fields: You can have up to %{count} items displayed as a table on your profile
         header: PNG, GIF or JPG. At most %{size}. Will be downscaled to %{dimensions}px
         inbox_url: Copy the URL from the frontpage of the relay you want to use
         irreversible: Filtered posts will disappear irreversibly, even if filter is later removed


### PR DESCRIPTION
Use `Account::DEFAULT_FIELDS_SIZE` in the hint, which would fallback to 4 if the environment variable isn't set.

<img width="359" alt="image" src="https://user-images.githubusercontent.com/83595468/196568544-a5410179-749d-4aeb-af30-69dfac120fb5.png">
