### PR TITLE
Change ul, ol margin-left to 2em

### DIFF
--- a/app/javascript/flavours/glitch/styles/components/status.scss
+++ b/app/javascript/flavours/glitch/styles/components/status.scss
@@ -134,7 +134,7 @@
     }
 
     ul, ol {
-      margin-left: 1em;
+      margin-left: 2em;
 
       p {
         margin: 0;


### PR DESCRIPTION
Fixes #1878

### Firefox, macOS
<img width="343" alt="image" src="https://user-images.githubusercontent.com/83595468/199152262-1a20d036-666c-4fbe-9b43-49edb9c5e055.png">


### Safari, iOS
![IMG_1870](https://user-images.githubusercontent.com/83595468/199152306-6516139d-a009-4865-8131-4fb19ee56c64.png)


### Safari, macOS
<img width="626" alt="Screenshot 2022-10-31 at 22 27 18" src="https://user-images.githubusercontent.com/83595468/199152196-3ea0cdd0-e1b3-4b36-9825-7c8dcf82e740.png">
