### PR TITLE
Allow Publish button text to be customizable

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -294,6 +294,11 @@ MAX_POLL_OPTION_CHARS=100
 # HCAPTCHA_SECRET_KEY=
 # HCAPTCHA_SITE_KEY=
 
+# Publish Button Text
+# If the following is set, the publish button text will no
+# longer be translated!
+# PUBLISH_BUTTON_TEXT=Toot
+
 # IP and session retention
 # -----------------------
 # Make sure to modify the scheduling of ip_cleanup_scheduler in config/sidekiq.yml

--- a/app/javascript/flavours/glitch/features/compose/components/publisher.js
+++ b/app/javascript/flavours/glitch/features/compose/components/publisher.js
@@ -11,7 +11,7 @@ import Button from 'flavours/glitch/components/button';
 import Icon from 'flavours/glitch/components/icon';
 
 //  Utils.
-import { maxChars } from 'flavours/glitch/initial_state';
+import { maxChars, publishButtonText } from 'flavours/glitch/initial_state';
 
 //  Messages.
 const messages = defineMessages({
@@ -60,13 +60,25 @@ class Publisher extends ImmutablePureComponent {
       publishText = intl.formatMessage(messages.saveChanges);
     } else if (privacy === 'private' || privacy === 'direct') {
       const iconId = privacyIcons[privacy];
-      publishText = (
-        <span>
-          <Icon id={iconId} /> {intl.formatMessage(messages.publish)}
-        </span>
-      );
+      if (publishButtonText !== null){
+        publishText = (
+          <span>
+            <Icon id={iconId} /> {publishButtonText}
+          </span>
+        );
+      } else {
+        publishText = (
+          <span>
+            <Icon id={iconId} /> {intl.formatMessage(messages.publish)}
+          </span>
+        );
+      }
     } else {
-      publishText = privacy !== 'unlisted' ? intl.formatMessage(messages.publishLoud, { publish: intl.formatMessage(messages.publish) }) : intl.formatMessage(messages.publish);
+      if (publishButtonText !== null){
+        publishText = privacy !== 'unlisted' ? publishButtonText+'!' : publishButtonText;
+      } else {
+        publishText = privacy !== 'unlisted' ? intl.formatMessage(messages.publishLoud, { publish: intl.formatMessage(messages.publish) }) : intl.formatMessage(messages.publish);
+      }
     }
 
     return (

--- a/app/javascript/flavours/glitch/initial_state.js
+++ b/app/javascript/flavours/glitch/initial_state.js
@@ -141,5 +141,6 @@ export const favouriteModal = getMeta('favourite_modal');
 export const pollLimits = (initialState && initialState.poll_limits);
 export const defaultContentType = getMeta('default_content_type');
 export const useSystemEmojiFont = getMeta('system_emoji_font');
+export const publishButtonText = (initialState && initialState.publish_button_text);  // Should be null when not set
 
 export default initialState;

--- a/app/javascript/mastodon/features/compose/components/compose_form.js
+++ b/app/javascript/mastodon/features/compose/components/compose_form.js
@@ -21,7 +21,7 @@ import ImmutablePureComponent from 'react-immutable-pure-component';
 import { length } from 'stringz';
 import { countableText } from '../util/counter';
 import Icon from 'mastodon/components/icon';
-import { maxChars } from '../../../initial_state';
+import { maxChars, publishButtonText } from '../../../initial_state';
 
 const allowedAroundShortCode = '><\u0085\u0020\u00a0\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u202f\u205f\u3000\u2028\u2029\u0009\u000a\u000b\u000c\u000d';
 
@@ -212,9 +212,17 @@ class ComposeForm extends ImmutablePureComponent {
     if (this.props.isEditing) {
       publishText = intl.formatMessage(messages.saveChanges);
     } else if (this.props.privacy === 'private' || this.props.privacy === 'direct') {
-      publishText = <span className='compose-form__publish-private'><Icon id='lock' /> {intl.formatMessage(messages.publish)}</span>;
+      if (publishButtonText !== null){
+        publishText = <span className='compose-form__publish-private'><Icon id='lock' /> {publishButtonText}</span>;
+      } else {
+        publishText = <span className='compose-form__publish-private'><Icon id='lock' /> {intl.formatMessage(messages.publish)}</span>;
+      }
     } else {
-      publishText = this.props.privacy !== 'unlisted' ? intl.formatMessage(messages.publishLoud, { publish: intl.formatMessage(messages.publish) }) : intl.formatMessage(messages.publish);
+      if (publishButtonText !== null){
+        publishText = this.props.privacy !== 'unlisted' ? publishButtonText+'!' : publishButtonText;
+      } else {
+        publishText = this.props.privacy !== 'unlisted' ? intl.formatMessage(messages.publishLoud, { publish: intl.formatMessage(messages.publish) }) : intl.formatMessage(messages.publish);
+      }
     }
 
     return (

--- a/app/javascript/mastodon/initial_state.js
+++ b/app/javascript/mastodon/initial_state.js
@@ -131,5 +131,6 @@ export const languages = initialState?.languages;
 
 // Glitch-soc-specific settings
 export const maxChars = (initialState && initialState.max_toot_chars) || 500;
+export const publishButtonText = (initialState && initialState.publish_button_text);  // Should be null when not set
 
 export default initialState;

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -6,13 +6,17 @@ class InitialStateSerializer < ActiveModel::Serializer
   attributes :meta, :compose, :accounts,
              :media_attachments, :settings,
              :max_toot_chars, :poll_limits,
-             :languages
+             :languages, :publish_button_text
 
   has_one :push_subscription, serializer: REST::WebPushSubscriptionSerializer
   has_one :role, serializer: REST::RoleSerializer
 
   def max_toot_chars
     StatusLengthValidator::MAX_CHARS
+  end
+
+  def publish_button_text
+    ENV['PUBLISH_BUTTON_TEXT']
   end
 
   def poll_limits

--- a/app/serializers/rest/v1/instance_serializer.rb
+++ b/app/serializers/rest/v1/instance_serializer.rb
@@ -40,6 +40,10 @@ class REST::V1::InstanceSerializer < ActiveModel::Serializer
     StatusLengthValidator::MAX_CHARS
   end
 
+  def publish_button_text
+    ENV['PUBLISH_BUTTON_TEXT']
+  end
+
   def poll_limits
     {
       max_options: PollValidator::MAX_OPTIONS,


### PR DESCRIPTION
This feels sorta hacky, but it does the trick. Fixes #1817

**Note:** The customized text will not be translated!