### PR TITLE
Fix 'App settings' label visible in sidebar on mobile UI

### DIFF
--- a/app/javascript/flavours/glitch/features/ui/components/column_link.js
+++ b/app/javascript/flavours/glitch/features/ui/components/column_link.js
@@ -34,7 +34,7 @@ const ColumnLink = ({ icon, text, to, onClick, href, method, badge, transparent,
     return (
       <a href='#' onClick={onClick && handleOnClick} className={className} title={text} {...other} tabIndex='0'>
         {iconElement}
-        {text}
+        <span>{text}</span>
         {badgeElement}
       </a>
     );


### PR DESCRIPTION
Fixes #1887