### PR TITLE
ci: write permissions to packages

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -12,6 +12,7 @@ on:
       - Dockerfile
 permissions:
   contents: read
+  packages: write
 
 jobs:
   build-image:


### PR DESCRIPTION
This PR fixes the custom changes to push to GHCR that were broken by this commit: https://github.com/glitch-soc/mastodon/commit/af46584f826165687611d97c08dbecb8f1a0416b.

Because we're using Github Packages, we also need to set `packages` to `write`.