### PR TITLE
Use a tree‐based approach for advanced text formatting

### DIFF
--- a/app/lib/advanced_text_formatter.rb
+++ b/app/lib/advanced_text_formatter.rb
@@ -69,7 +69,7 @@ class AdvancedTextFormatter < TextFormatter
       Sanitize.node!(@tree, Sanitize::Config::MASTODON_OUTGOING)
       document = @tree.document
 
-      @tree.xpath('.//text()[not(ancestor::a)]').each do |text_node|
+      @tree.xpath('.//text()[not(ancestor::a | ancestor::code)]').each do |text_node|
         # Iterate over text elements and build up their replacements.
         content = text_node.content
         replacement = Nokogiri::XML::NodeSet.new(document)

--- a/app/lib/advanced_text_formatter.rb
+++ b/app/lib/advanced_text_formatter.rb
@@ -19,6 +19,8 @@ class AdvancedTextFormatter < TextFormatter
     end
   end
 
+  attr_reader :content_type
+
   # @param [String] text
   # @param [Hash] options
   # @option options [Boolean] :multiline
@@ -27,7 +29,7 @@ class AdvancedTextFormatter < TextFormatter
   # @option options [Array<Account>] :preloaded_accounts
   # @option options [String] :content_type
   def initialize(text, options = {})
-    content_type = options.delete(:content_type)
+    @content_type = options.delete(:content_type)
     super(text, options)
 
     @text = format_markdown(text) if content_type == 'text/markdown'
@@ -50,7 +52,7 @@ class AdvancedTextFormatter < TextFormatter
         entity.replace(link_to_mention({ screen_name: entity['value'] }))
       end
     end
-    result.to_html
+    result.to_html.html_safe # rubocop:disable Rails/OutputSafety
   end
 
   ##
@@ -84,7 +86,7 @@ class AdvancedTextFormatter < TextFormatter
             # Text node for content which precedes entity.
             replacement << Nokogiri::XML::Text.new(
               content[processed_index, advance],
-              @tree.document
+              document
             )
           end
           elt = Nokogiri::XML::Element.new('mastodon-entity', document)

--- a/spec/lib/advanced_text_formatter_spec.rb
+++ b/spec/lib/advanced_text_formatter_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe AdvancedTextFormatter do
       end
 
       context 'given a block code' do
-        let(:text) { "test\n\n```\nint main(void) {\n  return 0;\n}\n```\n" }
+        let(:text) { "test\n\n```\nint main(void) {\n  return 0; // https://joinmastodon.org/foo\n}\n```\n" }
 
         it 'formats code using <pre> and <code>' do
           is_expected.to include '<pre><code>int main'
@@ -44,13 +44,17 @@ RSpec.describe AdvancedTextFormatter do
         it 'does not strip leading spaces' do
           is_expected.to include '>  return 0'
         end
+
+        it 'does not format links' do
+          is_expected.to include 'return 0; // https://joinmastodon.org/foo'
+        end
       end
 
-      context 'given some quote' do
-        let(:text) { "> foo\n\nbar" }
+      context 'given a link in inline code using backticks' do
+        let(:text) { 'test `https://foo.bar/bar` bar' }
 
-        it 'formats code using <code>' do
-          is_expected.to include '<blockquote><p>foo</p></blockquote>'
+        it 'does not rewrite the link' do
+          is_expected.to include 'test <code>https://foo.bar/bar</code> bar'
         end
       end
 


### PR DESCRIPTION
Sanitizing HTML/Markdown means parsing the content into an HTML tree under‐the‐hood anyway, and it is more accurate to do mention/hashtag replacement on the text nodes in that tree than it is to try to hack it in with regexes et cetera.

This undoes the overrides of `#entities` and `#rewrite` on `AdvancedTextFormatter` but also stops using them, instead keeping track of the parsed Nokogiri tree itself and using that in the `#to_s` method.

Internally, this tree uses `<mastodon-entity>` nodes to keep track of hashtags, links, and mentions. Sanitization is moved to the beginning, so it should be known that these do not appear in the input.

---

(I was thinking of doing a feature locally for markdown posts, and did this as prerequisite work. Hopefully this fixes *some* of the weird mention/hashtag behaviour in HTML/Markdown.)

(I noticed that most of the other parts of the codebase, including the hashtag/mention extractors for the model, the status length validator, and the link preview card service, don’t operate on the formatted post but rather directly on its text. That means they probably have and will continue to have weird behaviour for HTML/Markdown posts.)