### PR TITLE
Add “Glitch-only” label to some settings

### DIFF
--- a/app/javascript/flavours/glitch/styles/accounts.scss
+++ b/app/javascript/flavours/glitch/styles/accounts.scss
@@ -205,7 +205,8 @@
 
 .account-role,
 .simple_form .recommended,
-.simple_form .not_recommended {
+.simple_form .not_recommended,
+.simple_form .glitch_only {
   display: inline-block;
   padding: 4px 6px;
   cursor: default;
@@ -234,6 +235,12 @@
   color: lighten($error-red, 12%);
   background-color: rgba(lighten($error-red, 12%), 0.1);
   border-color: rgba(lighten($error-red, 12%), 0.5);
+}
+
+.simple_form .glitch_only {
+  color: lighten($warning-red, 12%);
+  background-color: rgba(lighten($warning-red, 12%), 0.1);
+  border-color: rgba(lighten($warning-red, 12%), 0.5);
 }
 
 .account__header__fields {

--- a/app/javascript/flavours/glitch/styles/forms.scss
+++ b/app/javascript/flavours/glitch/styles/forms.scss
@@ -104,7 +104,8 @@ code {
       }
 
       .recommended,
-      .not_recommended {
+      .not_recommended,
+      .glitch_only {
         position: absolute;
         margin: 0 4px;
         margin-top: -2px;

--- a/app/views/admin/settings/discovery/show.html.haml
+++ b/app/views/admin/settings/discovery/show.html.haml
@@ -19,7 +19,7 @@
     = f.input :trendable_by_default, as: :boolean, wrapper: :with_label, recommended: :not_recommended
 
   .fields-group
-    = f.input :trending_status_cw, as: :boolean, wrapper: :with_label, label: t('admin.settings.trending_status_cw.title'), hint: t('admin.settings.trending_status_cw.desc_html')
+    = f.input :trending_status_cw, as: :boolean, wrapper: :with_label, label: t('admin.settings.trending_status_cw.title'), hint: t('admin.settings.trending_status_cw.desc_html'), glitch_only: true
 
   %h4= t('admin.settings.discovery.public_timelines')
 

--- a/app/views/admin/settings/registrations/show.html.haml
+++ b/app/views/admin/settings/registrations/show.html.haml
@@ -19,7 +19,7 @@
 
   - if captcha_available?
     .fields-group
-      = f.input :captcha_enabled, as: :boolean, wrapper: :with_label, label: t('admin.settings.captcha_enabled.title'), hint: t('admin.settings.captcha_enabled.desc_html')
+      = f.input :captcha_enabled, as: :boolean, wrapper: :with_label, label: t('admin.settings.captcha_enabled.title'), hint: t('admin.settings.captcha_enabled.desc_html'), glitch_only: true
 
   .fields-group
     = f.input :closed_registrations_message, as: :text, wrapper: :with_block_label, input_html: { rows: 2 }

--- a/app/views/settings/preferences/appearance/show.html.haml
+++ b/app/views/settings/preferences/appearance/show.html.haml
@@ -29,7 +29,7 @@
     = f.input :setting_reduce_motion, as: :boolean, wrapper: :with_label
     = f.input :setting_disable_swiping, as: :boolean, wrapper: :with_label
     = f.input :setting_system_font_ui, as: :boolean, wrapper: :with_label
-    = f.input :setting_system_emoji_font, as: :boolean, wrapper: :with_label
+    = f.input :setting_system_emoji_font, as: :boolean, wrapper: :with_label, glitch_only: true
 
   %h4= t 'appearance.toot_layout'
 
@@ -46,7 +46,7 @@
   .fields-group
     = f.input :setting_unfollow_modal, as: :boolean, wrapper: :with_label
     = f.input :setting_boost_modal, as: :boolean, wrapper: :with_label
-    = f.input :setting_favourite_modal, as: :boolean, wrapper: :with_label
+    = f.input :setting_favourite_modal, as: :boolean, wrapper: :with_label, glitch_only: true
     = f.input :setting_delete_modal, as: :boolean, wrapper: :with_label
 
   %h4= t 'appearance.sensitive_content'

--- a/app/views/settings/preferences/other/show.html.haml
+++ b/app/views/settings/preferences/other/show.html.haml
@@ -15,7 +15,7 @@
 
   - unless Setting.hide_followers_count
     .fields-group
-      = f.input :setting_hide_followers_count, as: :boolean, wrapper: :with_label
+      = f.input :setting_hide_followers_count, as: :boolean, wrapper: :with_label, glitch_only: true
 
   %h4= t 'preferences.posting_defaults'
 
@@ -33,7 +33,7 @@
     = f.input :setting_show_application, as: :boolean, wrapper: :with_label, recommended: true
 
   .fields-group
-    = f.input :setting_default_content_type, collection: ['text/plain', 'text/markdown', 'text/html'], wrapper: :with_label, include_blank: false, label_method: lambda { |item| safe_join([t("simple_form.labels.defaults.setting_default_content_type_#{item.split('/')[1]}"), content_tag(:span, t("simple_form.hints.defaults.setting_default_content_type_#{item.split('/')[1]}"), class: 'hint')]) }, required: false, as: :radio_buttons, collection_wrapper_tag: 'ul', item_wrapper_tag: 'li'
+    = f.input :setting_default_content_type, collection: ['text/plain', 'text/markdown', 'text/html'], wrapper: :with_label, include_blank: false, label_method: lambda { |item| safe_join([t("simple_form.labels.defaults.setting_default_content_type_#{item.split('/')[1]}"), content_tag(:span, t("simple_form.hints.defaults.setting_default_content_type_#{item.split('/')[1]}"), class: 'hint')]) }, required: false, as: :radio_buttons, collection_wrapper_tag: 'ul', item_wrapper_tag: 'li', glitch_only: true
 
   %h4= t 'preferences.public_timelines'
 

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -19,8 +19,17 @@ module RecommendedComponent
   end
 end
 
+module GlitchOnlyComponent
+  def glitch_only(_wrapper_options = nil)
+    return unless options[:glitch_only]
+    options[:label_text] = ->(raw_label_text, _required_label_text, _label_present) { safe_join([raw_label_text, ' ', content_tag(:span, I18n.t('simple_form.glitch_only'), class: 'glitch_only')]) }
+    nil
+  end
+end
+
 SimpleForm.include_component(AppendComponent)
 SimpleForm.include_component(RecommendedComponent)
+SimpleForm.include_component(GlitchOnlyComponent)
 
 SimpleForm.setup do |config|
   # Wrappers are used by the form builder to generate a
@@ -78,6 +87,7 @@ SimpleForm.setup do |config|
 
     b.wrapper tag: :div, class: :label_input do |ba|
       ba.optional :recommended
+      ba.optional :glitch_only
       ba.use :label
 
       ba.wrapper tag: :div, class: :label_input__wrapper do |bb|

--- a/config/locales-glitch/simple_form.en.yml
+++ b/config/locales-glitch/simple_form.en.yml
@@ -9,6 +9,7 @@ en:
         setting_default_content_type_markdown: When writing toots, assume they are using Markdown for rich text formatting, unless specified otherwise
         setting_default_content_type_plain: When writing toots, assume they are plain text with no special formatting, unless specified otherwise (default Mastodon behavior)
         setting_default_language: The language of your toots can be detected automatically, but it's not always accurate
+        setting_hide_followers_count: Hide your followers count from everybody, including you. Some applications may display a negative followers count.
         setting_skin: Reskins the selected Mastodon flavour
     labels:
       defaults:

--- a/config/locales-glitch/simple_form.en.yml
+++ b/config/locales-glitch/simple_form.en.yml
@@ -1,6 +1,7 @@
 ---
 en:
   simple_form:
+    glitch_only: glitch-soc
     hints:
       defaults:
         fields: You can have up to %{count} items displayed as a table on your profile


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/384364/201470078-877e9d22-122b-408c-891a-9a1b0cd6147b.png)

This is so that settings can easily be identified as glitch-soc additions, to avoid upstream reports on glitch-soc features and so on.