### PR TITLE
Helm: Fix reference to deployment in HPA template

### DIFF
--- a/chart/templates/hpa.yaml
+++ b/chart/templates/hpa.yaml
@@ -9,7 +9,7 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "mastodon.fullname" . }}
+    name: {{ include "mastodon.fullname" . }}-web
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:


### PR DESCRIPTION
This should fix the deployment name that the HPA template uses to reference the mastodon web deployment.

Without this change, the HPA wasn't able to discover pods to scale. With the change, it's able to scale web pods on my K8s cluster.

