### PR TITLE
Substantially reworked Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,121 +1,100 @@
-FROM ubuntu:20.04 as build-dep
+# This needs to be bullseye-slim because the Ruby image is built on bullseye-slim
+ARG NODE_VERSION="16.17.1-bullseye-slim"
 
-# Use bash for the shell
-SHELL ["/bin/bash", "-c"]
-RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+# TARGETPLATFORM is set by BuildKit/buildx
+FROM --platform=${TARGETPLATFORM} ghcr.io/moritzheiber/ruby-jemalloc:3.0.4-slim as ruby
+FROM node:${NODE_VERSION} as build
 
-# Install Node v16 (LTS)
-ENV NODE_VER="16.17.1"
-RUN ARCH= && \
-    dpkgArch="$(dpkg --print-architecture)" && \
-  case "${dpkgArch##*-}" in \
-    amd64) ARCH='x64';; \
-    ppc64el) ARCH='ppc64le';; \
-    s390x) ARCH='s390x';; \
-    arm64) ARCH='arm64';; \
-    armhf) ARCH='armv7l';; \
-    i386) ARCH='x86';; \
-    *) echo "unsupported architecture"; exit 1 ;; \
-  esac && \
-    echo "Etc/UTC" > /etc/localtime && \
-	apt-get update && \
-	apt-get install -y --no-install-recommends ca-certificates wget python3 apt-utils && \
-	cd ~ && \
-	wget -q https://nodejs.org/download/release/v$NODE_VER/node-v$NODE_VER-linux-$ARCH.tar.gz && \
-	tar xf node-v$NODE_VER-linux-$ARCH.tar.gz && \
-	rm node-v$NODE_VER-linux-$ARCH.tar.gz && \
-	mv node-v$NODE_VER-linux-$ARCH /opt/node
+# This inherets NODE_VERSION from the beginning of the file
+ARG NODE_VERSION
 
-# Install Ruby 3.0
-ENV RUBY_VER="3.0.4"
-RUN apt-get update && \
-  apt-get install -y --no-install-recommends build-essential \
-    bison libyaml-dev libgdbm-dev libreadline-dev libjemalloc-dev \
-		libncurses5-dev libffi-dev zlib1g-dev libssl-dev && \
-	cd ~ && \
-	wget https://cache.ruby-lang.org/pub/ruby/${RUBY_VER%.*}/ruby-$RUBY_VER.tar.gz && \
-	tar xf ruby-$RUBY_VER.tar.gz && \
-	cd ruby-$RUBY_VER && \
-	./configure --prefix=/opt/ruby \
-	  --with-jemalloc \
-	  --with-shared \
-	  --disable-install-doc && \
-	make -j"$(nproc)" > /dev/null && \
-	make install && \
-	rm -rf ../ruby-$RUBY_VER.tar.gz ../ruby-$RUBY_VER
+COPY --from=ruby /opt/ruby /opt/ruby
 
-ENV PATH="${PATH}:/opt/ruby/bin:/opt/node/bin"
+ENV DEBIAN_FRONTEND="noninteractive" \
+	PATH="${PATH}:/opt/ruby/bin"
 
-RUN npm install -g npm@latest && \
-	npm install -g yarn && \
-	gem install bundler && \
-	apt-get update && \
-	apt-get install -y --no-install-recommends git libicu-dev libidn11-dev \
-	libpq-dev shared-mime-info
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
+WORKDIR /opt/mastodon
 COPY Gemfile* package.json yarn.lock /opt/mastodon/
 
-RUN cd /opt/mastodon && \
-  bundle config set --local deployment 'true' && \
-  bundle config set --local without 'development test' && \
-  bundle config set silence_root_warning true && \
+RUN apt update && \
+	apt-get install -y --no-install-recommends build-essential \
+		ca-certificates \
+		git \
+		libicu-dev \
+		libidn11-dev \
+		libpq-dev \
+		libjemalloc-dev \
+		zlib1g-dev \
+		libgdbm-dev \
+		libgmp-dev \
+		libssl-dev \
+		libyaml-0-2 \
+		ca-certificates \
+		libreadline8 \
+		python3 \
+		shared-mime-info && \
+  	bundle config set --local deployment 'true' && \
+  	bundle config set --local without 'development test' && \
+  	bundle config set silence_root_warning true && \
 	bundle install -j"$(nproc)" && \
 	yarn install --pure-lockfile
 
-FROM ubuntu:20.04
+FROM node:${NODE_VERSION}
 
-# Copy over all the langs needed for runtime
-COPY --from=build-dep /opt/node /opt/node
-COPY --from=build-dep /opt/ruby /opt/ruby
+# This inherets NODE_VERSION from the beginning of the file
+ARG NODE_VERSION
+ARG UID="991"
+ARG GID="991"
 
-# Add more PATHs to the PATH
-ENV PATH="${PATH}:/opt/ruby/bin:/opt/node/bin:/opt/mastodon/bin"
+COPY --from=ruby /opt/ruby /opt/ruby
 
-# Create the mastodon user
-ARG UID=991
-ARG GID=991
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+ENV DEBIAN_FRONTEND="noninteractive" \
+	PATH="${PATH}:/opt/ruby/bin:/opt/mastodon/bin"
+
 RUN apt-get update && \
 	echo "Etc/UTC" > /etc/localtime && \
-	apt-get install -y --no-install-recommends whois wget && \
-	addgroup --gid $GID mastodon && \
-	useradd -m -u $UID -g $GID -d /opt/mastodon mastodon && \
-	echo "mastodon:$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 24 | mkpasswd -s -m sha-256)" | chpasswd && \
-	rm -rf /var/lib/apt/lists/*
+	groupadd -g "${GID}" mastodon && \
+	useradd -u "$UID" -g "${GID}" -m -d /opt/mastodon mastodon && \
+	apt-get -y --no-install-recommends install whois \
+		wget \
+		libssl1.1 \
+		libpq5 \
+		imagemagick \
+		ffmpeg \
+		libjemalloc2 \
+		libicu67 \
+		libidn11 \
+		libyaml-0-2 \
+		file \
+		ca-certificates \
+		tzdata \
+		libreadline8 \
+		tini && \
+	ln -s /opt/mastodon /mastodon
 
-# Install mastodon runtime deps
-RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
-RUN apt-get update && \
-  apt-get -y --no-install-recommends install \
-	  libssl1.1 libpq5 imagemagick ffmpeg libjemalloc2 \
-	  libicu66 libidn11 libyaml-0-2 \
-	  file ca-certificates tzdata libreadline8 gcc tini apt-utils && \
-	ln -s /opt/mastodon /mastodon && \
-	gem install bundler && \
-	rm -rf /var/cache && \
-	rm -rf /var/lib/apt/lists/*
+# Note: no, cleaning here since Debian does this automatically
+# See the file /etc/apt/apt.conf.d/docker-clean within the Docker image's filesystem
 
-# Copy over mastodon source, and dependencies from building, and set permissions
 COPY --chown=mastodon:mastodon . /opt/mastodon
-COPY --from=build-dep --chown=mastodon:mastodon /opt/mastodon /opt/mastodon
+COPY --chown=mastodon:mastodon --from=build /opt/mastodon /opt/mastodon
 
-# Run mastodon services in prod mode
-ENV RAILS_ENV="production"
-ENV NODE_ENV="production"
-
-# Tell rails to serve static files
-ENV RAILS_SERVE_STATIC_FILES="true"
-ENV BIND="0.0.0.0"
+ENV RAILS_ENV="production" \
+	NODE_ENV="production" \
+	RAILS_SERVE_STATIC_FILES="true" \
+	BIND="0.0.0.0"
 
 # Set the run user
 USER mastodon
+WORKDIR /opt/mastodon
 
 # Precompile assets
-RUN cd ~ && \
-	OTP_SECRET=precompile_placeholder SECRET_KEY_BASE=precompile_placeholder rails assets:precompile && \
+RUN OTP_SECRET=precompile_placeholder SECRET_KEY_BASE=precompile_placeholder rails assets:precompile && \
 	yarn cache clean
 
 # Set the work dir and the container entry point
-WORKDIR /opt/mastodon
 ENTRYPOINT ["/usr/bin/tini", "--"]
 EXPOSE 3000 4000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,13 @@
 # This needs to be bullseye-slim because the Ruby image is built on bullseye-slim
 ARG NODE_VERSION="16.17.1-bullseye-slim"
 
-# TARGETPLATFORM is set by BuildKit/buildx
-FROM --platform=${TARGETPLATFORM} ghcr.io/moritzheiber/ruby-jemalloc:3.0.4-slim as ruby
+FROM ghcr.io/moritzheiber/ruby-jemalloc:3.0.4-slim as ruby
 FROM node:${NODE_VERSION} as build
 
-# This inherets NODE_VERSION from the beginning of the file
-ARG NODE_VERSION
-
-COPY --from=ruby /opt/ruby /opt/ruby
+COPY --link --from=ruby /opt/ruby /opt/ruby
 
 ENV DEBIAN_FRONTEND="noninteractive" \
-	PATH="${PATH}:/opt/ruby/bin"
+    PATH="${PATH}:/opt/ruby/bin"
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -19,62 +15,60 @@ WORKDIR /opt/mastodon
 COPY Gemfile* package.json yarn.lock /opt/mastodon/
 
 RUN apt update && \
-	apt-get install -y --no-install-recommends build-essential \
-		ca-certificates \
-		git \
-		libicu-dev \
-		libidn11-dev \
-		libpq-dev \
-		libjemalloc-dev \
-		zlib1g-dev \
-		libgdbm-dev \
-		libgmp-dev \
-		libssl-dev \
-		libyaml-0-2 \
-		ca-certificates \
-		libreadline8 \
-		python3 \
-		shared-mime-info && \
-  	bundle config set --local deployment 'true' && \
-  	bundle config set --local without 'development test' && \
-  	bundle config set silence_root_warning true && \
-	bundle install -j"$(nproc)" && \
-	yarn install --pure-lockfile
+    apt-get install -y --no-install-recommends build-essential \
+        ca-certificates \
+        git \
+        libicu-dev \
+        libidn11-dev \
+        libpq-dev \
+        libjemalloc-dev \
+        zlib1g-dev \
+        libgdbm-dev \
+        libgmp-dev \
+        libssl-dev \
+        libyaml-0-2 \
+        ca-certificates \
+        libreadline8 \
+        python3 \
+        shared-mime-info && \
+    bundle config set --local deployment 'true' && \
+    bundle config set --local without 'development test' && \
+    bundle config set silence_root_warning true && \
+    bundle install -j"$(nproc)" && \
+    yarn install --pure-lockfile
 
 FROM node:${NODE_VERSION}
 
-# This inherets NODE_VERSION from the beginning of the file
-ARG NODE_VERSION
 ARG UID="991"
 ARG GID="991"
 
-COPY --from=ruby /opt/ruby /opt/ruby
+COPY --link --from=ruby /opt/ruby /opt/ruby
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ENV DEBIAN_FRONTEND="noninteractive" \
-	PATH="${PATH}:/opt/ruby/bin:/opt/mastodon/bin"
+    PATH="${PATH}:/opt/ruby/bin:/opt/mastodon/bin"
 
 RUN apt-get update && \
-	echo "Etc/UTC" > /etc/localtime && \
-	groupadd -g "${GID}" mastodon && \
-	useradd -u "$UID" -g "${GID}" -m -d /opt/mastodon mastodon && \
-	apt-get -y --no-install-recommends install whois \
-		wget \
-		libssl1.1 \
-		libpq5 \
-		imagemagick \
-		ffmpeg \
-		libjemalloc2 \
-		libicu67 \
-		libidn11 \
-		libyaml-0-2 \
-		file \
-		ca-certificates \
-		tzdata \
-		libreadline8 \
-		tini && \
-	ln -s /opt/mastodon /mastodon
+    echo "Etc/UTC" > /etc/localtime && \
+    groupadd -g "${GID}" mastodon && \
+    useradd -u "$UID" -g "${GID}" -m -d /opt/mastodon mastodon && \
+    apt-get -y --no-install-recommends install whois \
+        wget \
+        libssl1.1 \
+        libpq5 \
+        imagemagick \
+        ffmpeg \
+        libjemalloc2 \
+        libicu67 \
+        libidn11 \
+        libyaml-0-2 \
+        file \
+        ca-certificates \
+        tzdata \
+        libreadline8 \
+        tini && \
+    ln -s /opt/mastodon /mastodon
 
 # Note: no, cleaning here since Debian does this automatically
 # See the file /etc/apt/apt.conf.d/docker-clean within the Docker image's filesystem
@@ -83,9 +77,9 @@ COPY --chown=mastodon:mastodon . /opt/mastodon
 COPY --chown=mastodon:mastodon --from=build /opt/mastodon /opt/mastodon
 
 ENV RAILS_ENV="production" \
-	NODE_ENV="production" \
-	RAILS_SERVE_STATIC_FILES="true" \
-	BIND="0.0.0.0"
+    NODE_ENV="production" \
+    RAILS_SERVE_STATIC_FILES="true" \
+    BIND="0.0.0.0"
 
 # Set the run user
 USER mastodon
@@ -93,7 +87,7 @@ WORKDIR /opt/mastodon
 
 # Precompile assets
 RUN OTP_SECRET=precompile_placeholder SECRET_KEY_BASE=precompile_placeholder rails assets:precompile && \
-	yarn cache clean
+    yarn cache clean
 
 # Set the work dir and the container entry point
 ENTRYPOINT ["/usr/bin/tini", "--"]


### PR DESCRIPTION
_Note: this is a carbon copy of mastodon/mastodon#20678, which I don't believe will see quick adoption, but I wanted for Glitch to have a better UX for working with containers as well_

This PR splits the current monolithic `Dockerfile` into two parts, one of which is now executed in a separate pipeline (and repository).

### Why

The current `Dockerfile` builds a new version of Ruby _every time_ the image is built. That's wasteful and slow, especially since we're building against other targets than `linux/amd64` (which is even slower; at least until GitHub Actions finally gets native `linux/arm64` support).

Additionally, the `Dockerfile` now relies on the official NodeJS and Ruby images from the Docker Hub to build its assets, meaning there is no more overhead for the contributors in this repository to care for updating/maintaining Ruby and NodeJS installations and stacks (but rather source them from the Hub directly).

### Consequences

- The image is now based on Debian, since the official "slim" images are based on Debian, specifically "Bullseye". I also could've gone for Alpine, but I faintly remember there being issues with Ruby on Alpine under certain conditions and especially when `jemalloc` is involved.
- The image relies on a [new Ruby image](https://github.com/moritzheiber/ruby-jemalloc-docker/pkgs/container/ruby-jemalloc), built in a separate repository, for its source of the Ruby interpreter. Aside from a few cosmetic changes, its instructions haven't changed much. The plan is to move this repository into the `mastodon` organization as soon as it's feasible. We can also add any number of Ruby versions or supported architectures to the image itself, should it become necessary.
- I've removed the platform instructions at beginning, as one shouldn't be cleverer than the actual operator. If you're building this image with an unsupported architecture you'll just receive an error from Docker/`containerd`.

### Notes

Most of the stuff I either removed or left out was cosmetic or "solved" by using a different syntax (e.g. `WORKDIR` instead of `cd`, passing the `--chown` flag to `ADD` instead of using `chown` manually etc.).

The the already existing pipeline it should be split its runtime _in half_, maybe even reduce it be a larger amount.