### PR TITLE
Modify image build workflow for Glitch workflows

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - 'main'
-    tags:
-      - '*'
   pull_request:
     paths:
       - .github/workflows/build-image.yml
@@ -31,13 +29,10 @@ jobs:
         id: meta
         with:
           images: ghcr.io/${{ github.repository_owner }}/mastodon
-          flavor: |
-            latest=auto
           tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
             type=edge,branch=main
-            type=pep440,pattern={{raw}}
-            type=pep440,pattern=v{{major}}.{{minor}}
-            type=ref,event=pr
+            type=sha,prefix=,format=long
       - uses: docker/build-push-action@v3
         with:
           context: .


### PR DESCRIPTION
Fixes #1938.

Because Glitch does not have discrete, semantically versioned releases (created as git tags), the upstream Mastodon tagging workflows don't quite work.

Changes:

- Remove building on git tags as they're not in use
- Remove tagging rules for PRs as PR images aren't pushed
- Ensure `latest` is always pushed for builds on the default branch (currently `main`)
- Push a Docker tag corresponding to the git commit id/sha/hash (to make it easy to deploy/pin a particular version of Glitch)