### PR TITLE
Add form-action CSP directive

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -41,6 +41,7 @@ if Rails.env.production?
     p.worker_src      :self, :blob, assets_host
     p.connect_src     :self, :blob, :data, Rails.configuration.x.streaming_api_base_url, *data_hosts
     p.manifest_src    :self, assets_host
+    p.form_action     :self
   end
 end
 


### PR DESCRIPTION
Port of https://github.com/mastodon/mastodon/pull/20781

Hardening against potential attacks.

Most pages require to be able to submit forms in one way or another (e.g. log-out link), so this can't be set to `:none` in general.