### PR TITLE
Fix pillbar buttons in light theme

### DIFF
--- a/app/javascript/flavours/glitch/styles/components/columns.scss
+++ b/app/javascript/flavours/glitch/styles/components/columns.scss
@@ -558,6 +558,7 @@ $ui-header-height: 55px;
   border-radius: 4px;
   margin-bottom: 10px;
   align-items: stretch;
+  gap: 2px;
 }
 
 .pillbar-button {
@@ -565,7 +566,6 @@ $ui-header-height: 55px;
   color: #fafafa;
   padding: 2px;
   margin: 0;
-  margin-left: 2px;
   font-size: inherit;
   flex: auto;
   background-color: $ui-base-color;
@@ -578,42 +578,19 @@ $ui-header-height: 55px;
   }
 
   &:not([disabled]) {
-    &:hover {
+    &:hover,
+    &:focus {
       background-color: darken($ui-base-color, 10%);
     }
 
-    &:focus {
-      background-color: darken($ui-base-color, 15%);
-    }
-
-    &:active {
-      background-color: darken($ui-base-color, 20%);
-    }
-
     &.active {
-      background-color: $ui-highlight-color;
-      box-shadow: inset 0 5px darken($ui-highlight-color, 20%);
+      background-color: darken($ui-highlight-color, 2%);
 
-      &:hover {
-        background-color: lighten($ui-highlight-color, 10%);
-        box-shadow: inset 0 5px darken($ui-highlight-color, 10%);
-      }
-
+      &:hover,
       &:focus {
-        background-color: lighten($ui-highlight-color, 15%);
-        box-shadow: inset 0 5px darken($ui-highlight-color, 5%);
-      }
-
-      &:active {
-        background-color: lighten($ui-highlight-color, 20%);
-        box-shadow: inset 0 5px $ui-highlight-color;
+        background-color: $ui-highlight-color;
       }
     }
-  }
-
-  /* TODO: check RTL? */
-  &:first-child {
-    margin-left: 0;
   }
 }
 

--- a/app/javascript/flavours/glitch/styles/mastodon-light/diff.scss
+++ b/app/javascript/flavours/glitch/styles/mastodon-light/diff.scss
@@ -712,6 +712,26 @@ html {
 
 // Glitch-soc-specific changes
 
+.pillbar-button {
+  background: $ui-secondary-color;
+
+  &:not([disabled]) {
+    &:hover,
+    &:focus {
+      background: darken($ui-secondary-color, 10%);
+    }
+
+    &.active {
+      background-color: darken($ui-highlight-color, 2%);
+
+      &:hover,
+      &:focus {
+        background: lighten($ui-highlight-color, 10%);
+      }
+    }
+  }
+}
+
 .glitch.local-settings {
   background: $ui-base-color;
   border: 1px solid lighten($ui-base-color, 8%);


### PR DESCRIPTION
Fixes #1970

Also simplify the pillbar's styling overall and make it more consistent with the rest of the UI by using the same colors as the toggle buttons and dropping the `box-shadow`.

![image](https://user-images.githubusercontent.com/384364/203735891-5290d2bf-e5f4-468a-bd46-3a1b457d9177.png)
![image](https://user-images.githubusercontent.com/384364/203735785-b87c43d6-0fc0-4fb9-9b05-c246fd95513c.png)