### PR TITLE
Add exclusive lists to glitch

### DIFF
--- a/app/controllers/api/v1/lists_controller.rb
+++ b/app/controllers/api/v1/lists_controller.rb
@@ -42,6 +42,6 @@ class Api::V1::ListsController < Api::BaseController
   end
 
   def list_params
-    params.permit(:title, :replies_policy)
+    params.permit(:title, :replies_policy, :is_exclusive)
   end
 end

--- a/app/javascript/flavours/glitch/actions/lists.js
+++ b/app/javascript/flavours/glitch/actions/lists.js
@@ -10,9 +10,10 @@ export const LISTS_FETCH_REQUEST = 'LISTS_FETCH_REQUEST';
 export const LISTS_FETCH_SUCCESS = 'LISTS_FETCH_SUCCESS';
 export const LISTS_FETCH_FAIL    = 'LISTS_FETCH_FAIL';
 
-export const LIST_EDITOR_TITLE_CHANGE = 'LIST_EDITOR_TITLE_CHANGE';
-export const LIST_EDITOR_RESET        = 'LIST_EDITOR_RESET';
-export const LIST_EDITOR_SETUP        = 'LIST_EDITOR_SETUP';
+export const LIST_EDITOR_TITLE_CHANGE        = 'LIST_EDITOR_TITLE_CHANGE';
+export const LIST_EDITOR_IS_EXCLUSIVE_CHANGE = 'LIST_EDITOR_IS_EXCLUSIVE_CHANGE';
+export const LIST_EDITOR_RESET               = 'LIST_EDITOR_RESET';
+export const LIST_EDITOR_SETUP               = 'LIST_EDITOR_SETUP';
 
 export const LIST_CREATE_REQUEST = 'LIST_CREATE_REQUEST';
 export const LIST_CREATE_SUCCESS = 'LIST_CREATE_SUCCESS';
@@ -102,11 +103,12 @@ export const fetchListsFail = error => ({
 export const submitListEditor = shouldReset => (dispatch, getState) => {
   const listId = getState().getIn(['listEditor', 'listId']);
   const title  = getState().getIn(['listEditor', 'title']);
+  const isExclusive = getState().getIn(['listEditor', 'isExclusive']);
 
   if (listId === null) {
     dispatch(createList(title, shouldReset));
   } else {
-    dispatch(updateList(listId, title, shouldReset));
+    dispatch(updateList(listId, title, shouldReset, isExclusive));
   }
 };
 
@@ -121,6 +123,11 @@ export const setupListEditor = listId => (dispatch, getState) => {
 
 export const changeListEditorTitle = value => ({
   type: LIST_EDITOR_TITLE_CHANGE,
+  value,
+});
+
+export const changeListEditorIsExclusive = value => ({
+  type: LIST_EDITOR_IS_EXCLUSIVE_CHANGE,
   value,
 });
 
@@ -150,10 +157,10 @@ export const createListFail = error => ({
   error,
 });
 
-export const updateList = (id, title, shouldReset, replies_policy) => (dispatch, getState) => {
+export const updateList = (id, title, shouldReset, isExclusive, replies_policy) => (dispatch, getState) => {
   dispatch(updateListRequest(id));
 
-  api(getState).put(`/api/v1/lists/${id}`, { title, replies_policy }).then(({ data }) => {
+  api(getState).put(`/api/v1/lists/${id}`, { title, replies_policy, is_exclusive: typeof isExclusive === 'undefined' ? undefined : !!isExclusive }).then(({ data }) => {
     dispatch(updateListSuccess(data));
 
     if (shouldReset) {

--- a/app/javascript/flavours/glitch/features/list_editor/components/edit_list_form.js
+++ b/app/javascript/flavours/glitch/features/list_editor/components/edit_list_form.js
@@ -1,12 +1,14 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { changeListEditorTitle, submitListEditor } from 'flavours/glitch/actions/lists';
+import { changeListEditorTitle, changeListEditorIsExclusive, submitListEditor } from 'flavours/glitch/actions/lists';
 import IconButton from 'flavours/glitch/components/icon_button';
 import { defineMessages, injectIntl } from 'react-intl';
+import Toggle from 'react-toggle';
 
 const messages = defineMessages({
   title: { id: 'lists.edit.submit', defaultMessage: 'Change title' },
+  exclusive: {id: 'lists.is-exclusive', defaultMessage: 'Exclusive?' },
 });
 
 const mapStateToProps = state => ({
@@ -17,6 +19,7 @@ const mapStateToProps = state => ({
 const mapDispatchToProps = dispatch => ({
   onChange: value => dispatch(changeListEditorTitle(value)),
   onSubmit: () => dispatch(submitListEditor(false)),
+  onToggle: value => dispatch(changeListEditorIsExclusive(value)),
 });
 
 export default @connect(mapStateToProps, mapDispatchToProps)
@@ -26,9 +29,11 @@ class ListForm extends React.PureComponent {
   static propTypes = {
     value: PropTypes.string.isRequired,
     disabled: PropTypes.bool,
+    isExclusive: PropTypes.bool,
     intl: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
     onSubmit: PropTypes.func.isRequired,
+    onToggle: PropTypes.func.isRequired,
   };
 
   handleChange = e => {
@@ -44,6 +49,10 @@ class ListForm extends React.PureComponent {
     this.props.onSubmit();
   }
 
+  handleToggle = e => {
+    this.props.onToggle(e.target.checked);
+  }
+
   render () {
     const { value, disabled, intl } = this.props;
 
@@ -56,6 +65,11 @@ class ListForm extends React.PureComponent {
           value={value}
           onChange={this.handleChange}
         />
+
+        <label htmlFor='is-exclusive-checkbox'>
+          <Toggle className='is-exclusive-checkbox' defaultChecked={isExclusive} onChange={this.handleToggle} />
+          {intl.formatMessage(messages.exclusive)}
+        </label>
 
         <IconButton
           disabled={disabled}

--- a/app/javascript/flavours/glitch/features/list_editor/components/edit_list_form.js
+++ b/app/javascript/flavours/glitch/features/list_editor/components/edit_list_form.js
@@ -54,7 +54,7 @@ class ListForm extends React.PureComponent {
   }
 
   render () {
-    const { value, disabled, intl } = this.props;
+    const { value, disabled, intl, isExclusive } = this.props;
 
     const title = intl.formatMessage(messages.title);
 

--- a/app/javascript/flavours/glitch/features/list_editor/index.js
+++ b/app/javascript/flavours/glitch/features/list_editor/index.js
@@ -30,6 +30,7 @@ class ListEditor extends ImmutablePureComponent {
     listId: PropTypes.string.isRequired,
     onClose: PropTypes.func.isRequired,
     intl: PropTypes.object.isRequired,
+    isExclusive: PropTypes.bool.isRequired,
     onInitialize: PropTypes.func.isRequired,
     onClear: PropTypes.func.isRequired,
     onReset: PropTypes.func.isRequired,
@@ -53,7 +54,7 @@ class ListEditor extends ImmutablePureComponent {
 
     return (
       <div className='modal-root__modal list-editor'>
-        <EditListForm />
+        <EditListForm isExclusive={this.props.isExclusive} />
 
         <SearchContainer />
 

--- a/app/javascript/flavours/glitch/features/list_timeline/index.js
+++ b/app/javascript/flavours/glitch/features/list_timeline/index.js
@@ -113,7 +113,7 @@ class ListTimeline extends React.PureComponent {
   }
 
   handleEditClick = () => {
-    this.props.dispatch(openModal('LIST_EDITOR', { listId: this.props.params.id }));
+    this.props.dispatch(openModal('LIST_EDITOR', { listId: this.props.params.id, isExclusive: this.props.list.get('is_exclusive') }));
   }
 
   handleDeleteClick = () => {
@@ -138,7 +138,7 @@ class ListTimeline extends React.PureComponent {
   handleRepliesPolicyChange = ({ target }) => {
     const { dispatch, list } = this.props;
     const { id } = this.props.params;
-    this.props.dispatch(updateList(id, undefined, false, target.value));
+    this.props.dispatch(updateList(id, undefined, false, undefined, target.value));
   }
 
   render () {

--- a/app/javascript/flavours/glitch/reducers/list_editor.js
+++ b/app/javascript/flavours/glitch/reducers/list_editor.js
@@ -9,6 +9,7 @@ import {
   LIST_EDITOR_RESET,
   LIST_EDITOR_SETUP,
   LIST_EDITOR_TITLE_CHANGE,
+  LIST_EDITOR_IS_EXCLUSIVE_CHANGE,
   LIST_ACCOUNTS_FETCH_REQUEST,
   LIST_ACCOUNTS_FETCH_SUCCESS,
   LIST_ACCOUNTS_FETCH_FAIL,
@@ -21,6 +22,7 @@ import {
 
 const initialState = ImmutableMap({
   listId: null,
+  isExclusive: false,
   isSubmitting: false,
   isChanged: false,
   title: '',
@@ -45,11 +47,17 @@ export default function listEditorReducer(state = initialState, action) {
     return state.withMutations(map => {
       map.set('listId', action.list.get('id'));
       map.set('title', action.list.get('title'));
+      map.set('isExclusive', action.list.get('is_exclusive'));
       map.set('isSubmitting', false);
     });
   case LIST_EDITOR_TITLE_CHANGE:
     return state.withMutations(map => {
       map.set('title', action.value);
+      map.set('isChanged', true);
+    });
+  case LIST_EDITOR_IS_EXCLUSIVE_CHANGE:
+    return state.withMutations(map => {
+      map.set('isExclusive', action.value);
       map.set('isChanged', true);
     });
   case LIST_CREATE_REQUEST:

--- a/app/javascript/flavours/glitch/styles/components/index.scss
+++ b/app/javascript/flavours/glitch/styles/components/index.scss
@@ -1017,6 +1017,15 @@
   border-color: $ui-highlight-color;
 }
 
+label[for="is-exclusive-checkbox"] {
+  margin-left: 20px;
+}
+
+.is-exclusive-checkbox {
+  transform: scale(0.7);
+  transform-origin: bottom;
+}
+
 .getting-started__wrapper,
 .getting_started,
 .flex-spacer {

--- a/app/javascript/mastodon/actions/lists.js
+++ b/app/javascript/mastodon/actions/lists.js
@@ -10,9 +10,10 @@ export const LISTS_FETCH_REQUEST = 'LISTS_FETCH_REQUEST';
 export const LISTS_FETCH_SUCCESS = 'LISTS_FETCH_SUCCESS';
 export const LISTS_FETCH_FAIL    = 'LISTS_FETCH_FAIL';
 
-export const LIST_EDITOR_TITLE_CHANGE = 'LIST_EDITOR_TITLE_CHANGE';
-export const LIST_EDITOR_RESET        = 'LIST_EDITOR_RESET';
-export const LIST_EDITOR_SETUP        = 'LIST_EDITOR_SETUP';
+export const LIST_EDITOR_TITLE_CHANGE        = 'LIST_EDITOR_TITLE_CHANGE';
+export const LIST_EDITOR_IS_EXCLUSIVE_CHANGE = 'LIST_EDITOR_IS_EXCLUSIVE_CHANGE';
+export const LIST_EDITOR_RESET               = 'LIST_EDITOR_RESET';
+export const LIST_EDITOR_SETUP               = 'LIST_EDITOR_SETUP';
 
 export const LIST_CREATE_REQUEST = 'LIST_CREATE_REQUEST';
 export const LIST_CREATE_SUCCESS = 'LIST_CREATE_SUCCESS';
@@ -100,13 +101,14 @@ export const fetchListsFail = error => ({
 });
 
 export const submitListEditor = shouldReset => (dispatch, getState) => {
-  const listId = getState().getIn(['listEditor', 'listId']);
-  const title  = getState().getIn(['listEditor', 'title']);
+  const listId      = getState().getIn(['listEditor', 'listId']);
+  const title       = getState().getIn(['listEditor', 'title']);
+  const isExclusive = getState().getIn(['listEditor', 'isExclusive']);
 
   if (listId === null) {
     dispatch(createList(title, shouldReset));
   } else {
-    dispatch(updateList(listId, title, shouldReset));
+    dispatch(updateList(listId, title, shouldReset, isExclusive));
   }
 };
 
@@ -121,6 +123,11 @@ export const setupListEditor = listId => (dispatch, getState) => {
 
 export const changeListEditorTitle = value => ({
   type: LIST_EDITOR_TITLE_CHANGE,
+  value,
+});
+
+export const changeListEditorIsExclusive = value => ({
+  type: LIST_EDITOR_IS_EXCLUSIVE_CHANGE,
   value,
 });
 
@@ -150,10 +157,10 @@ export const createListFail = error => ({
   error,
 });
 
-export const updateList = (id, title, shouldReset, replies_policy) => (dispatch, getState) => {
+export const updateList = (id, title, shouldReset, isExclusive, replies_policy) => (dispatch, getState) => {
   dispatch(updateListRequest(id));
 
-  api(getState).put(`/api/v1/lists/${id}`, { title, replies_policy }).then(({ data }) => {
+  api(getState).put(`/api/v1/lists/${id}`, { title, replies_policy, is_exclusive: !!isExclusive }).then(({ data }) => {
     dispatch(updateListSuccess(data));
 
     if (shouldReset) {

--- a/app/javascript/mastodon/actions/lists.js
+++ b/app/javascript/mastodon/actions/lists.js
@@ -160,7 +160,7 @@ export const createListFail = error => ({
 export const updateList = (id, title, shouldReset, isExclusive, replies_policy) => (dispatch, getState) => {
   dispatch(updateListRequest(id));
 
-  api(getState).put(`/api/v1/lists/${id}`, { title, replies_policy, is_exclusive: !!isExclusive }).then(({ data }) => {
+  api(getState).put(`/api/v1/lists/${id}`, { title, replies_policy, is_exclusive: typeof isExclusive === 'undefined' ? undefined : !!isExclusive }).then(({ data }) => {
     dispatch(updateListSuccess(data));
 
     if (shouldReset) {

--- a/app/javascript/mastodon/features/list_editor/components/edit_list_form.js
+++ b/app/javascript/mastodon/features/list_editor/components/edit_list_form.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { changeListEditorTitle, submitListEditor } from '../../../actions/lists';
+import { changeListEditorTitle, changeListEditorIsExclusive, submitListEditor } from '../../../actions/lists';
 import IconButton from '../../../components/icon_button';
-import { defineMessages, injectIntl } from 'react-intl';
+import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
+import Toggle from 'react-toggle';
 
 const messages = defineMessages({
   title: { id: 'lists.edit.submit', defaultMessage: 'Change title' },
@@ -17,6 +18,7 @@ const mapStateToProps = state => ({
 const mapDispatchToProps = dispatch => ({
   onChange: value => dispatch(changeListEditorTitle(value)),
   onSubmit: () => dispatch(submitListEditor(false)),
+  onToggle: value => dispatch(changeListEditorIsExclusive(value)),
 });
 
 export default @connect(mapStateToProps, mapDispatchToProps)
@@ -26,9 +28,11 @@ class ListForm extends React.PureComponent {
   static propTypes = {
     value: PropTypes.string.isRequired,
     disabled: PropTypes.bool,
+    isExclusive: PropTypes.bool,
     intl: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
     onSubmit: PropTypes.func.isRequired,
+    onToggle: PropTypes.func.isRequired,
   };
 
   handleChange = e => {
@@ -44,8 +48,12 @@ class ListForm extends React.PureComponent {
     this.props.onSubmit();
   }
 
+  handleToggle = e => {
+    this.props.onToggle(e.target.checked);
+  }
+
   render () {
-    const { value, disabled, intl } = this.props;
+    const { value, disabled, intl, isExclusive, hello } = this.props;
 
     const title = intl.formatMessage(messages.title);
 
@@ -56,6 +64,11 @@ class ListForm extends React.PureComponent {
           value={value}
           onChange={this.handleChange}
         />
+
+        <label htmlFor='is-exclusive-checkbox'>
+          <Toggle className='is-exclusive-checkbox' defaultChecked={isExclusive} onChange={this.handleToggle}/>
+          <FormattedMessage id='lists.is-exclusive' defaultMessage='Exclusive?' />
+        </label>
 
         <IconButton
           disabled={disabled}

--- a/app/javascript/mastodon/features/list_editor/components/edit_list_form.js
+++ b/app/javascript/mastodon/features/list_editor/components/edit_list_form.js
@@ -3,11 +3,12 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { changeListEditorTitle, changeListEditorIsExclusive, submitListEditor } from '../../../actions/lists';
 import IconButton from '../../../components/icon_button';
-import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
+import { defineMessages, injectIntl } from 'react-intl';
 import Toggle from 'react-toggle';
 
 const messages = defineMessages({
   title: { id: 'lists.edit.submit', defaultMessage: 'Change title' },
+  exclusive: { id: 'lists.is-exclusive', defaultMessage: 'Exclusive?' },
 });
 
 const mapStateToProps = state => ({
@@ -53,7 +54,7 @@ class ListForm extends React.PureComponent {
   }
 
   render () {
-    const { value, disabled, intl, isExclusive, hello } = this.props;
+    const { value, disabled, intl, isExclusive } = this.props;
 
     const title = intl.formatMessage(messages.title);
 
@@ -67,7 +68,7 @@ class ListForm extends React.PureComponent {
 
         <label htmlFor='is-exclusive-checkbox'>
           <Toggle className='is-exclusive-checkbox' defaultChecked={isExclusive} onChange={this.handleToggle}/>
-          <FormattedMessage id='lists.is-exclusive' defaultMessage='Exclusive?' />
+          {intl.formatMessage(messages.exclusive)}
         </label>
 
         <IconButton

--- a/app/javascript/mastodon/features/list_editor/index.js
+++ b/app/javascript/mastodon/features/list_editor/index.js
@@ -28,6 +28,7 @@ class ListEditor extends ImmutablePureComponent {
 
   static propTypes = {
     listId: PropTypes.string.isRequired,
+    isExclusive: PropTypes.bool.isRequired,
     onClose: PropTypes.func.isRequired,
     intl: PropTypes.object.isRequired,
     onInitialize: PropTypes.func.isRequired,
@@ -53,7 +54,7 @@ class ListEditor extends ImmutablePureComponent {
 
     return (
       <div className='modal-root__modal list-editor'>
-        <EditListForm />
+        <EditListForm isExclusive={this.props.isExclusive} />
 
         <Search />
 

--- a/app/javascript/mastodon/features/list_timeline/index.js
+++ b/app/javascript/mastodon/features/list_timeline/index.js
@@ -113,7 +113,7 @@ class ListTimeline extends React.PureComponent {
   }
 
   handleEditClick = () => {
-    this.props.dispatch(openModal('LIST_EDITOR', { listId: this.props.params.id }));
+    this.props.dispatch(openModal('LIST_EDITOR', { listId: this.props.params.id, isExclusive: this.props.list.get('is_exclusive') }));
   }
 
   handleDeleteClick = () => {

--- a/app/javascript/mastodon/features/list_timeline/index.js
+++ b/app/javascript/mastodon/features/list_timeline/index.js
@@ -138,7 +138,7 @@ class ListTimeline extends React.PureComponent {
   handleRepliesPolicyChange = ({ target }) => {
     const { dispatch } = this.props;
     const { id } = this.props.params;
-    dispatch(updateList(id, undefined, false, target.value));
+    dispatch(updateList(id, undefined, false, undefined, target.value));
   }
 
   render () {

--- a/app/javascript/mastodon/reducers/list_editor.js
+++ b/app/javascript/mastodon/reducers/list_editor.js
@@ -25,6 +25,7 @@ const initialState = ImmutableMap({
   isSubmitting: false,
   isChanged: false,
   title: '',
+  isExclusive: false,
 
   accounts: ImmutableMap({
     items: ImmutableList(),
@@ -46,6 +47,7 @@ export default function listEditorReducer(state = initialState, action) {
     return state.withMutations(map => {
       map.set('listId', action.list.get('id'));
       map.set('title', action.list.get('title'));
+      map.set('isExclusive', action.list.get('is_exclusive'));
       map.set('isSubmitting', false);
     });
   case LIST_EDITOR_TITLE_CHANGE:

--- a/app/javascript/mastodon/reducers/list_editor.js
+++ b/app/javascript/mastodon/reducers/list_editor.js
@@ -9,6 +9,7 @@ import {
   LIST_EDITOR_RESET,
   LIST_EDITOR_SETUP,
   LIST_EDITOR_TITLE_CHANGE,
+  LIST_EDITOR_IS_EXCLUSIVE_CHANGE,
   LIST_ACCOUNTS_FETCH_REQUEST,
   LIST_ACCOUNTS_FETCH_SUCCESS,
   LIST_ACCOUNTS_FETCH_FAIL,
@@ -50,6 +51,11 @@ export default function listEditorReducer(state = initialState, action) {
   case LIST_EDITOR_TITLE_CHANGE:
     return state.withMutations(map => {
       map.set('title', action.value);
+      map.set('isChanged', true);
+    });
+  case LIST_EDITOR_IS_EXCLUSIVE_CHANGE:
+    return state.withMutations(map => {
+      map.set('isExclusive', action.value);
       map.set('isChanged', true);
     });
   case LIST_CREATE_REQUEST:

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -3046,6 +3046,15 @@ $ui-header-height: 55px;
   border-color: $ui-highlight-color;
 }
 
+label[for="is-exclusive-checkbox"] {
+  margin-left: 20px;
+}
+
+.is-exclusive-checkbox {
+  transform: scale(0.7);
+  transform-origin: bottom;
+}
+
 .column-link {
   background: lighten($ui-base-color, 8%);
   color: $primary-text-color;

--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -43,14 +43,13 @@ class FeedManager
       filter_from_home?(status, receiver.id, build_crutches(receiver.id, [status]))
     when :list
       filter_from_list?(status, receiver) || filter_from_home?(status, receiver.account_id, build_crutches(receiver.account_id, [status]))
+      filter_from_home?(status, receiver.id, build_crutches(receiver.id, [status]), :list)
     when :mentions
       filter_from_mentions?(status, receiver.id)
     when :direct
       filter_from_direct?(status, receiver.id)
     when :tags
       filter_from_tags?(status, receiver.id, build_crutches(receiver.id, [status]))
-    when :list
-      filter_from_home?(status, receiver.id, build_crutches(receiver.id, [status]), :list)
     else
       false
     end

--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -49,6 +49,8 @@ class FeedManager
       filter_from_direct?(status, receiver.id)
     when :tags
       filter_from_tags?(status, receiver.id, build_crutches(receiver.id, [status]))
+    when :list
+      filter_from_home?(status, receiver.id, build_crutches(receiver.id, [status]), :list)
     else
       false
     end
@@ -399,11 +401,19 @@ class FeedManager
   # @param [Status] status
   # @param [Integer] receiver_id
   # @param [Hash] crutches
-  # @return [Boolean]
-  def filter_from_home?(status, receiver_id, crutches)
+  # @param [Symbol] timeline_type
+  # @return [Boolean]  
+  def filter_from_home?(status, receiver_id, crutches, timeline_type=:home)
     return false if receiver_id == status.account_id
     return true  if status.reply? && (status.in_reply_to_id.nil? || status.in_reply_to_account_id.nil?)
     return true  if crutches[:languages][status.account_id].present? && status.language.present? && !crutches[:languages][status.account_id].include?(status.language)
+    # hometown: exclusive list rules
+    unless timeline_type == :list
+      # find all exclusive lists
+      lists = List.where(account_id: receiver_id, is_exclusive: true)
+      # is there a list the receiver owns with this account on it? if so, return true
+      return true if ListAccount.where(list: lists, account_id: status.account_id).exists?
+    end
 
     check_for_blocks = crutches[:active_mentions][status.id] || []
     check_for_blocks.concat([status.account_id])

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -9,6 +9,7 @@
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
 #  replies_policy :integer          default("list"), not null
+#  is_exclusive   :boolean          default(FALSE)
 #
 
 class List < ApplicationRecord

--- a/app/serializers/rest/list_serializer.rb
+++ b/app/serializers/rest/list_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class REST::ListSerializer < ActiveModel::Serializer
-  attributes :id, :title, :replies_policy
+  attributes :id, :title, :replies_policy, :is_exclusive
 
   def id
     object.id.to_s

--- a/db/migrate/20221207102920_add_is_exclusive_to_lists.rb
+++ b/db/migrate/20221207102920_add_is_exclusive_to_lists.rb
@@ -1,0 +1,6 @@
+class AddIsExclusiveToLists < ActiveRecord::Migration[6.1]
+  def change
+    add_column :lists, :is_exclusive, :boolean
+    change_column_default :lists, :is_exclusive, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_12_06_114142) do
+ActiveRecord::Schema.define(version: 2022_12_07_102920) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -540,6 +540,7 @@ ActiveRecord::Schema.define(version: 2022_12_06_114142) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "replies_policy", default: 0, null: false
+    t.boolean "is_exclusive", default: false
     t.index ["account_id"], name: "index_lists_on_account_id"
   end
 


### PR DESCRIPTION
Closes #1204
Ref #1293

Updated port of hometowns [exclusive lists feature](https://github.com/hometown-fork/hometown/wiki/Exclusive-lists).
Basically, if you add a user to an exclusive lists, toots from them don't appear in home anymore.

I think this is a useful feature, especially for people who follow a lot of accounts and have an unusable home tl.
There is a PR upstream, but due to upstreams reluctance to add new features despite popular interest, the chances of it being merged are very low.
Glitch would benefit from this feature though.

I have been running this on my custom fork without any issues so far and the feature itself has been proven by hometown.