### PR TITLE
Add ISO 639-3 language code for "no linguistic content"

### DIFF
--- a/app/helpers/languages_helper.rb
+++ b/app/helpers/languages_helper.rb
@@ -202,6 +202,7 @@ module LanguagesHelper
     tok: ['Toki Pona', 'toki pona'].freeze,
     zba: ['Balaibalan', 'باليبلن'].freeze,
     zgh: ['Standard Moroccan Tamazight', 'ⵜⴰⵎⴰⵣⵉⵖⵜ'].freeze,
+    zxx: ['No linguistic content', 'Toot!'].freeze,
   }.freeze
 
   SUPPORTED_LOCALES = {}.merge(ISO_639_1).merge(ISO_639_3).freeze


### PR DESCRIPTION
I'd like to be able to make posts only containing noises without linguistic content, such as "meow" or "beep". Although those are transcribed into the English orthography, it's not really appropriate to say these posts to have English-language content. Luckily, ISO 639-3 provides the `zxx` code for these purposes. To quote [Wikipedia](https://en.wikipedia.org/wiki/ISO_639-3#Special_codes):

> `zxx` (no linguistic content / not applicable) is intended for data which is not a language at all, such as animal calls.[13]

I've had this addition on my personal instance for a couple of weeks, and I'm happy enough with it that I would like to share it with others.

One issue that by virtue of having no linguistic content, it's not really possible to give a native name to this "language". I think "Toot!" is a thematically appropriate animal call which would work well, but I'm happy to discuss alternatives if you want something clearer and/or less whimsical.