### PR TITLE
Remove frontend limit for featured tags

### DIFF
--- a/app/javascript/flavours/glitch/features/account/components/featured_tags.js
+++ b/app/javascript/flavours/glitch/features/account/components/featured_tags.js
@@ -35,7 +35,7 @@ class FeaturedTags extends ImmutablePureComponent {
       <div className='getting-started__trends'>
         <h4><FormattedMessage id='account.featured_tags.title' defaultMessage="{name}'s featured hashtags" values={{ name: <bdi dangerouslySetInnerHTML={{ __html: account.get('display_name_html') }} /> }} /></h4>
 
-        {featuredTags.take(3).map(featuredTag => (
+        {featuredTags.map(featuredTag => (
           <Hashtag
             key={featuredTag.get('name')}
             name={featuredTag.get('name')}


### PR DESCRIPTION
Partially addresses #1987
Reverts c9d3c7d63a3218e3e113435213b7f9e63feb68a1

As discussed in the issue, scrolling is a non-issue and limiting featured tags is far worse.
Only applies to glitch flavour, while I don't see any reason not to also revert 23d367f544485eaeed888c707012a8282bbb5806.