### PR TITLE
Wraps status timestamps in a `div`

### DIFF
--- a/app/javascript/flavours/glitch/components/status_action_bar.js
+++ b/app/javascript/flavours/glitch/components/status_action_bar.js
@@ -328,9 +328,11 @@ class StatusActionBar extends ImmutablePureComponent {
           />
         </div>
 
-        <a href={status.get('url')} className='status__relative-time' target='_blank' rel='noopener'>
-          <RelativeTimestamp timestamp={status.get('created_at')} />{status.get('edited_at') && <abbr title={intl.formatMessage(messages.edited, { date: intl.formatDate(status.get('edited_at'), { hour12: false, year: 'numeric', month: 'short', day: '2-digit', hour: '2-digit', minute: '2-digit' }) })}> *</abbr>}
-        </a>
+        <div className='status__action-bar-timestamp'>
+          <a href={status.get('url')} className='status__relative-time' target='_blank' rel='noopener'>
+            <RelativeTimestamp timestamp={status.get('created_at')} />{status.get('edited_at') && <abbr title={intl.formatMessage(messages.edited, { date: intl.formatDate(status.get('edited_at'), { hour12: false, year: 'numeric', month: 'short', day: '2-digit', hour: '2-digit', minute: '2-digit' }) })}> *</abbr>}
+          </a>
+        </div>
       </div>
     );
   }

--- a/app/javascript/flavours/glitch/styles/components/status.scss
+++ b/app/javascript/flavours/glitch/styles/components/status.scss
@@ -590,6 +590,10 @@
   width: 23.15px;
 }
 
+.status__action-bar-timestamp {
+  margin: 0 0 0 auto;
+}
+
 .detailed-status__action-bar-dropdown {
   flex: 1 1 auto;
   display: flex;

--- a/app/javascript/flavours/glitch/styles/components/status.scss
+++ b/app/javascript/flavours/glitch/styles/components/status.scss
@@ -591,7 +591,8 @@
 }
 
 .status__action-bar-timestamp {
-  margin: 0 0 0 auto;
+  flex-grow: 1;
+  text-align: end;
 }
 
 .detailed-status__action-bar-dropdown {


### PR DESCRIPTION
Fixes #1985

This wraps the status timestamp in a `div` to reduce the clickable target size of the link. The `div` gets a `margin: 0 0 0 auto` to stick it to the right margin of the status.