### PR TITLE
Realign timestamps

### DIFF
--- a/app/javascript/flavours/glitch/styles/components/status.scss
+++ b/app/javascript/flavours/glitch/styles/components/status.scss
@@ -593,6 +593,8 @@
 .status__action-bar-timestamp {
   flex-grow: 1;
   text-align: end;
+  display: flex;
+  overflow: hidden;
 }
 
 .detailed-status__action-bar-dropdown {


### PR DESCRIPTION
Add missing display and overflow properties.

Fixes misaligned timestamps and missing hidden overflow in search caused by #2038.

Before:
(Search)
![Screenshot_2022-12-23_11-35-08](https://user-images.githubusercontent.com/29483052/209322015-40359944-3132-4972-b63d-45c894cb4d23.png)
(Timeline)
![Screenshot_2022-12-23_11-31-24](https://user-images.githubusercontent.com/29483052/209322100-af9c2dd3-d5ce-4e6a-8799-382f86ea6f9f.png)

With this change:
(Search)
![Screenshot_2022-12-23_11-36-05](https://user-images.githubusercontent.com/29483052/209321991-0a87d87e-3d56-4875-94f7-6a11b890e1d4.png)
(Timeline)
![Screenshot_2022-12-23_11-31-54](https://user-images.githubusercontent.com/29483052/209322057-47cf3737-1bbb-41c4-8e34-2b3e91dfb523.png)

Before #2038 for comparison:
(Search)
![Screenshot_2022-12-23_11-56-25](https://user-images.githubusercontent.com/29483052/209324203-3d4393eb-5df4-4aa6-ae4c-bb51cd21feb9.png)
(Timeline)
![Screenshot_2022-12-23_11-57-08](https://user-images.githubusercontent.com/29483052/209324211-71d2f6fe-0f3c-458b-a468-d1aad655059f.png)

Not sure if it comes across in the screenshots, but #2038 caused timestamps to be a bit higher than before, making them look misaligned. 
