### PR TITLE
Use wrapper div as a spacer

### DIFF
--- a/app/javascript/flavours/glitch/components/status_action_bar.js
+++ b/app/javascript/flavours/glitch/components/status_action_bar.js
@@ -328,11 +328,10 @@ class StatusActionBar extends ImmutablePureComponent {
           />
         </div>
 
-        <div className='status__action-bar-timestamp'>
-          <a href={status.get('url')} className='status__relative-time' target='_blank' rel='noopener'>
-            <RelativeTimestamp timestamp={status.get('created_at')} />{status.get('edited_at') && <abbr title={intl.formatMessage(messages.edited, { date: intl.formatDate(status.get('edited_at'), { hour12: false, year: 'numeric', month: 'short', day: '2-digit', hour: '2-digit', minute: '2-digit' }) })}> *</abbr>}
-          </a>
-        </div>
+        <div className='status__action-bar-spacer' />
+        <a href={status.get('url')} className='status__relative-time' target='_blank' rel='noopener'>
+          <RelativeTimestamp timestamp={status.get('created_at')} />{status.get('edited_at') && <abbr title={intl.formatMessage(messages.edited, { date: intl.formatDate(status.get('edited_at'), { hour12: false, year: 'numeric', month: 'short', day: '2-digit', hour: '2-digit', minute: '2-digit' }) })}> *</abbr>}
+        </a>
       </div>
     );
   }

--- a/app/javascript/flavours/glitch/styles/components/status.scss
+++ b/app/javascript/flavours/glitch/styles/components/status.scss
@@ -444,7 +444,6 @@
 
 .status__relative-time {
   display: inline-block;
-  flex-grow: 1;
   color: $dark-text-color;
   font-size: 14px;
   text-align: right;
@@ -590,11 +589,8 @@
   width: 23.15px;
 }
 
-.status__action-bar-timestamp {
+.status__action-bar-spacer {
   flex-grow: 1;
-  text-align: end;
-  display: flex;
-  overflow: hidden;
 }
 
 .detailed-status__action-bar-dropdown {


### PR DESCRIPTION
Follow-up to #2044

Sorry, I completely missed that setting `display:flex` also increases the clickable size again.
This changes the div from being a wrapper to being a flexible spacer, so the alignment of timestamps is kept, while also reducing the clickable size.