### PR TITLE
Split 'show boosts/replies in public timelines' glitch admin setting into local and federated (neatchee/mastodon#8)

### DIFF
--- a/app/controllers/api/v1/timelines/public_controller.rb
+++ b/app/controllers/api/v1/timelines/public_controller.rb
@@ -39,8 +39,8 @@ class Api::V1::Timelines::PublicController < Api::BaseController
       remote: truthy_param?(:remote),
       only_media: truthy_param?(:only_media),
       allow_local_only: truthy_param?(:allow_local_only),
-      with_replies: Setting.show_replies_in_public_timelines,
-      with_reblogs: Setting.show_reblogs_in_public_timelines,
+      with_replies: truthy_param?(:local) ? Setting.show_replies_in_local_timelines : Setting.show_replies_in_federated_timelines,
+      with_reblogs: truthy_param?(:local) ? Setting.show_reblogs_in_local_timelines : Setting.show_reblogs_in_federated_timelines,
     )
   end
 

--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -25,8 +25,10 @@ class Form::AdminSettings
     flavour_and_skin
     thumbnail
     mascot
-    show_reblogs_in_public_timelines
-    show_replies_in_public_timelines
+    show_reblogs_in_local_timelines
+    show_replies_in_local_timelines
+    show_reblogs_in_federated_timelines
+    show_replies_in_federated_timelines
     trends
     trendable_by_default
     trending_status_cw
@@ -54,8 +56,10 @@ class Form::AdminSettings
     preview_sensitive_media
     profile_directory
     hide_followers_count
-    show_reblogs_in_public_timelines
-    show_replies_in_public_timelines
+    show_reblogs_in_local_timelines
+    show_replies_in_local_timelines
+    show_reblogs_in_federated_timelines
+    show_replies_in_federated_timelines
     trends
     trendable_by_default
     trending_status_cw

--- a/app/views/admin/settings/other/show.html.haml
+++ b/app/views/admin/settings/other/show.html.haml
@@ -14,10 +14,16 @@
     = f.input :hide_followers_count, as: :boolean, wrapper: :with_label, label: t('admin.settings.hide_followers_count.title'), hint: t('admin.settings.hide_followers_count.desc_html'), glitch_only: true
 
   .fields-group
-    = f.input :show_reblogs_in_public_timelines, as: :boolean, wrapper: :with_label, label: t('admin.settings.show_reblogs_in_public_timelines.title'), hint: t('admin.settings.show_reblogs_in_public_timelines.desc_html'), glitch_only: true
+    = f.input :show_reblogs_in_local_timelines, as: :boolean, wrapper: :with_label, label: t('admin.settings.show_reblogs_in_local_timelines.title'), hint: t('admin.settings.show_reblogs_in_local_timelines.desc_html'), glitch_only: true
 
   .fields-group
-    = f.input :show_replies_in_public_timelines, as: :boolean, wrapper: :with_label, label: t('admin.settings.show_replies_in_public_timelines.title'), hint: t('admin.settings.show_replies_in_public_timelines.desc_html'), glitch_only: true
+    = f.input :show_replies_in_local_timelines, as: :boolean, wrapper: :with_label, label: t('admin.settings.show_replies_in_local_timelines.title'), hint: t('admin.settings.show_replies_in_local_timelines.desc_html'), glitch_only: true
+
+  .fields-group
+    = f.input :show_reblogs_in_federated_timelines, as: :boolean, wrapper: :with_label, label: t('admin.settings.show_reblogs_in_federated_timelines.title'), hint: t('admin.settings.show_reblogs_in_federated_timelines.desc_html'), glitch_only: true
+
+  .fields-group
+    = f.input :show_replies_in_federated_timelines, as: :boolean, wrapper: :with_label, label: t('admin.settings.show_replies_in_federated_timelines.title'), hint: t('admin.settings.show_replies_in_federated_timelines.desc_html'), glitch_only: true
 
   .fields-group
     = f.input :outgoing_spoilers, wrapper: :with_label, label: t('admin.settings.outgoing_spoilers.title'), hint: t('admin.settings.outgoing_spoilers.desc_html'), glitch_only: true

--- a/config/locales-glitch/en.yml
+++ b/config/locales-glitch/en.yml
@@ -19,12 +19,18 @@ en:
       outgoing_spoilers:
         desc_html: When federating toots, add this content warning to toots that do not have one. It is useful if your server is specialized in content other servers might want to have under a Content Warning. Media will also be marked as sensitive.
         title: Content warning for outgoing toots
-      show_reblogs_in_public_timelines:
-        desc_html: Show public boosts of public toots in local and public timelines.
-        title: Show boosts in public timelines
-      show_replies_in_public_timelines:
-        desc_html: In addition to public self-replies (threads), show public replies in local and public timelines.
-        title: Show replies in public timelines
+      show_reblogs_in_federated_timelines:
+        desc_html: Show public boosts of public toots in the federated timeline.
+        title: Show boosts in the federated timeline
+      show_reblogs_in_local_timelines:
+        desc_html: Show public boosts in the instance's local timeline.
+        title: Show boosts in the local timeline
+      show_replies_in_federated_timelines:
+        desc_html: In addition to public self-replies (threads), show public replies in the federated timeline.
+        title: Show replies in the federated timeline
+      show_replies_in_local_timelines:
+        desc_html: In addition to public self-replies (threads), show public replies in the instance's local timeline.
+        title: Show replies in the local timeline
       trending_status_cw:
         desc_html: When trending posts are enabled, allow posts with Content Warnings to be eligible. Changes to this setting are not retroactive.
         title: Allow posts with Content Warnings to trend


### PR DESCRIPTION
Showing all federated boosts is noisy while local boosts may be acceptable (especially once neatchee/mastodon#4 is addressed)