### PR TITLE
Add option to enlarge emoji on mouse-over

### DIFF
--- a/app/javascript/flavours/glitch/components/status.js
+++ b/app/javascript/flavours/glitch/components/status.js
@@ -798,6 +798,7 @@ class Status extends ImmutablePureComponent {
             disabled={!router}
             tagLinks={settings.get('tag_misleading_links')}
             rewriteMentions={settings.get('rewrite_mentions')}
+            zoomEmojisOnHover={settings.get('zoom_emojis_on_hover')}
           />
 
           {!isCollapsed || !(muted || !settings.getIn(['collapsed', 'show_action_bar'])) ? (

--- a/app/javascript/flavours/glitch/components/status_content.js
+++ b/app/javascript/flavours/glitch/components/status_content.js
@@ -121,6 +121,7 @@ class StatusContent extends React.PureComponent {
     tagLinks: PropTypes.bool,
     rewriteMentions: PropTypes.string,
     intl: PropTypes.object,
+    zoomEmojisOnHover: PropTypes.bool.isRequired,
   };
 
   static defaultProps = {
@@ -312,6 +313,7 @@ class StatusContent extends React.PureComponent {
       tagLinks,
       rewriteMentions,
       intl,
+      zoomEmojisOnHover,
     } = this.props;
 
     const hidden = this.props.onExpandedToggle ? !this.props.expanded : this.state.hidden;
@@ -323,7 +325,12 @@ class StatusContent extends React.PureComponent {
     const classNames = classnames('status__content', {
       'status__content--with-action': parseClick && !disabled,
       'status__content--with-spoiler': status.get('spoiler_text').length > 0,
+      'status__content--zoom-emojis-on-hover': zoomEmojisOnHover,
     });
+    const textClassNames = classnames('status__content__text translate', {
+      'status__content--zoom-emojis-on-hover': zoomEmojisOnHover,
+    });
+
 
     const translateButton = renderTranslate && (
       <TranslateButton onClick={this.handleTranslate} translation={status.get('translation')} />
@@ -399,7 +406,7 @@ class StatusContent extends React.PureComponent {
               key={`contents-${tagLinks}`}
               tabIndex={!hidden ? 0 : null}
               dangerouslySetInnerHTML={content}
-              className='status__content__text translate'
+              className={textClassNames}
               onMouseEnter={this.handleMouseEnter}
               onMouseLeave={this.handleMouseLeave}
               lang={lang}
@@ -423,7 +430,7 @@ class StatusContent extends React.PureComponent {
             ref={this.setContentsRef}
             key={`contents-${tagLinks}-${rewriteMentions}`}
             dangerouslySetInnerHTML={content}
-            className='status__content__text translate'
+            className={textClassNames}
             tabIndex='0'
             onMouseEnter={this.handleMouseEnter}
             onMouseLeave={this.handleMouseLeave}
@@ -437,13 +444,13 @@ class StatusContent extends React.PureComponent {
     } else {
       return (
         <div
-          className='status__content'
+          className={'status__content'}
           tabIndex='0'
         >
           <div
             ref={this.setContentsRef}
             key={`contents-${tagLinks}`}
-            className='status__content__text translate'
+            className={textClassNames}
             dangerouslySetInnerHTML={content}
             tabIndex='0'
             onMouseEnter={this.handleMouseEnter}

--- a/app/javascript/flavours/glitch/features/direct_timeline/components/conversation.js
+++ b/app/javascript/flavours/glitch/features/direct_timeline/components/conversation.js
@@ -144,13 +144,13 @@ class Conversation extends ImmutablePureComponent {
   }
 
   render () {
-    const { accounts, lastStatus, unread, scrollKey, intl } = this.props;
+    const { accounts, lastStatus, unread, scrollKey, intl, settings } = this.props;
 
     if (lastStatus === null) {
       return null;
     }
 
-    const isExpanded = this.props.settings.getIn(['content_warnings', 'shared_state']) ? !lastStatus.get('hidden') : this.state.isExpanded;
+    const isExpanded = settings.getIn(['content_warnings', 'shared_state']) ? !lastStatus.get('hidden') : this.state.isExpanded;
 
     const menu = [
       { text: intl.formatMessage(messages.open), action: this.handleClick },
@@ -206,6 +206,7 @@ class Conversation extends ImmutablePureComponent {
               onExpandedToggle={this.handleShowMore}
               collapsable
               media={media}
+              zoomEmojisOnHover={settings.get('zoom_emojis_on_hover')}
             />
 
             <div className='status__action-bar'>

--- a/app/javascript/flavours/glitch/features/local_settings/page/index.js
+++ b/app/javascript/flavours/glitch/features/local_settings/page/index.js
@@ -55,6 +55,14 @@ class LocalSettingsPage extends React.PureComponent {
         </LocalSettingsPageItem>
         <LocalSettingsPageItem
           settings={settings}
+          item={['zoom_emojis_on_hover']}
+          id='mastodon-settings--zoom-on-hover'
+          onChange={onChange}
+        >
+          <FormattedMessage id='settings.zoom_emojis_on_hover' defaultMessage='Zoom in on emojis when hovering over them' />
+        </LocalSettingsPageItem>
+        <LocalSettingsPageItem
+          settings={settings}
           item={['hicolor_privacy_icons']}
           id='mastodon-settings--hicolor_privacy_icons'
           onChange={onChange}

--- a/app/javascript/flavours/glitch/features/status/components/detailed_status.js
+++ b/app/javascript/flavours/glitch/features/status/components/detailed_status.js
@@ -316,6 +316,7 @@ class DetailedStatus extends ImmutablePureComponent {
             onUpdate={this.handleChildUpdate}
             tagLinks={settings.get('tag_misleading_links')}
             rewriteMentions={settings.get('rewrite_mentions')}
+            zoomEmojisOnHover={settings.get('zoom_emojis_on_hover')}
             disabled
           />
 

--- a/app/javascript/flavours/glitch/locales/defaultMessages.json
+++ b/app/javascript/flavours/glitch/locales/defaultMessages.json
@@ -595,6 +595,10 @@
         "id": "settings.show_reply_counter"
       },
       {
+        "defaultMessage": "Zoom in on emojis when hovering over them",
+        "id": "settings.zoom_emojis_on_hover"
+      },
+      {
         "defaultMessage": "High color privacy icons",
         "id": "settings.hicolor_privacy_icons"
       },

--- a/app/javascript/flavours/glitch/locales/en.json
+++ b/app/javascript/flavours/glitch/locales/en.json
@@ -160,6 +160,7 @@
   "settings.show_action_bar": "Show action buttons in collapsed toots",
   "settings.show_content_type_choice": "Show content-type choice when authoring toots",
   "settings.show_reply_counter": "Display an estimate of the reply count",
+  "settings.zoom_emojis_on_hover": "Zoom in on emojis when hovering over them",
   "settings.side_arm": "Secondary toot button:",
   "settings.side_arm.none": "None",
   "settings.side_arm_reply_mode": "When replying to a toot, the secondary toot button should:",

--- a/app/javascript/flavours/glitch/reducers/local_settings.js
+++ b/app/javascript/flavours/glitch/reducers/local_settings.js
@@ -12,6 +12,7 @@ const initialState = ImmutableMap({
   side_arm  : 'none',
   side_arm_reply_mode : 'keep',
   show_reply_count : false,
+  zoom_emojis_on_hover : true,
   always_show_spoilers_field: false,
   confirm_missing_media_description: false,
   confirm_boost_missing_media_description: false,

--- a/app/javascript/flavours/glitch/styles/components/status.scss
+++ b/app/javascript/flavours/glitch/styles/components/status.scss
@@ -82,10 +82,11 @@
     overflow: visible;
 
     .emojione {
+      transition-property: transform, filter;
       transition-duration:0.08s;
     }
-
-    .emojione:hover {
+    
+    &.status__content--zoom-emojis-on-hover .emojione:hover {
       transform: scale(1.8);
       filter: drop-shadow(0 0 3px #0c0c0c);
       z-index:99;

--- a/app/javascript/flavours/glitch/styles/components/status.scss
+++ b/app/javascript/flavours/glitch/styles/components/status.scss
@@ -79,7 +79,17 @@
 
   .status__content__text,
   .e-content {
-    overflow: hidden;
+    overflow: visible;
+
+    .emojione {
+      transition-duration:0.08s;
+    }
+
+    .emojione:hover {
+      transform: scale(1.8);
+      filter: drop-shadow(0 0 3px #0c0c0c);
+      z-index:99;
+    }
 
     & > ul,
     & > ol {


### PR DESCRIPTION
Depending on a number of factors, emoji can be too small to see details. This feature adds an option to the glitch preferences menus to enlarge emoji in statuses on mouse-over or tap.