### PR TITLE
Collapsed post visibility improvements

### DIFF
--- a/app/javascript/flavours/glitch/styles/components/status.scss
+++ b/app/javascript/flavours/glitch/styles/components/status.scss
@@ -332,6 +332,10 @@
   &.status-direct {
     background: lighten($ui-base-color, 8%);
     border-bottom-color: lighten($ui-base-color, 12%);
+
+    .status__collapse-button.active {
+      background-image: linear-gradient(rgba(lighten($ui-base-color, 16%), 255) 0 0);
+    }
   }
 
   &.light {
@@ -490,6 +494,10 @@
   .text-icon {
     padding-left: 2px;
     padding-right: 2px;
+  }
+
+  .status__collapse-button.active {
+    background-image: linear-gradient(rgba(lighten($ui-base-color, 8%), 255) 0 0);
   }
 
   .status__collapse-button.active > .fa-angle-double-up {

--- a/app/javascript/flavours/glitch/styles/components/status.scss
+++ b/app/javascript/flavours/glitch/styles/components/status.scss
@@ -412,6 +412,10 @@
         pointer-events: none;
       }
       
+      .media-gallery {
+        display: none;
+      }
+
       a:hover {
         text-decoration: none;
       }

--- a/app/javascript/flavours/glitch/styles/components/status.scss
+++ b/app/javascript/flavours/glitch/styles/components/status.scss
@@ -332,10 +332,6 @@
   &.status-direct {
     background: lighten($ui-base-color, 8%);
     border-bottom-color: lighten($ui-base-color, 12%);
-
-    .status__collapse-button.active {
-      background-image: linear-gradient(rgba(lighten($ui-base-color, 16%), 255) 0 0);
-    }
   }
 
   &.light {
@@ -427,7 +423,27 @@
       background: linear-gradient(rgba(lighten($ui-base-color, 8%), 0), rgba(lighten($ui-base-color, 8%), 1));
     }
 
-    .notification__message {
+    &.status-direct .status__collapse-button {
+      background-image: linear-gradient(rgba(lighten($ui-base-color, 12%), 255) 0 0);
+    
+      &:active,
+      &:hover,
+      &:focus {
+        background-image: linear-gradient(rgba(lighten($ui-base-color, 20%), 255) 0 0);
+      }
+    }
+					  
+    .status__collapse-button {
+      background-image: linear-gradient(rgba(lighten($ui-base-color, 4%), 255) 0 0);
+
+      &:active,
+      &:hover,
+      &:focus {
+        background-image: linear-gradient(rgba(lighten($ui-base-color, 12%), 255) 0 0);
+      }
+    }
+
+    notification__message {
       margin-bottom: 0;
     }
 
@@ -498,10 +514,6 @@
   .text-icon {
     padding-left: 2px;
     padding-right: 2px;
-  }
-
-  .status__collapse-button.active {
-    background-image: linear-gradient(rgba(lighten($ui-base-color, 8%), 255) 0 0);
   }
 
   .status__collapse-button.active > .fa-angle-double-up {

--- a/app/javascript/flavours/glitch/styles/components/status.scss
+++ b/app/javascript/flavours/glitch/styles/components/status.scss
@@ -391,7 +391,8 @@
     }
 
     .status__content {
-      height: 60px;
+      max-height: 60px;
+      min-height: 22px;
       overflow: hidden;
       text-overflow: ellipsis;
       padding-top: 0;

--- a/app/javascript/flavours/glitch/styles/components/status.scss
+++ b/app/javascript/flavours/glitch/styles/components/status.scss
@@ -391,7 +391,7 @@
     }
 
     .status__content {
-      height: 20px;
+      height: 60px;
       overflow: hidden;
       text-overflow: ellipsis;
       padding-top: 0;


### PR DESCRIPTION
It can be difficult to quickly identify collapsed posts when scrolling, and it is hard to decide if you should expand the post when the first line of the post doesn't contain the post premise. To address this we:

* Let collapsed posts have max-height 60px instead of a static 20px
  * This will show three lines with a fade-out
* Hide the media-gallery on collapsed posts, so we don't get the top of the preview peeking above the fold
* Add a background to an "active" collapse button so that collapsed posts are obvious when scrolling 
  * The fade out and blue chevrons alone are too subtle