### PR TITLE
[Glitch] Fix French and QC locales

### DIFF
--- a/config/locales-glitch/fr-QC.yml
+++ b/config/locales-glitch/fr-QC.yml
@@ -34,7 +34,7 @@ fr-QC:
       glitch_guide_link_text: Et c'est pareil avec glitch-soc !
   auth:
     captcha_confirmation:
-      hint_html: Plus qu'une étape ! Pour vérifier votre compte sur ce serveur, vous devez résoudre un CAPTCHA. Vous pouvez <a href="/about/more>contacter l'administrateur du serveur</a> si vous avez des questions ou besoin d'assistance dans la vérification de votre compte.
+      hint_html: Plus qu'une étape ! Pour vérifier votre compte sur ce serveur, vous devez résoudre un CAPTCHA. Vous pouvez <a href="/about/more">contacter l'administrateur du serveur</a> si vous avez des questions ou besoin d'assistance dans la vérification de votre compte.
       title: Vérification de l'utilisateur
   generic:
     use_this: Utiliser ceci

--- a/config/locales-glitch/fr.yml
+++ b/config/locales-glitch/fr.yml
@@ -34,7 +34,7 @@ fr:
       glitch_guide_link_text: Et c'est pareil avec glitch-soc !
   auth:
     captcha_confirmation:
-      hint_html: Plus qu'une étape ! Pour vérifier votre compte sur ce serveur, vous devez résoudre un CAPTCHA. Vous pouvez <a href="/about/more>contacter l'administrateur du serveur</a> si vous avez des questions ou besoin d'assistance dans la vérification de votre compte.
+      hint_html: Plus qu'une étape ! Pour vérifier votre compte sur ce serveur, vous devez résoudre un CAPTCHA. Vous pouvez <a href="/about/more">contacter l'administrateur du serveur</a> si vous avez des questions ou besoin d'assistance dans la vérification de votre compte.
       title: Vérification de l'utilisateur
   generic:
     use_this: Utiliser ceci


### PR DESCRIPTION
A double-quote was missing on the captcha confirmation page.  
This didn't let the `<a>` tag close properly and broke the page, preventing French-speaking people from confirming their accounts if the instance has hCaptcha enabled.

I tried to fix that on Crowdin but huh... I think it's broken @ClearlyClaire.
![image](https://user-images.githubusercontent.com/843787/212723774-4b854bd8-20cf-42f6-b708-1286c940eda6.png)
