### PR TITLE
Fix missing admin CSS in glitch-soc flavor

### DIFF
--- a/app/javascript/flavours/glitch/styles/forms.scss
+++ b/app/javascript/flavours/glitch/styles/forms.scss
@@ -157,6 +157,15 @@ code {
       padding: 0.2em 0.4em;
       background: darken($ui-base-color, 12%);
     }
+
+    li {
+      list-style: disc;
+      margin-left: 18px;
+    }
+  }
+
+  ul.hint {
+    margin-bottom: 15px;
   }
 
   span.hint {


### PR DESCRIPTION
Port SCSS changes from 43f56f12917f154fbb70cbc305daba9e2fd364ed