### PR TITLE
fix hashtag ordering

### DIFF
--- a/app/javascript/flavours/glitch/reducers/compose.js
+++ b/app/javascript/flavours/glitch/reducers/compose.js
@@ -282,9 +282,9 @@ const sortHashtagsByUse = (state, tags) => {
     if (usedA === usedB) {
       return 0;
     } else if (usedA && !usedB) {
-      return 1;
-    } else {
       return -1;
+    } else {
+      return 1;
     }
   });
 };


### PR DESCRIPTION
closes #2106

see https://github.com/neatchee/mastodon/issues/35

It appears that Mastodon has the correct ordering, but Glitch does not. Perhaps Mastodon fixed it at some point and the fix never got brought over, or there was a bad merge?