### PR TITLE
Fix profile header not scrolling to top when clicked in simple UI

### DIFF
--- a/app/javascript/flavours/glitch/features/account_gallery/index.jsx
+++ b/app/javascript/flavours/glitch/features/account_gallery/index.jsx
@@ -200,7 +200,7 @@ class AccountGallery extends ImmutablePureComponent {
     }
 
     return (
-      <Column ref={this.setColumnRef}>
+      <Column bindToDocument={!multiColumn} ref={this.setColumnRef}>
         <ProfileColumnHeader onClick={this.handleHeaderClick} multiColumn={multiColumn} />
 
         <ScrollContainer scrollKey='account_gallery'>

--- a/app/javascript/flavours/glitch/features/account_timeline/index.jsx
+++ b/app/javascript/flavours/glitch/features/account_timeline/index.jsx
@@ -184,7 +184,7 @@ class AccountTimeline extends ImmutablePureComponent {
     const remoteMessage = remote ? <RemoteHint url={remoteUrl} /> : null;
 
     return (
-      <Column ref={this.setRef}>
+      <Column bindToDocument={!multiColumn} ref={this.setRef}>
         <ProfileColumnHeader onClick={this.handleHeaderClick} multiColumn={multiColumn} />
 
         <StatusList

--- a/app/javascript/flavours/glitch/features/followers/index.jsx
+++ b/app/javascript/flavours/glitch/features/followers/index.jsx
@@ -150,7 +150,7 @@ class Followers extends ImmutablePureComponent {
     const remoteMessage = remote ? <RemoteHint url={remoteUrl} /> : null;
 
     return (
-      <Column ref={this.setRef}>
+      <Column bindToDocument={!multiColumn} ref={this.setRef}>
         <ProfileColumnHeader onClick={this.handleHeaderClick} multiColumn={multiColumn} />
 
         <ScrollableList

--- a/app/javascript/flavours/glitch/features/following/index.jsx
+++ b/app/javascript/flavours/glitch/features/following/index.jsx
@@ -150,7 +150,7 @@ class Following extends ImmutablePureComponent {
     const remoteMessage = remote ? <RemoteHint url={remoteUrl} /> : null;
 
     return (
-      <Column ref={this.setRef}>
+      <Column bindToDocument={!multiColumn} ref={this.setRef}>
         <ProfileColumnHeader onClick={this.handleHeaderClick} multiColumn={multiColumn} />
 
         <ScrollableList


### PR DESCRIPTION
Fixes scrolling to top when viewing profiles in simple UI.

When viewing accounts in the simple UI, clicking the header doesn't bring you back to the top.
This adds the `bindToDocument` attribute to those columns to fix that.