### PR TITLE
Lighten the background image in mastodon-light theme

### DIFF
--- a/app/javascript/flavours/glitch/styles/mastodon-light/diff.scss
+++ b/app/javascript/flavours/glitch/styles/mastodon-light/diff.scss
@@ -264,6 +264,10 @@ html {
   background: $white;
 }
 
+.status.collapsed.has-background::before {
+  background-image: linear-gradient(to bottom, rgba($ui-base-color, .75), rgba($ui-base-color, .65) 24px, rgba($ui-base-color, .8));
+}
+
 // Change the background colors of status__content__spoiler-link
 .reply-indicator__content .status__content__spoiler-link,
 .status__content .status__content__spoiler-link {


### PR DESCRIPTION
After the change:

![2023-02-16 12 40 57 99c67c3](https://user-images.githubusercontent.com/147687/219355457-2456b1b6-3805-464a-9997-34a054b3ee71.png)
Combined with #2115

Before:

![2023-02-16 12 42 23 chrome pl 0ec4483a969f](https://user-images.githubusercontent.com/147687/219355816-ca3a94b9-132f-4fc4-a08f-8294f2fc5834.png)
