### PR TITLE
Add option to allow toots with sensitive media to trend

### DIFF
--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -33,6 +33,7 @@ class Form::AdminSettings
     trends_as_landing_page
     trendable_by_default
     trending_status_cw
+    trending_status_sensitive
     show_domain_blocks
     show_domain_blocks_rationale
     noindex
@@ -66,6 +67,7 @@ class Form::AdminSettings
     trends_as_landing_page
     trendable_by_default
     trending_status_cw
+    trending_status_sensitive
     noindex
     require_invite_text
     captcha_enabled

--- a/app/models/trends/statuses.rb
+++ b/app/models/trends/statuses.rb
@@ -106,7 +106,7 @@ class Trends::Statuses < Trends::Base
   private
 
   def eligible?(status)
-    status.public_visibility? && status.account.discoverable? && !status.account.silenced? && !status.account.sensitized? && (status.spoiler_text.blank? || Setting.trending_status_cw) && !status.sensitive? && !status.reply? && valid_locale?(status.language)
+    status.public_visibility? && status.account.discoverable? && !status.account.silenced? && !status.account.sensitized? && (status.spoiler_text.blank? || Setting.trending_status_cw) && (!status.sensitive? || Setting.trending_status_sensitive) && !status.reply? && valid_locale?(status.language)
   end
 
   def calculate_scores(statuses, at_time)

--- a/app/views/admin/settings/discovery/show.html.haml
+++ b/app/views/admin/settings/discovery/show.html.haml
@@ -24,6 +24,9 @@
   .fields-group
     = f.input :trending_status_cw, as: :boolean, wrapper: :with_label, label: t('admin.settings.trending_status_cw.title'), hint: t('admin.settings.trending_status_cw.desc_html'), glitch_only: true
 
+  .fields-group
+    = f.input :trending_status_sensitive, as: :boolean, wrapper: :with_label, label: t('admin.settings.trending_status_sensitive.title'), hint: t('admin.settings.trending_status_sensitive.desc_html'), glitch_only: true
+
   %h4= t('admin.settings.discovery.public_timelines')
 
   .fields-group

--- a/config/locales-glitch/en.yml
+++ b/config/locales-glitch/en.yml
@@ -28,6 +28,9 @@ en:
       trending_status_cw:
         desc_html: When trending posts are enabled, allow posts with Content Warnings to be eligible. Changes to this setting are not retroactive.
         title: Allow posts with Content Warnings to trend
+      trending_status_sensitive:
+        desc_html: When trending posts are enabled, allow posts with sensitive media to be eligible. Changes to this setting are not retroactive.
+        title: Allow posts with sensitive media to trend
   appearance:
     localization:
       glitch_guide_link: https://crowdin.com/project/glitch-soc

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -22,6 +22,7 @@ defaults: &defaults
   trends_as_landing_page: true
   trendable_by_default: false
   trending_status_cw: true
+  trending_status_sensitive: false
   hide_followers_count: false
   reserved_usernames:
     - admin


### PR DESCRIPTION
Closes #2123

I'm not sure whether this should be disabled by default or not.
I set it to false to not change the current behaviour, but actually prefer it being enabled by default.