### PR TITLE
Remove not sensitive requirement for trending statuses

### DIFF
--- a/app/models/trends/statuses.rb
+++ b/app/models/trends/statuses.rb
@@ -91,7 +91,7 @@ class Trends::Statuses < Trends::Base
   private
 
   def eligible?(status)
-    status.public_visibility? && status.account.discoverable? && !status.account.silenced? && (status.spoiler_text.blank? || Setting.trending_status_cw) && !status.sensitive? && !status.reply? && valid_locale?(status.language)
+    status.public_visibility? && status.account.discoverable? && !status.account.silenced? && (status.spoiler_text.blank? || Setting.trending_status_cw) && !status.reply? && valid_locale?(status.language)
   end
 
   def calculate_scores(statuses, at_time)


### PR DESCRIPTION
Closes #2123 
Alternative to #2124 

Instead of adding a new option, removes the not sensitive requirement altogether.