### PR TITLE
Allow small tag in toots

### DIFF
--- a/app/javascript/flavours/glitch/styles/rich_text.scss
+++ b/app/javascript/flavours/glitch/styles/rich_text.scss
@@ -73,6 +73,10 @@
     vertical-align: super;
   }
 
+  small {
+    font-size: smaller;
+  }
+
   ul,
   ol {
     margin-left: 2em;

--- a/lib/sanitize_ext/sanitize_config.rb
+++ b/lib/sanitize_ext/sanitize_config.rb
@@ -70,7 +70,7 @@ class Sanitize
     end
 
     MASTODON_STRICT ||= freeze_config(
-      elements: %w(p br span a abbr del pre blockquote code b strong u sub sup i em h1 h2 h3 h4 h5 ul ol li),
+      elements: %w(p br span a abbr del pre blockquote code b strong u sub sup small i em h1 h2 h3 h4 h5 ul ol li),
 
       attributes: {
         'a' => %w(href rel class title),


### PR DESCRIPTION
Closes #2131 

Allows the usage of \<small> in toots.
Chose `smaller` as font size to keep it consistent with \<sub> and \<sup>

Preview:
![Screenshot_2023-03-15_10-26-48](https://user-images.githubusercontent.com/29483052/225268141-d792228b-cea1-47c6-af00-4612e5deb662.png)
