### PR TITLE
Fix docker images not being pushed

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -49,7 +49,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           provenance: false
           builder: ${{ steps.buildx.outputs.name }}
-          push: ${{ github.repository == 'glitch-soc/mastodon' && github.event_name != 'pull_request' }}
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -49,7 +49,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           provenance: false
           builder: ${{ steps.buildx.outputs.name }}
-          push: ${{ github.repository == 'mastodon/mastodon' && github.event_name != 'pull_request' }}
+          push: ${{ github.repository == 'glitch-soc/mastodon' && github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
Closes #2142

I'm not familiar with docker or the workflows for it, but 0b8b0ef65221e5341cd81b212f0e40722ffd5ef7 introduced a condition where docker images are only pushed when the repo matches mastodon/mastodon, so the images are still built for glitch-soc, but don't end up being available.
~Kept the check, but changed the repo to `glitch-soc/mastodon`~
Removed the repo check

Tested downstream. With this change docker builds are published again.