### PR TITLE
Update resize_image.js

### DIFF
--- a/app/javascript/flavours/glitch/utils/resize_image.js
+++ b/app/javascript/flavours/glitch/utils/resize_image.js
@@ -1,6 +1,6 @@
 import EXIF from 'exif-js';
 
-const MAX_IMAGE_PIXELS = 2073600; // 1920x1080px
+const MAX_IMAGE_PIXELS = 34184160; // 7360x4912px
 
 const _browser_quirks = {};
 


### PR DESCRIPTION
Update Glitch UI for Media Upload limit now implemented in Mastodon:Mastodon and remove resizing.
Glitch UI was still resizing images to 1080
but the attachmentable and mediaattachment allowed for 8k images to be uploaded to compressed to 4k
this also adds support for 2:3 DSLR Images