### PR TITLE
Fix small mistakes in RTL layout

### DIFF
--- a/app/javascript/flavours/glitch/styles/components/misc.scss
+++ b/app/javascript/flavours/glitch/styles/components/misc.scss
@@ -738,7 +738,7 @@ body > [data-popper-placement] {
   vertical-align: top;
 
   .account__avatar {
-    margin-right: 5px;
+    margin-inline-end: 5px;
     border-radius: 50%;
   }
 
@@ -1699,7 +1699,7 @@ button.icon-button.active i.fa-retweet {
   &__content {
     flex: 1 1 auto;
     padding: 10px 5px;
-    padding-right: 15px;
+    padding-inline-end: 15px;
     overflow: hidden;
 
     &__info {

--- a/app/javascript/flavours/glitch/styles/components/status.scss
+++ b/app/javascript/flavours/glitch/styles/components/status.scss
@@ -177,7 +177,7 @@
   .status,
   .notification-follow,
   .notification-follow-request {
-    padding-right: ($dismiss-overlay-width + 0.5rem);
+    padding-inline-end: ($dismiss-overlay-width + 0.5rem);
   }
 }
 

--- a/app/javascript/flavours/glitch/styles/rich_text.scss
+++ b/app/javascript/flavours/glitch/styles/rich_text.scss
@@ -93,7 +93,7 @@
 
 .reply-indicator__content {
   blockquote {
-    border-left-color: $inverted-text-color;
+    border-inline-start-color: $inverted-text-color;
     color: $inverted-text-color;
   }
 }


### PR DESCRIPTION
Follow-up to #2156

Borders in blockquotes in reply-indicator weren't colored properly.
avatar margin when viewing edited toots dropdown was applied to wrong side.
Conversations had padding applied to the wrong side.
Padding for notifcation cleaner checkboxes was applied to wrong side.