### PR TITLE
Fix crash when opening filter modal

### DIFF
--- a/app/javascript/flavours/glitch/features/ui/components/filter_modal.jsx
+++ b/app/javascript/flavours/glitch/features/ui/components/filter_modal.jsx
@@ -131,4 +131,4 @@ class FilterModal extends ImmutablePureComponent {
 
 }
 
-export default connect(injectIntl(FilterModal));
+export default connect()(injectIntl(FilterModal));


### PR DESCRIPTION
Fixes #2186

The export default statement was incorrect, causing a crash when opening the filter modal.