### PR TITLE
Change `drawer--header` to `drawer__header`

### DIFF
--- a/app/javascript/flavours/glitch/features/compose/components/header.jsx
+++ b/app/javascript/flavours/glitch/features/compose/components/header.jsx
@@ -77,7 +77,7 @@ class Header extends ImmutablePureComponent {
 
     //  The result.
     return (
-      <nav className='drawer--header'>
+      <nav className='drawer__header'>
         <Link
           aria-label={intl.formatMessage(messages.start)}
           title={intl.formatMessage(messages.start)}

--- a/app/javascript/flavours/glitch/styles/components/drawer.scss
+++ b/app/javascript/flavours/glitch/styles/components/drawer.scss
@@ -49,7 +49,7 @@
   }
 }
 
-.drawer--header {
+.drawer__header {
   flex: none;
   font-size: 16px;
   background: lighten($ui-base-color, 8%);


### PR DESCRIPTION
As per https://github.com/glitch-soc/mastodon/pull/2161#issuecomment-1495791257

This might break some skins downstream.