### PR TITLE
Fix JS crashing if initial-state is not set

### DIFF
--- a/app/javascript/flavours/glitch/initial_state.js
+++ b/app/javascript/flavours/glitch/initial_state.js
@@ -96,10 +96,12 @@ const element = document.getElementById('initial-state');
 const initialState = element?.textContent && JSON.parse(element.textContent);
 
 // Glitch-soc-specific “local settings”
-try {
-  initialState.local_settings = JSON.parse(localStorage.getItem('mastodon-settings'));
-} catch (e) {
-  initialState.local_settings = {};
+if (initialState) {
+  try {
+    initialState.local_settings = JSON.parse(localStorage.getItem('mastodon-settings'));
+  } catch (e) {
+    initialState.local_settings = {};
+  }
 }
 
 /**


### PR DESCRIPTION
Fixes issues with the JS for at least sign-up pages not working