### PR TITLE
Change mapStateToProps to null in LimitedAccountHint

### DIFF
--- a/app/javascript/flavours/glitch/features/account_timeline/components/limited_account_hint.jsx
+++ b/app/javascript/flavours/glitch/features/account_timeline/components/limited_account_hint.jsx
@@ -34,4 +34,4 @@ class LimitedAccountHint extends React.PureComponent {
 
 }
 
-export default connect(() => {}, mapDispatchToProps)(LimitedAccountHint);
+export default connect(null, mapDispatchToProps)(LimitedAccountHint);


### PR DESCRIPTION
Fixes `mapStateToProps() in Connect(LimitedAccountHint) must return a plain object. Instead received undefined.
Doesn't matter too much as this is only printed on a dev env.

Also present upstream, but I have no intention of contributing upstream.