### PR TITLE
Add option for multiple local-only emojis

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -301,3 +301,10 @@ MAX_POLL_OPTION_CHARS=100
 # -----------------------
 IP_RETENTION_PERIOD=31556952
 SESSION_RETENTION_PERIOD=31556952
+
+# Local-only Emoji
+# **Always add old local-only emojis to the ALTERNATIVE_LOCAL_ONLY_EMOJI**,
+# otherwise old local-only messages will become public
+# ALTERNATIVE_LOCAL_ONLY_EMOJI is a comma-separated list of alternate emoji to use for local-only messages.
+# DEFAULT_LOCAL_ONLY_EMOJI=
+# ALTERNATIVE_LOCAL_ONLY_EMOJI=

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -431,11 +431,15 @@ class Status < ApplicationRecord
 
   def marked_local_only?
     # match both with and without U+FE0F (the emoji variation selector)
-    /#{local_only_emoji}\ufe0f?\z/.match?(content)
+    /(#{all_local_only_emojis.join('|')})\ufe0f?\z/.match?(content)
   end
 
   def local_only_emoji
-    '👁'
+    ENV.get('DEFAULT_LOCAL_ONLY_EMOJI', '👁')
+  end
+
+  def all_local_only_emojis
+    ENV.get('ALTERNATIVE_LOCAL_ONLY_EMOJI', '').split(',').push(local_only_emoji)
   end
 
   def status_stat


### PR DESCRIPTION
By reading the env variables DEFAULT_LOCAL_ONLY_EMOJI (defaulting to 👁) and ALTERNATIVE_LOCAL_ONLY_EMOJI (a comma-separated list of emojis to also accept as local-only characters).

The latter is necessary to allow for a smooth transition from one default local-only emoji to another (to keep previous local-only posts as local-only, the old local-only emoji should be added to ALTERNATIVE_LOCAL_ONLY_EMOJI).