### PR TITLE
Fix rubocop warnings

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -225,6 +225,8 @@ Lint/Void:
 # Configuration parameters: AllowedMethods, AllowedPatterns, CountRepeatedAttributes.
 Metrics/AbcSize:
   Max: 150
+  Exclude:
+    - 'app/serializers/initial_state_serializer.rb'
 
 # Configuration parameters: CountBlocks, Max.
 Metrics/BlockNesting:
@@ -247,6 +249,7 @@ Metrics/ModuleLength:
     - 'app/helpers/jsonld_helper.rb'
     - 'app/models/concerns/account_interactions.rb'
     - 'app/models/concerns/has_user_settings.rb'
+    - 'lib/sanitize_ext/sanitize_config.rb'
 
 # Configuration parameters: Max, CountKeywordArgs, MaxOptionalParameters.
 Metrics/ParameterLists:

--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -64,14 +64,16 @@ class PostStatusService < BaseService
   def fill_blank_text!
     return unless @text.blank? && @options[:spoiler_text].present?
 
-    if @media&.any?(&:video?) || @media&.any?(&:gifv?)
-      @text = '📹'
-    elsif @media&.any?(&:audio?)
-      @text = '🎵'
-    elsif @media&.any?(&:image?)
-      @text = '🖼'
-    else
-      @text = '.'
+    @text = begin
+      if @media&.any?(&:video?) || @media&.any?(&:gifv?)
+        '📹'
+      elsif @media&.any?(&:audio?)
+        '🎵'
+      elsif @media&.any?(&:image?)
+        '🖼'
+      else
+        '.'
+      end
     end
   end
 


### PR DESCRIPTION
Size/complexity-related issues were marked as exceptions, as doing otherwise would require refactoring in a way that probably would make it more complicated to keep with upstream in the future.