### PR TITLE
Fix thread lines not being properly updated when new posts are received

### DIFF
--- a/app/javascript/flavours/glitch/components/status.jsx
+++ b/app/javascript/flavours/glitch/components/status.jsx
@@ -134,6 +134,9 @@ class Status extends ImmutablePureComponent {
     'expanded',
     'unread',
     'pictureInPicture',
+    'previousId',
+    'nextInReplyToId',
+    'rootId',
   ];
 
   updateOnStates = [


### PR DESCRIPTION
At some point we'll have to reconsider why we're using `updateOnProps` in the first place and remove or memoize any offending function props if there is still any left.