### PR TITLE
Fix more JS linting issues

### DIFF
--- a/app/javascript/flavours/glitch/features/compose/components/publisher.jsx
+++ b/app/javascript/flavours/glitch/features/compose/components/publisher.jsx
@@ -24,6 +24,10 @@ const messages = defineMessages({
     id: 'compose_form.publish_loud',
   },
   saveChanges: { id: 'compose_form.save_changes', defaultMessage: 'Save changes' },
+  public: { id: 'privacy.public.short', defaultMessage: 'Public' },
+  unlisted: { id: 'privacy.unlisted.short', defaultMessage: 'Unlisted' },
+  private: { id: 'privacy.private.short', defaultMessage: 'Followers-only' },
+  direct: { id: 'privacy.direct.short', defaultMessage: 'Mentioned people only' },
 });
 
 class Publisher extends ImmutablePureComponent {
@@ -68,6 +72,13 @@ class Publisher extends ImmutablePureComponent {
       publishText = privacy !== 'unlisted' ? intl.formatMessage(messages.publishLoud, { publish: intl.formatMessage(messages.publish) }) : intl.formatMessage(messages.publish);
     }
 
+    const privacyNames = {
+      public: messages.public,
+      unlisted: messages.unlisted,
+      private: messages.private,
+      direct: messages.direct,
+    };
+
     return (
       <div className={computedClass}>
         {sideArm && !isEditing && sideArm !== 'none' ? (
@@ -78,7 +89,7 @@ class Publisher extends ImmutablePureComponent {
               onClick={onSecondarySubmit}
               style={{ padding: null }}
               text={<Icon id={privacyIcons[sideArm]} />}
-              title={`${intl.formatMessage(messages.publish)}: ${intl.formatMessage({ id: `privacy.${sideArm}.short` })}`}
+              title={`${intl.formatMessage(messages.publish)}: ${intl.formatMessage(privacyNames[sideArm])}`}
             />
           </div>
         ) : null}
@@ -86,7 +97,7 @@ class Publisher extends ImmutablePureComponent {
           <Button
             className='primary'
             text={publishText}
-            title={`${intl.formatMessage(messages.publish)}: ${intl.formatMessage({ id: `privacy.${privacy}.short` })}`}
+            title={`${intl.formatMessage(messages.publish)}: ${intl.formatMessage(privacyNames[privacy])}`}
             onClick={this.handleSubmit}
             disabled={disabled}
           />

--- a/app/javascript/flavours/glitch/features/local_settings/page/index.jsx
+++ b/app/javascript/flavours/glitch/features/local_settings/page/index.jsx
@@ -29,6 +29,10 @@ const messages = defineMessages({
   rewrite_mentions_username: { id: 'settings.rewrite_mentions_username', defaultMessage:  'Rewrite with username' },
   pop_in_left: { id: 'settings.pop_in_left', defaultMessage: 'Left' },
   pop_in_right: { id: 'settings.pop_in_right', defaultMessage:  'Right' },
+  public: { id: 'privacy.public.short', defaultMessage: 'Public' },
+  unlisted: { id: 'privacy.unlisted.short', defaultMessage: 'Unlisted' },
+  private: { id: 'privacy.private.short', defaultMessage: 'Followers-only' },
+  direct: { id: 'privacy.direct.short', defaultMessage: 'Mentioned people only' },
 });
 
 class LocalSettingsPage extends React.PureComponent {
@@ -241,10 +245,10 @@ class LocalSettingsPage extends React.PureComponent {
           id='mastodon-settings--side_arm'
           options={[
             { value: 'none', message: intl.formatMessage(messages.side_arm_none) },
-            { value: 'direct', message: intl.formatMessage({ id: 'privacy.direct.short' }) },
-            { value: 'private', message: intl.formatMessage({ id: 'privacy.private.short' }) },
-            { value: 'unlisted', message: intl.formatMessage({ id: 'privacy.unlisted.short' }) },
-            { value: 'public', message: intl.formatMessage({ id: 'privacy.public.short' }) },
+            { value: 'direct', message: intl.formatMessage(messages.direct) },
+            { value: 'private', message: intl.formatMessage(messages.private) },
+            { value: 'unlisted', message: intl.formatMessage(messages.unlisted) },
+            { value: 'public', message: intl.formatMessage(messages.public) },
           ]}
           onChange={onChange}
         >

--- a/app/javascript/flavours/glitch/features/ui/components/column_link.jsx
+++ b/app/javascript/flavours/glitch/features/ui/components/column_link.jsx
@@ -32,6 +32,7 @@ const ColumnLink = ({ icon, text, to, onClick, href, method, badge, transparent,
       return onClick(e);
     };
     return (
+      // eslint-disable-next-line jsx-a11y/anchor-is-valid -- intentional to have the same look and feel as other menu items
       <a href='#' onClick={onClick && handleOnClick} className={className} title={text} {...other} tabIndex={0}>
         {iconElement}
         <span>{text}</span>


### PR DESCRIPTION
The remaining issues are:
- `JSX props should not use arrow functions` in `app/javascript/flavours/glitch/components/avatar_composite.jsx` and `app/javascript/flavours/glitch/components/display_name.jsx`: this is somewhat involved to fix, but iirc upstream has recently rewritten these in functional react components in Typescript, so it might not be worth fixing that before porting the changes
- `jsx-a11y/anchor-is-valid` in `app/javascript/flavours/glitch/components/error_boundary.jsx`: it might be worth rewriting the error boundary, and evaluate whether upstream's is good enough for us
- `jsx-a11y/anchor-is-valid` in `app/javascript/flavours/glitch/features/local_settings/navigation/item/index.jsx`: long term, this should probably be rewritten to be more accessible, but I don't know what the proper short-term fix should be
- `import/named` in `app/javascript/flavours/glitch/features/ui/index.jsx`: that's the onboarding being broken from an upstream merge ages ago… do we want to switch to upstream's onboarding?