### PR TITLE
[Glitch] Update style of captcha confirmation page to match sign-up form

### DIFF
--- a/app/javascript/flavours/glitch/styles/forms.scss
+++ b/app/javascript/flavours/glitch/styles/forms.scss
@@ -137,6 +137,10 @@ code {
     line-height: 22px;
     color: $secondary-text-color;
     margin-bottom: 30px;
+
+    a {
+      color: $highlight-text-color;
+    }
   }
 
   .rules-list {

--- a/app/views/auth/confirmations/captcha.html.haml
+++ b/app/views/auth/confirmations/captcha.html.haml
@@ -2,10 +2,11 @@
   = t('auth.captcha_confirmation.title')
 
 = form_tag auth_captcha_confirmation_url, method: 'POST', class: 'simple_form' do
+  = render 'auth/shared/progress', stage: 'confirm'
+
   = hidden_field_tag :confirmation_token, params[:confirmation_token]
 
-  .field-group
-    %p.hint= t('auth.captcha_confirmation.hint_html')
+  %p.lead= t('auth.captcha_confirmation.hint_html')
 
   .field-group
     = render_captcha


### PR DESCRIPTION
We merged glitch-soc's hCaptcha feature into upstream but with a few changes.

This ports some of them back to glitch-soc.