### PR TITLE
Change captcha to be presented even for invited users

### DIFF
--- a/app/controllers/auth/confirmations_controller.rb
+++ b/app/controllers/auth/confirmations_controller.rb
@@ -57,9 +57,6 @@ class Auth::ConfirmationsController < Devise::ConfirmationsController
 
   def captcha_user_bypass?
     return true if @confirmation_user.nil? || @confirmation_user.confirmed?
-
-    invite = Invite.find(@confirmation_user.invite_id) if @confirmation_user.invite_id.present?
-    invite.present? && !invite.max_uses.nil?
   end
 
   def set_pack

--- a/config/locales-glitch/en.yml
+++ b/config/locales-glitch/en.yml
@@ -6,7 +6,7 @@ en:
       batch_error: 'An error occurred: %{message}'
     settings:
       captcha_enabled:
-        desc_html: This relies on external scripts from hCaptcha, which may be a security and privacy concern. In addition, <strong>this can make the registration process significantly less accessible to some (especially disabled) people</strong>. For these reasons, please consider alternative measures such as approval-based or invite-based registration.<br>Users that have been invited through a limited-use invite will not need to solve a CAPTCHA
+        desc_html: This relies on external scripts from hCaptcha, which may be a security and privacy concern. In addition, <strong>this can make the registration process significantly less accessible to some (especially disabled) people</strong>. For these reasons, please consider alternative measures such as approval-based or invite-based registration.
         title: Require new users to solve a CAPTCHA to confirm their account
       flavour_and_skin:
         title: Flavour and skin


### PR DESCRIPTION
We merged glitch-soc's hCaptcha feature into upstream but with a few changes.

This ports some of them back to glitch-soc.