### PR TITLE
Add restrictions for user created invites

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -273,6 +273,8 @@ MAX_POLL_OPTION_CHARS=100
 # MAX_ACTIVE_INVITES=5
 # Maximum amount of invites created in the past 24h
 # MAX_DAILY_INVITES=20
+# Minimun amount of days an account has to exist before being able to create invites
+# MIN_DAYS_BEFORE_INVITE=7
 
 # Maximum image and video/audio upload sizes
 # Units are in bytes

--- a/.env.production.sample
+++ b/.env.production.sample
@@ -269,6 +269,11 @@ MAX_POLL_OPTIONS=5
 # Maximum allowed poll option characters
 MAX_POLL_OPTION_CHARS=100
 
+# Maximum amount of active invites
+# MAX_ACTIVE_INVITES=5
+# Maximum amount of invites created in the past 24h
+# MAX_DAILY_INVITES=20
+
 # Maximum image and video/audio upload sizes
 # Units are in bytes
 # 1048576 bytes equals 1 megabyte

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -23,6 +23,8 @@ class InvitesController < ApplicationController
     @invite      = Invite.new(resource_params)
     @invite.user = current_user
 
+    @invite.max_uses = 1 unless policy(:invite).unrestricted?
+
     if @invite.save
       redirect_to invites_path
     else

--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -25,6 +25,7 @@ class Invite < ApplicationRecord
   scope :available, -> { where(expires_at: nil).or(where('expires_at >= ?', Time.now.utc)) }
 
   validates :comment, length: { maximum: 420 }
+  validates_with InviteValidator
 
   before_validation :set_code
 

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -36,6 +36,7 @@ class UserRole < ApplicationRecord
     manage_roles: (1 << 17),
     manage_user_access: (1 << 18),
     delete_user_data: (1 << 19),
+    bypass_invite_limits: (1 << 50),
   }.freeze
 
   module Flags
@@ -47,6 +48,7 @@ class UserRole < ApplicationRecord
     CATEGORIES = {
       invites: %i(
         invite_users
+        bypass_invite_limits
       ).freeze,
 
       moderation: %w(
@@ -187,6 +189,6 @@ class UserRole < ApplicationRecord
   end
 
   def validate_dangerous_permissions
-    errors.add(:permissions_as_keys, :dangerous) if everyone? && Flags::DEFAULT & permissions != permissions
+    errors.add(:permissions_as_keys, :dangerous) if everyone? && (Flags::DEFAULT | FLAGS[:bypass_invite_limits]) & permissions != permissions
   end
 end

--- a/app/policies/invite_policy.rb
+++ b/app/policies/invite_policy.rb
@@ -9,6 +9,10 @@ class InvitePolicy < ApplicationPolicy
     role.can?(:invite_users)
   end
 
+  def unrestricted?
+    role.can?(:bypass_invite_limits)
+  end
+
   def deactivate_all?
     role.can?(:manage_invites)
   end

--- a/app/policies/invite_policy.rb
+++ b/app/policies/invite_policy.rb
@@ -6,7 +6,7 @@ class InvitePolicy < ApplicationPolicy
   end
 
   def create?
-    role.can?(:invite_users)
+    role.can?(:invite_users) && (current_user.created_at <= InviteValidator::MIN_ACCOUNT_AGE.ago || unrestricted?)
   end
 
   def unrestricted?

--- a/app/validators/invite_validator.rb
+++ b/app/validators/invite_validator.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class InviteValidator < ActiveModel::Validator
+  LIMIT = (ENV['MAX_ACTIVE_INVITES'] || 5).to_i
+  DAILY_LIMIT = (ENV['MAX_DAILY_INVITES'] || 20).to_i
+
+  def validate(invite)
+    return if invite.user.can?(:bypass_invite_limits)
+
+    invite.errors.add(:base, I18n.t('invites.errors.limit_reached')) if limit_reached?(invite)
+    invite.errors.add(:base, I18n.t('invites.errors.daily_limit_reached')) if daily_limit_reached?(invite)
+  end
+
+  private
+
+  def limit_reached?(invite)
+    invite.user.invites.available.count >= LIMIT
+  end
+
+  def daily_limit_reached?(invite)
+    invite.user.invites.where('created_at >= ?', (Time.now.utc - 24.hours)).count >= DAILY_LIMIT
+  end
+end

--- a/app/validators/invite_validator.rb
+++ b/app/validators/invite_validator.rb
@@ -19,6 +19,6 @@ class InviteValidator < ActiveModel::Validator
   end
 
   def daily_limit_reached?(invite)
-    invite.user.invites.where('created_at >= ?', (Time.now.utc - 24.hours)).count >= DAILY_LIMIT
+    invite.user.invites.where(created_at: 1.day.ago...).count >= DAILY_LIMIT
   end
 end

--- a/app/validators/invite_validator.rb
+++ b/app/validators/invite_validator.rb
@@ -3,6 +3,7 @@
 class InviteValidator < ActiveModel::Validator
   LIMIT = (ENV['MAX_ACTIVE_INVITES'] || 5).to_i
   DAILY_LIMIT = (ENV['MAX_DAILY_INVITES'] || 20).to_i
+  MIN_ACCOUNT_AGE = (ENV['MIN_DAYS_BEFORE_INVITE'] || 7).to_i.days
 
   def validate(invite)
     return if invite.user.can?(:bypass_invite_limits)

--- a/app/views/invites/_form.html.haml
+++ b/app/views/invites/_form.html.haml
@@ -2,8 +2,9 @@
   = render 'shared/error_messages', object: @invite
 
   .fields-row
-    .fields-row__column.fields-row__column-6.fields-group
-      = f.input :max_uses, wrapper: :with_label, collection: [1, 5, 10, 25, 50, 100], label_method: ->(num) { I18n.t('invites.max_uses', count: num) }, prompt: I18n.t('invites.max_uses_prompt')
+    - if policy(:invite).unrestricted?
+      .fields-row__column.fields-row__column-6.fields-group
+        = f.input :max_uses, wrapper: :with_label, collection: [1, 5, 10, 25, 50, 100], label_method: ->(num) { I18n.t('invites.max_uses', count: num) }, prompt: I18n.t('invites.max_uses_prompt')
     .fields-row__column.fields-row__column-6.fields-group
       = f.input :expires_in, wrapper: :with_label, collection: [30.minutes, 1.hour, 6.hours, 12.hours, 1.day, 1.week].map(&:to_i), label_method: ->(i) { I18n.t("invites.expires_in.#{i}") }, prompt: I18n.t('invites.expires_in_prompt')
 

--- a/config/locales-glitch/en.yml
+++ b/config/locales-glitch/en.yml
@@ -42,5 +42,9 @@ en:
       title: User verification
   generic:
     use_this: Use this
+  invites:
+    errors:
+      daily_limit_reached: Daily limit of created invites reached
+      limit_reached: Maximum amount of active invites reached
   settings:
     flavours: Flavours

--- a/config/locales-glitch/en.yml
+++ b/config/locales-glitch/en.yml
@@ -4,6 +4,10 @@ en:
     custom_emojis:
       batch_copy_error: 'An error occurred when copying some of the selected emoji: %{message}'
       batch_error: 'An error occurred: %{message}'
+    roles:
+      privileges:
+        bypass_invite_limits: Bypass invite limits
+        bypass_invite_limits_description: Allows users to create unlimited amounts of invites with adjustable uses (vanilla behaviour)
     settings:
       captcha_enabled:
         desc_html: This relies on external scripts from hCaptcha, which may be a security and privacy concern. In addition, <strong>this can make the registration process significantly less accessible to some (especially disabled) people</strong>. For these reasons, please consider alternative measures such as approval-based or invite-based registration.

--- a/config/roles.yml
+++ b/config/roles.yml
@@ -7,6 +7,7 @@ moderator:
     - manage_users
     - manage_reports
     - manage_taxonomies
+    - bypass_invite_limits
 admin:
   name: Admin
   position: 100
@@ -28,6 +29,7 @@ admin:
     - manage_custom_emojis
     - manage_webhooks
     - manage_roles
+    - bypass_invite_limits
 owner:
   name: Owner
   position: 1000

--- a/db/post_migrate/20230522141920_glitch_add_bypass_invite_limits_permission.rb
+++ b/db/post_migrate/20230522141920_glitch_add_bypass_invite_limits_permission.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class GlitchAddBypassInviteLimitsPermission < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  class UserRole < ApplicationRecord; end
+
+  def change
+    admin_role     = UserRole.find_by(name: 'Admin')
+    moderator_role = UserRole.find_by(name: 'Moderator')
+
+    if admin_role
+      admin_role.permissions |= ::UserRole::FLAGS[:bypass_invite_limits]
+      admin_role.save
+    end
+
+    return unless moderator_role
+
+    moderator_role.permissions |= ::UserRole::FLAGS[:bypass_invite_limits]
+    moderator_role.save
+  end
+end

--- a/db/post_migrate/20230522141920_glitch_add_bypass_invite_limits_permission.rb
+++ b/db/post_migrate/20230522141920_glitch_add_bypass_invite_limits_permission.rb
@@ -3,20 +3,24 @@
 class GlitchAddBypassInviteLimitsPermission < ActiveRecord::Migration[6.1]
   disable_ddl_transaction!
 
-  class UserRole < ApplicationRecord; end
+  class UserRole < ApplicationRecord
+    FLAGS = {
+      bypass_invite_limits: (1 << 50),
+    }.freeze
+  end
 
   def change
     admin_role     = UserRole.find_by(name: 'Admin')
     moderator_role = UserRole.find_by(name: 'Moderator')
 
     if admin_role
-      admin_role.permissions |= ::UserRole::FLAGS[:bypass_invite_limits]
+      admin_role.permissions |= UserRole::FLAGS[:bypass_invite_limits]
       admin_role.save
     end
 
     return unless moderator_role
 
-    moderator_role.permissions |= ::UserRole::FLAGS[:bypass_invite_limits]
+    moderator_role.permissions |= UserRole::FLAGS[:bypass_invite_limits]
     moderator_role.save
   end
 end

--- a/spec/controllers/invites_controller_spec.rb
+++ b/spec/controllers/invites_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 describe InvitesController do
   render_views
 
-  let(:user) { Fabricate(:user) }
+  let(:user) { Fabricate(:user, created_at: 7.days.ago) }
 
   before do
     sign_in user

--- a/spec/controllers/invites_controller_spec.rb
+++ b/spec/controllers/invites_controller_spec.rb
@@ -54,7 +54,19 @@ describe InvitesController do
       it 'succeeds to create a invite' do
         expect { subject }.to change(Invite, :count).by(1)
         expect(subject).to redirect_to invites_path
-        expect(Invite.last).to have_attributes(user_id: user.id, max_uses: 10)
+        expect(Invite.last).to have_attributes(user_id: user.id, max_uses: 1)
+      end
+
+      context 'without restrictions' do
+        before do
+          UserRole.everyone.update(permissions: UserRole.everyone.permissions | UserRole::FLAGS[:invite_users] | UserRole::FLAGS[:bypass_invite_limits])
+        end
+
+        it 'succeeds to create an invite' do
+          expect { subject }.to change(Invite, :count).by(1)
+          expect(subject).to redirect_to invites_path
+          expect(Invite.last).to have_attributes(user_id: user.id, max_uses: 10)
+        end
       end
     end
 

--- a/spec/policies/invite_policy_spec.rb
+++ b/spec/policies/invite_policy_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe InvitePolicy do
   subject { described_class }
 
   let(:admin)   { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
-  let(:john)    { Fabricate(:user).account }
+  let(:john)    { Fabricate(:user, created_at: 7.days.ago).account }
 
   permissions :index? do
     context 'when staff?' do

--- a/spec/policies/invite_policy_spec.rb
+++ b/spec/policies/invite_policy_spec.rb
@@ -39,6 +39,24 @@ RSpec.describe InvitePolicy do
     end
   end
 
+  permissions :unrestricted? do
+    context 'without permission' do
+      it 'denies' do
+        expect(subject).to_not permit(john, Invite)
+      end
+    end
+
+    context 'with permission' do
+      before do
+        UserRole.everyone.update(permissions: UserRole::FLAGS[:bypass_invite_limits])
+      end
+
+      it 'permits' do
+        expect(subject).to permit(john, Invite)
+      end
+    end
+  end
+
   permissions :deactivate_all? do
     context 'when admin?' do
       it 'permits' do

--- a/spec/validators/invite_validator_spec.rb
+++ b/spec/validators/invite_validator_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe InviteValidator do
+  let(:user) { Fabricate(:user, created_at: 7.days.ago) }
+  let(:invite) { instance_double(Invite, user: user, errors: errors) }
+  let(:errors) { instance_double(ActiveModel::Errors, add: nil) }
+
+  describe '#validate' do
+    it 'does not add error' do
+      subject.validate(invite)
+      expect(errors).to_not have_received(:add)
+    end
+
+    context 'when active invites limit is reached' do
+      before do
+        5.times do
+          Fabricate(:invite, user: user)
+        end
+      end
+
+      it 'adds error' do
+        subject.validate(invite)
+        expect(errors).to have_received(:add)
+      end
+
+      context 'when user can bypass limits' do
+        let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Moderator')) }
+
+        it 'does not add error' do
+          subject.validate(invite)
+          expect(errors).to_not have_received(:add)
+        end
+      end
+    end
+
+    context 'when daily limit is reached' do
+      before do
+        20.times do
+          Fabricate(:invite, user: user, expires_at: 10.minutes.ago.utc)
+        end
+      end
+
+      it 'adds error' do
+        subject.validate(invite)
+        expect(errors).to have_received(:add)
+      end
+
+      context 'when user can bypass limits' do
+        let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Moderator')) }
+
+        it 'does not add error' do
+          subject.validate(invite)
+          expect(errors).to_not have_received(:add)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
:warning: This adds a post deployment migration

Currently, the only way to prevent the invite feature from being abused is to prevent users from creating them entirely.
This adds a middle ground which would allow users to create invites, but with restrictions:
1\. An account has to be at least one week old to be able to create invites.
2\. A user can only have 5 non-expired invites at a time.
3\. A user can only create 20 invites in the past 24h.
4\. User created invites are limited to single use.

These limits can be bypassed by granting the `bypass_invite_limits` permission, which is given to the moderator and admin role by default.

The following env vars have been added:
`MAX_ACTIVE_INVITES` - The amount of active invites a user can create
`MAX_DAILY_INVITES` - The amount of total invites a user can create in 24h

Some considerations:
For large instances, this could significantly increase the amount of created invites. How much of an issue this is in practice, I can't say.
For instances with approval only registrations, afaik the approval date is not saved, so should the approval take longer than a week, the account could be able to create invites right away.