### PR TITLE
Re-allow title attribute in <abbr>

### DIFF
--- a/lib/sanitize_ext/sanitize_config.rb
+++ b/lib/sanitize_ext/sanitize_config.rb
@@ -74,6 +74,7 @@ class Sanitize
 
       attributes: {
         'a' => %w(href rel class title),
+        'abbr' => %w(title),
         'span' => %w(class),
         'blockquote' => %w(cite),
         'ol' => %w(start reversed),

--- a/spec/lib/sanitize_config_spec.rb
+++ b/spec/lib/sanitize_config_spec.rb
@@ -43,6 +43,10 @@ describe Sanitize::Config do
     it 'keeps a with supported scheme and no host' do
       expect(Sanitize.fragment('<a href="dweb:/a/foo">Test</a>', subject)).to eq '<a href="dweb:/a/foo" rel="nofollow noopener noreferrer" target="_blank">Test</a>'
     end
+
+    it 'keeps title in abbr' do
+      expect(Sanitize.fragment('<abbr title="HyperText Markup Language">HTML</abbr>', subject)).to eq '<abbr title="HyperText Markup Language">HTML</abbr>'
+    end
   end
 
   describe '::MASTODON_OUTGOING' do


### PR DESCRIPTION
Fixes #2248 
This was accidentally removed in 7623e181247b4d2227b7774143514f6e1ca9253b