### PR TITLE
Fix an issue with a missing argument to resolve_pack

### DIFF
--- a/app/controllers/concerns/theming_concern.rb
+++ b/app/controllers/concerns/theming_concern.rb
@@ -75,7 +75,7 @@ module ThemingConcern
     end
 
     fallbacks.each do |fallback|
-      return resolve_pack(Themes.instance.flavour(fallback), pack_name) if Themes.instance.flavour(fallback)
+      return resolve_pack(Themes.instance.flavour(fallback), pack_name, skin) if Themes.instance.flavour(fallback)
     end
 
     nil


### PR DESCRIPTION
I was getting an error and noticed that this argument was missing. I get an error about it when I try to load a theme that has the `inherit` setting. This seems to fix it.