### PR TITLE
Fix notifications not loading when slow mode active

### DIFF
--- a/app/javascript/flavours/glitch/reducers/notifications.js
+++ b/app/javascript/flavours/glitch/reducers/notifications.js
@@ -313,7 +313,7 @@ export default function notifications(state = initialState, action) {
   case NOTIFICATIONS_EXPAND_FAIL:
     return state.update('isLoading', (nbLoading) => nbLoading - 1);
   case NOTIFICATIONS_FILTER_SET:
-    return state.set('items', ImmutableList()).set('hasMore', true);
+    return state.set('items', ImmutableList()).set('pendingItems', ImmutableList()).set('hasMore', true);
   case NOTIFICATIONS_SCROLL_TOP:
     return updateTop(state, action.top);
   case NOTIFICATIONS_UPDATE:


### PR DESCRIPTION
Fixes #2288

When slow mode is enabled, clicking a notification filter when a new notification was received will render an empty column.

This change has been missed in e91bf82083ac390a0cf229d8e94fa412fdec57ff