### PR TITLE
Add eslint rule to forbid vanilla imports in glitch

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -261,6 +261,18 @@ module.exports = {
       },
     ],
 
+    // Forbid imports from vanilla in glitch flavour
+    'import/no-restricted-paths': [
+      'error',
+      {
+        zones: [{
+          target: 'app/javascript/flavours/glitch/',
+          from: 'app/javascript/mastodon/',
+          message: 'Import from /flavours/glitch/ instead'
+        }]
+      }
+    ],
+
     'promise/always-return': 'off',
     'promise/catch-or-return': [
       'error',


### PR DESCRIPTION
Closes #2290

~This needs more testing.~
It successfully detects when trying to import vanilla components in glitch either with `../../component` or `mastodon/component` in both ts(x) and js(x) files.

Exceptions don't seem to be needed as no file in `/flavours/glitch` imports or is afaik expected to import from `mastodon/locales` (except `load_locales.ts` but it doesn't cause a violation) and imports from `mastodon/../images` don't violate this rule as the images directory is not in the mastodon directory.

An exception for imports from `mastodon/locales` would also make it possible to accidentally import `IntlProvider` from mastodon.