### PR TITLE
Reduce dropdown menu margin and padding

### DIFF
--- a/app/javascript/flavours/glitch/styles/components/misc.scss
+++ b/app/javascript/flavours/glitch/styles/components/misc.scss
@@ -537,14 +537,14 @@ body > [data-popper-placement] {
 
 .dropdown-menu__separator {
   border-bottom: 1px solid var(--dropdown-border-color);
-  margin: 5px 0;
+  margin: 4px 0;
   height: 0;
 }
 
 .dropdown-menu {
   background: var(--dropdown-background-color);
   border: 1px solid var(--dropdown-border-color);
-  padding: 4px;
+  padding: 2px;
   border-radius: 4px;
   box-shadow: var(--dropdown-shadow);
   z-index: 9999;
@@ -568,8 +568,8 @@ body > [data-popper-placement] {
   &__container {
     &__header {
       border-bottom: 1px solid var(--dropdown-border-color);
-      padding: 10px 14px;
-      padding-bottom: 14px;
+      padding: 6px 12px;
+      padding-bottom: 12px;
       margin-bottom: 4px;
       font-size: 13px;
       line-height: 18px;
@@ -609,7 +609,7 @@ body > [data-popper-placement] {
     font: inherit;
     display: block;
     width: 100%;
-    padding: 10px 14px;
+    padding: 6px 12px;
     border: 0;
     margin: 0;
     background: transparent;

--- a/app/javascript/flavours/glitch/styles/components/misc.scss
+++ b/app/javascript/flavours/glitch/styles/components/misc.scss
@@ -537,7 +537,7 @@ body > [data-popper-placement] {
 
 .dropdown-menu__separator {
   border-bottom: 1px solid var(--dropdown-border-color);
-  margin: 4px 0;
+  margin: 2px 0;
   height: 0;
 }
 

--- a/app/javascript/flavours/glitch/styles/components/misc.scss
+++ b/app/javascript/flavours/glitch/styles/components/misc.scss
@@ -568,7 +568,7 @@ body > [data-popper-placement] {
   &__container {
     &__header {
       border-bottom: 1px solid var(--dropdown-border-color);
-      padding: 6px 12px;
+      padding: 6px 14px;
       padding-bottom: 12px;
       margin-bottom: 4px;
       font-size: 13px;
@@ -609,7 +609,7 @@ body > [data-popper-placement] {
     font: inherit;
     display: block;
     width: 100%;
-    padding: 6px 12px;
+    padding: 6px 14px;
     border: 0;
     margin: 0;
     background: transparent;


### PR DESCRIPTION
Upstream's new dropdown menu style is more consistent with the rest of the interface, but it also has big margins/padding (which glitch-soc already cuts down on in places), leading dropdown menus to less often fit in a typical screen.

This PR reduces margins in an attempt to fix that.

## Before

![image](https://github.com/glitch-soc/mastodon/assets/384364/8cb49b8e-6458-4ad7-a767-5a97c8b3786d)

## After

![image](https://github.com/glitch-soc/mastodon/assets/384364/03723f1c-7568-40ff-983b-91f3b98420f7)