### PR TITLE
[Glitch] Update client-side media resizing resolution to 3840x2160 to match model

### DIFF
--- a/app/javascript/flavours/glitch/utils/resize_image.js
+++ b/app/javascript/flavours/glitch/utils/resize_image.js
@@ -1,6 +1,6 @@
 import EXIF from 'exif-js';
 
-const MAX_IMAGE_PIXELS = 2073600; // 1920x1080px
+const MAX_IMAGE_PIXELS = 8294400; // 3840x2160px
 
 const _browser_quirks = {};
 


### PR DESCRIPTION
Both mainline mastodon and the backend of glitch have increased the image size limit to 3840x2160.

Client-side resizing has been overlooked, causing images uploaded via the glitch flavour to be resized, when uploading via the vanilla flavour wouldn't resize the same images.