### PR TITLE
Fix “Open in advanced web interface” being shown on mobile view

### DIFF
--- a/app/javascript/flavours/glitch/features/ui/components/navigation_panel.jsx
+++ b/app/javascript/flavours/glitch/features/ui/components/navigation_panel.jsx
@@ -55,12 +55,12 @@ class NavigationPanel extends Component {
     return (
       <div className='navigation-panel'>
         {transientSingleColumn && (
-          <>
+          <div className='navigation-panel__logo'>
             <a href={`/deck${location.pathname}`} className='button button--block'>
               {intl.formatMessage(messages.advancedInterface)}
             </a>
             <hr />
-          </>
+          </div>
         )}
 
         {signedIn && (


### PR DESCRIPTION
Fixes #2307