### PR TITLE
Fix relationship-tag background color

### DIFF
--- a/app/javascript/flavours/glitch/styles/components/accounts.scss
+++ b/app/javascript/flavours/glitch/styles/components/accounts.scss
@@ -319,7 +319,7 @@
   color: $white;
   margin-bottom: 4px;
   display: block;
-  background-color: $base-overlay-background;
+  background-color: rgba($black, 0.45);
   text-transform: uppercase;
   font-size: 11px;
   font-weight: 500;


### PR DESCRIPTION
This PR fixes relationship-tag on light theme
![image](https://github.com/glitch-soc/mastodon/assets/5047683/810a08ce-6b0d-48f5-91a4-4f9033104418)
