### PR TITLE
Fix CW icon being on wrong side in app settings in RTL languages

### DIFF
--- a/app/javascript/flavours/glitch/styles/components/local_settings.scss
+++ b/app/javascript/flavours/glitch/styles/components/local_settings.scss
@@ -70,6 +70,7 @@
   .text-icon-button {
     color: inherit;
     transition: unset;
+    unicode-bidi: embed;
   }
 
   &:hover {


### PR DESCRIPTION
As per https://github.com/glitch-soc/mastodon/pull/2320#issuecomment-1646849555

Before:
![App settings showing CW icon being left of text](https://github.com/glitch-soc/mastodon/assets/29483052/0dd87c06-dca7-4dae-85fb-17c726ce12d2)

After:
![App settings showing CW being right of text](https://github.com/glitch-soc/mastodon/assets/29483052/755ef9b7-fe1f-42ae-a444-b8a71296f2d6)
