### PR TITLE
Apply padding to all notifications in notif-cleaning mode

### DIFF
--- a/app/javascript/flavours/glitch/styles/components/status.scss
+++ b/app/javascript/flavours/glitch/styles/components/status.scss
@@ -175,9 +175,7 @@
 
 .notif-cleaning {
   .status,
-  .notification-follow,
-  .notification-follow-request,
-  .notification-admin-sign-up {
+  .notification {
     padding-inline-end: ($dismiss-overlay-width + 0.5rem);
   }
 }

--- a/app/javascript/flavours/glitch/styles/components/status.scss
+++ b/app/javascript/flavours/glitch/styles/components/status.scss
@@ -176,7 +176,8 @@
 .notif-cleaning {
   .status,
   .notification-follow,
-  .notification-follow-request {
+  .notification-follow-request,
+  .notification-admin-sign-up {
     padding-inline-end: ($dismiss-overlay-width + 0.5rem);
   }
 }


### PR DESCRIPTION
(Actually not an RTL issue)

~Admin sign up notifications are missing the padding in notif-cleaning mode, which isn't too noticeable, unless the display name is very long or using an RTL language.~
Some notifications were missing the padding for the checkbox in notification cleaning mode, which wasn't too noticable with some notifications, unless the display name is very long or using an RTL language.
This adds the missing padding.

Before:
![Sign up notification overflowing](https://github.com/glitch-soc/mastodon/assets/29483052/6e61f75a-2980-4521-98b3-366fb781c7aa)
![Report notification overflowing](https://github.com/glitch-soc/mastodon/assets/29483052/8ef1a2a0-01fb-4aa4-96a9-e19d7d30a30f)


After:
![Padding applied to sign-up notifications](https://github.com/glitch-soc/mastodon/assets/29483052/378aa036-95c6-4f50-905a-24508f0453d1)
![Padding applied to report notification](https://github.com/glitch-soc/mastodon/assets/29483052/c4bbd366-442d-4827-8721-883cf1e10ea5)


(The wrong text alignment is an upstream issue if I remember correctly)