### PR TITLE
Fix "All" live feed not loading automatically

### DIFF
--- a/app/javascript/flavours/glitch/features/firehose/index.jsx
+++ b/app/javascript/flavours/glitch/features/firehose/index.jsx
@@ -129,7 +129,7 @@ const Firehose = ({ feedType, multiColumn }) => {
       }
       break;
     case 'public':
-      dispatch(expandPublicTimeline({ onlyMedia }));
+      dispatch(expandPublicTimeline({ onlyMedia, allowLocalOnly }));
       if (signedIn) {
         disconnect = dispatch(connectPublicStream({ onlyMedia, allowLocalOnly }));
       }


### PR DESCRIPTION
Fixes #2273 

The dispatch to expand the timeline was missing the `allowLocalOnly` param.