### PR TITLE
Combine hashtag utils

### DIFF
--- a/app/javascript/flavours/glitch/actions/compose.js
+++ b/app/javascript/flavours/glitch/actions/compose.js
@@ -6,7 +6,7 @@ import { throttle } from 'lodash';
 import api from 'flavours/glitch/api';
 import { search as emojiSearch } from 'flavours/glitch/features/emoji/emoji_mart_search_light';
 import { tagHistory } from 'flavours/glitch/settings';
-import { recoverHashtags } from 'flavours/glitch/utils/hashtag';
+import { recoverHashtags } from 'flavours/glitch/utils/hashtags';
 import resizeImage from 'flavours/glitch/utils/resize_image';
 
 import { showAlert, showAlertForError } from './alerts';

--- a/app/javascript/flavours/glitch/reducers/compose.js
+++ b/app/javascript/flavours/glitch/reducers/compose.js
@@ -56,7 +56,7 @@ import { REDRAFT } from '../actions/statuses';
 import { STORE_HYDRATE } from '../actions/store';
 import { TIMELINE_DELETE } from '../actions/timelines';
 import { me, defaultContentType } from '../initial_state';
-import { recoverHashtags } from '../utils/hashtag';
+import { recoverHashtags } from '../utils/hashtags';
 import { unescapeHTML } from '../utils/html';
 import { overwrite } from '../utils/js_helpers';
 import { privacyPreference } from '../utils/privacy_preference';

--- a/app/javascript/flavours/glitch/utils/hashtag.js
+++ b/app/javascript/flavours/glitch/utils/hashtag.js
@@ -1,8 +1,0 @@
-export function recoverHashtags (recognizedTags, text) {
-  return recognizedTags.map(tag => {
-    const re = new RegExp(`(?:^|[^/)\\w])#(${tag.name})`, 'i');
-    const matched_hashtag = text.match(re);
-    return matched_hashtag ? matched_hashtag[1] : null;
-  },
-  ).filter(x => x !== null);
-}

--- a/app/javascript/flavours/glitch/utils/hashtags.ts
+++ b/app/javascript/flavours/glitch/utils/hashtags.ts
@@ -27,3 +27,22 @@ const buildHashtagRegex = () => {
 export const HASHTAG_PATTERN_REGEX = buildHashtagPatternRegex();
 
 export const HASHTAG_REGEX = buildHashtagRegex();
+
+/**
+ * Searches for recognizedTags.name in text and replaces it to match casing
+ * @param recognizedTags - hashtags in toot
+ * @param text - text of toot
+ * @returns recognizedTags with changed casing
+ */
+export const recoverHashtags = (
+  recognizedTags: { name: string; url: string }[],
+  text: string,
+) => {
+  return recognizedTags
+    .map((tag) => {
+      const re = new RegExp(`(?:^|[^/)\\w])#(${tag.name})`, 'i');
+      const matched_hashtag = text.match(re);
+      return matched_hashtag ? matched_hashtag[1] : null;
+    })
+    .filter((x) => x !== null);
+};


### PR DESCRIPTION
Follow-up to #2333

Move `recoverHashtags` from `hashtag.js` to `hashtags.ts`

Add type annotations.

Change imports of `recoverHashtags`