### PR TITLE
Add focus styling to App settings navigation items

### DIFF
--- a/app/javascript/flavours/glitch/styles/components/local_settings.scss
+++ b/app/javascript/flavours/glitch/styles/components/local_settings.scss
@@ -73,19 +73,28 @@
     unicode-bidi: embed;
   }
 
-  &:hover {
+  &:hover,
+  &:focus {
     background: $ui-secondary-color;
   }
 
   &.active {
     background: $ui-highlight-color;
     color: $primary-text-color;
+
+    &:focus-visible {
+      background: lighten($ui-highlight-color, 4%);
+    }
   }
 
-  &.close,
-  &.close:hover {
+  &.close {
     background: $error-value-color;
     color: $primary-text-color;
+
+    &:hover,
+    &:focus {
+      background: lighten($error-value-color, 8%);
+    }
   }
 }
 


### PR DESCRIPTION
Applies focus styling to local settings navigation, making keyboard navigation easier.

`focus-visible` used for `.active` as to not change background when an item was clicked.
