### PR TITLE
Remove `default_content_type` from settings.yml

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -38,7 +38,6 @@ defaults: &defaults
   peers_api_enabled: true
   show_reblogs_in_public_timelines: false
   show_replies_in_public_timelines: false
-  default_content_type: 'text/plain'
   show_domain_blocks: 'disabled'
   show_domain_blocks_rationale: 'disabled'
   outgoing_spoilers: ''


### PR DESCRIPTION
Alternative to #2361 

This setting has no effect since the refactor of user settings.