### PR TITLE
Fix: Return 0 to AP Request if Hide Followers Count

### DIFF
--- a/app/controllers/follower_accounts_controller.rb
+++ b/app/controllers/follower_accounts_controller.rb
@@ -60,7 +60,7 @@ class FollowerAccountsController < ApplicationController
 
   def collection_presenter
     options = { type: :ordered }
-    options[:size] = @account.followers_count unless Setting.hide_followers_count || @account.user&.setting_hide_followers_count
+    options[:size] = (Setting.hide_followers_count || @account.user&.setting_hide_followers_count) ? 0 : @account.followers_count
     if page_requested?
       ActivityPub::CollectionPresenter.new(
         id: account_followers_url(@account, page: params.fetch(:page, 1)),


### PR DESCRIPTION
We return 0 count to AP Request if the person is hiding his followers count 
Fix: https://github.com/glitch-soc/mastodon/issues/2374