### PR TITLE
Fix onboarding modal crashing when opened

### DIFF
--- a/app/javascript/flavours/glitch/features/ui/components/onboarding_modal.jsx
+++ b/app/javascript/flavours/glitch/features/ui/components/onboarding_modal.jsx
@@ -78,6 +78,7 @@ const PageThree = ({ myAccount }) => (
         onSubmit={noop}
         onClear={noop}
         onShow={noop}
+        recent={{}}
       />
 
       <div className='pseudo-drawer'>


### PR DESCRIPTION
Fixes #2393

The new search popout requires the `recent` prop to be set, otherwise onboarding crashes with "recent is undefined"