### PR TITLE
Fix onboarding modal always opening page 2 in webUI

### DIFF
--- a/app/javascript/flavours/glitch/features/ui/components/onboarding_modal.jsx
+++ b/app/javascript/flavours/glitch/features/ui/components/onboarding_modal.jsx
@@ -233,7 +233,9 @@ class OnboardingModal extends PureComponent {
     }));
   };
 
-  handleSwipe = (index) => {
+  handleSwipe = (index, lastIndex, meta) => {
+    if (meta.reason !== 'swipe') return;
+
     this.setState({ currentIndex: index });
   };
 


### PR DESCRIPTION
When opening the onboarding modal in the webUI, it always opens on page 2, as `handleSwipe` is called on load with 'focus', changing `currentIndex` from 0 to 1.

I uh... thought this was on purpose, but I couldn't find any documentation supporting this.