### PR TITLE
Fix wrong gradient color on collapsed private mentions

### DIFF
--- a/app/javascript/flavours/glitch/styles/components/status.scss
+++ b/app/javascript/flavours/glitch/styles/components/status.scss
@@ -362,8 +362,8 @@
 
     &.status-direct > .status__content::after {
       background: linear-gradient(
-        rgba(lighten($ui-base-color, 8%), 0),
-        rgba(lighten($ui-base-color, 8%), 1)
+        rgba(mix($ui-base-color, $ui-highlight-color, 95%), 0),
+        rgba(mix($ui-base-color, $ui-highlight-color, 95%), 1)
       );
     }
 


### PR DESCRIPTION
Follow-up to #2158 

Upstream changed the background color of private mentions, but the gradient used for collapsed toots still used the old color. (I forgot to update it...)

Before:
![Gradient is too bright](https://github.com/glitch-soc/mastodon/assets/29483052/dacab92c-09ad-43cf-8b34-f2931b2b5d86)

After:
![Gradient to new background color](https://github.com/glitch-soc/mastodon/assets/29483052/6cfc8cd6-d58b-4f10-92f2-33ea517ec2f9)
