### PR TITLE
Fix Version metadata have trailing dot

### DIFF
--- a/lib/mastodon/version.rb
+++ b/lib/mastodon/version.rb
@@ -25,7 +25,7 @@ module Mastodon
     end
 
     def build_metadata
-      ['glitch', ENV.fetch('MASTODON_VERSION_METADATA', nil)].compact.join('.')
+      ['glitch', ENV.fetch('MASTODON_VERSION_METADATA', nil)].compact_blank.join('.')
     end
 
     def to_a


### PR DESCRIPTION
As Dockerfile have these line, `MASTODON_VERSION_METADATA` is not `nil` but `""`
```Dockerfile
ARG MASTODON_VERSION_PRERELEASE=""
ARG MASTODON_VERSION_METADATA=""
```

So, Version string was `4.2.0-beta3+glitch.` instead of `4.2.0-beta3+glitch`
This PR will fix that problem