### PR TITLE
fix Content-Security-Policy when using Azure storage

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -26,7 +26,7 @@ unless Rails.env.development?
   assets_host = Rails.configuration.action_controller.asset_host || "https://#{ENV['WEB_DOMAIN'] || ENV['LOCAL_DOMAIN']}"
   data_hosts = [assets_host]
 
-  if ENV['S3_ENABLED'] == 'true'
+  if ENV['S3_ENABLED'] == 'true' || ENV['AZURE_ENABLED'] == 'true'
     attachments_host = "https://#{ENV['S3_ALIAS_HOST'] || ENV['S3_CLOUDFRONT_HOST'] || ENV['AZURE_ALIAS_HOST'] || ENV['S3_HOSTNAME'] || "s3-#{ENV['S3_REGION'] || 'us-east-1'}.amazonaws.com"}"
     attachments_host = "https://#{Addressable::URI.parse(attachments_host).host}"
   elsif ENV['SWIFT_ENABLED'] == 'true'


### PR DESCRIPTION
while looking through recent changes I saw that there is now first-class support for Azure's blob storage thingy, so I just had to try it out to get rid of that old minio-proxy i had ...  it almost worked fine except for this little thing called CSP :D 

added another check to the `if` statement and now it works like a charm