### PR TITLE
Fix mentions being formatted with Markdown

### DIFF
--- a/app/lib/advanced_text_formatter.rb
+++ b/app/lib/advanced_text_formatter.rb
@@ -98,7 +98,8 @@ class AdvancedTextFormatter < TextFormatter
   private
 
   def format_markdown(html)
-    html = markdown_formatter.render(html)
+    # Force escape usernames in mentions before formatting
+    html = markdown_formatter.render(html.gsub(Account::MENTION_RE) { |re| re.gsub('_', '\\_') })
     html.delete("\r").delete("\n")
   end
 

--- a/spec/lib/advanced_text_formatter_spec.rb
+++ b/spec/lib/advanced_text_formatter_spec.rb
@@ -75,6 +75,15 @@ RSpec.describe AdvancedTextFormatter do
         it 'creates a mention link' do
           expect(subject).to include '<a href="https://cb6e6126.ngrok.io/@alice" class="u-url mention">@<span>alice</span></a></span>'
         end
+
+        context 'when username contains underscores' do
+          let(:preloaded_accounts) { [Fabricate(:account, username: '_bob_')] }
+          let(:text) { '@_bob_' }
+
+          it 'creates a mention link' do
+            expect(subject).to include '<a href="https://cb6e6126.ngrok.io/@_bob_" class="u-url mention">@<span>_bob_</span></a></span>'
+          end
+        end
       end
 
       context 'with text containing unlinkable mentions' do


### PR DESCRIPTION
Fixes #2432 

Not the best solution, but the easiest I could think of not requiring a major refactor.
This will force escape underscores in mentions.