### PR TITLE
Fix Permalink adding router props to links

### DIFF
--- a/app/javascript/flavours/glitch/components/permalink.jsx
+++ b/app/javascript/flavours/glitch/components/permalink.jsx
@@ -1,6 +1,8 @@
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 
+import { omit } from 'lodash';
+
 import { withOptionalRouter, WithOptionalRouterPropTypes } from 'flavours/glitch/utils/react_router';
 
 class Permalink extends PureComponent {
@@ -38,8 +40,11 @@ class Permalink extends PureComponent {
       ...other
     } = this.props;
 
+    // Use lodash omit method to remove router props, as we don't want these to be added to the link
+    const extraAttributes = omit(other, [Object.keys(WithOptionalRouterPropTypes), 'staticContext'].flat());
+
     return (
-      <a target='_blank' href={href} onClick={this.handleClick} {...other} className={`permalink${className ? ' ' + className : ''}`}>
+      <a target='_blank' href={href} onClick={this.handleClick} {...extraAttributes} className={`permalink${className ? ' ' + className : ''}`}>
         {children}
       </a>
     );


### PR DESCRIPTION
Fixes #2459 

Uses lodash omit method to prevent undesired attributes from being added to links.
lodash was chosen, because it is used in other parts of the code and it's the most convenient and cleanest solution I found.
I'm not sure where `staticContext` comes from, but it's not a valid attribute and is always undefined.

Alternatively extra attributes could be added to propTypes as these are only `title` and `dangerouslySetInnerHTML`, but I'm not sure a propType for the latter exists.
