### PR TITLE
Fix recurring "switch to advanced interface" warning by adding missing…

### DIFF
--- a/app/javascript/flavours/glitch/features/ui/components/navigation_panel.jsx
+++ b/app/javascript/flavours/glitch/features/ui/components/navigation_panel.jsx
@@ -65,7 +65,11 @@ class NavigationPanel extends Component {
 
     return (
       <div className='navigation-panel'>
-        {banner}
+        {banner &&
+          <div class='navigation-panel__banner'>
+            {banner}
+          </div>
+        }
 
         {signedIn && (
           <>


### PR DESCRIPTION
…class to the navigation-panel__banner element