### PR TITLE
Change glitch-soc's CSP config to match upstream's closer

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -14,6 +14,17 @@ def host_to_url(str)
   uri.to_s
 end
 
+base_host = Rails.configuration.x.web_domain
+
+assets_host   = Rails.configuration.action_controller.asset_host
+assets_host ||= host_to_url(base_host)
+
+media_host   = host_to_url(ENV['S3_ALIAS_HOST'])
+media_host ||= host_to_url(ENV['S3_CLOUDFRONT_HOST'])
+media_host ||= host_to_url(ENV['AZURE_ALIAS_HOST'])
+media_host ||= host_to_url(ENV['S3_HOSTNAME']) if ENV['S3_ENABLED'] == 'true'
+media_host ||= assets_host
+
 def sso_host
   return unless ENV['ONE_CLICK_SSO_LOGIN'] == 'true'
   return unless ENV['OMNIAUTH_ONLY'] == 'true'
@@ -32,50 +43,35 @@ def sso_host
   end
 end
 
-unless Rails.env.development?
-  assets_host = Rails.configuration.action_controller.asset_host || "https://#{ENV['WEB_DOMAIN'] || ENV['LOCAL_DOMAIN']}"
-  data_hosts = [assets_host]
+Rails.application.config.content_security_policy do |p|
+  p.base_uri        :none
+  p.default_src     :none
+  p.frame_ancestors :none
+  p.font_src        :self, assets_host
+  p.img_src         :self, :data, :blob, assets_host
+  p.style_src       :self, assets_host
+  p.media_src       :self, :data, assets_host
+  p.frame_src       :self, :https
+  p.manifest_src    :self, assets_host
 
-  if ENV['S3_ENABLED'] == 'true' || ENV['AZURE_ENABLED'] == 'true'
-    attachments_host = host_to_url(ENV['S3_ALIAS_HOST'] || ENV['S3_CLOUDFRONT_HOST'] || ENV['AZURE_ALIAS_HOST'] || ENV['S3_HOSTNAME'] || "s3-#{ENV['S3_REGION'] || 'us-east-1'}.amazonaws.com")
-  elsif ENV['SWIFT_ENABLED'] == 'true'
-    attachments_host = ENV['SWIFT_OBJECT_URL']
-    attachments_host = "https://#{Addressable::URI.parse(attachments_host).host}"
+  if sso_host.present?
+    p.form_action     :self, sso_host
   else
-    attachments_host = nil
+    p.form_action     :self
   end
 
-  data_hosts << attachments_host unless attachments_host.nil?
+  p.child_src       :self, :blob, assets_host
+  p.worker_src      :self, :blob, assets_host
 
-  if ENV['PAPERCLIP_ROOT_URL']
-    url = Addressable::URI.parse(assets_host) + ENV['PAPERCLIP_ROOT_URL']
-    data_hosts << "https://#{url.host}"
-  end
+  if Rails.env.development?
+    webpacker_public_host = ENV.fetch('WEBPACKER_DEV_SERVER_PUBLIC', Webpacker.config.dev_server[:public])
+    webpacker_urls = %w(ws http).map { |protocol| "#{protocol}#{Webpacker.dev_server.https? ? 's' : ''}://#{webpacker_public_host}" }
 
-  data_hosts.concat(ENV['EXTRA_DATA_HOSTS'].split('|')) if ENV['EXTRA_DATA_HOSTS']
-
-  data_hosts.uniq!
-
-  Rails.application.config.content_security_policy do |p|
-    p.base_uri        :none
-    p.default_src     :none
-    p.frame_ancestors :none
-    p.script_src      :self, assets_host, "'wasm-unsafe-eval'"
-    p.font_src        :self, assets_host
-    p.img_src         :self, :data, :blob, *data_hosts
-    p.style_src       :self, assets_host
-    p.media_src       :self, :data, *data_hosts
-    p.frame_src       :self, :https
-    p.child_src       :self, :blob, assets_host
-    p.worker_src      :self, :blob, assets_host
-    p.connect_src     :self, :blob, :data, Rails.configuration.x.streaming_api_base_url, *data_hosts
-    p.manifest_src    :self, assets_host
-
-    if sso_host.present?
-      p.form_action     :self, sso_host
-    else
-      p.form_action     :self
-    end
+    p.connect_src :self, :data, :blob, assets_host, media_host, Rails.configuration.x.streaming_api_base_url, *webpacker_urls
+    p.script_src  :self, :unsafe_inline, :unsafe_eval, assets_host
+  else
+    p.connect_src :self, :data, :blob, assets_host, media_host, Rails.configuration.x.streaming_api_base_url
+    p.script_src  :self, assets_host, "'wasm-unsafe-eval'"
   end
 end
 

--- a/spec/requests/content_security_policy_spec.rb
+++ b/spec/requests/content_security_policy_spec.rb
@@ -20,7 +20,7 @@ describe 'Content-Security-Policy' do
       "form-action 'self'",
       "child-src 'self' blob: https://cb6e6126.ngrok.io",
       "worker-src 'self' blob: https://cb6e6126.ngrok.io",
-      "connect-src 'self' blob: data: ws://localhost:4000 https://cb6e6126.ngrok.io",
+      "connect-src 'self' data: blob: https://cb6e6126.ngrok.io https://cb6e6126.ngrok.io ws://localhost:4000",
       "script-src 'self' https://cb6e6126.ngrok.io 'wasm-unsafe-eval'"
     )
   end


### PR DESCRIPTION
Our implementations had diverged quite a bit, but the actual changes to the production environment were actually really tiny:
- stricter config for media and images (no `https`): I have kept this difference with upstream
- some clauses were ordered differently: removed that change
- deduplication of assets VS media hosts: dropped that for now, even though this would slightly reduce header size in some cases