### PR TITLE
Remove redundant asset preload

### DIFF
--- a/app/javascript/flavours/glitch/theme.yml
+++ b/app/javascript/flavours/glitch/theme.yml
@@ -13,7 +13,6 @@ pack:
     filename: packs/home.js
     preload:
       - flavours/glitch/async/compose
-      - flavours/glitch/async/getting_started
       - flavours/glitch/async/home_timeline
       - flavours/glitch/async/notifications
   mailer:

--- a/app/javascript/flavours/vanilla/theme.yml
+++ b/app/javascript/flavours/vanilla/theme.yml
@@ -12,7 +12,6 @@ pack:
   home:
     filename: application.js
     preload:
-      - features/getting_started
       - features/compose
       - features/home_timeline
       - features/notifications

--- a/app/views/shared/_web_app.html.haml
+++ b/app/views/shared/_web_app.html.haml
@@ -1,8 +1,5 @@
 - content_for :header_tags do
   - if user_signed_in?
-    = preload_pack_asset 'features/compose.js'
-    = preload_pack_asset 'features/home_timeline.js'
-    = preload_pack_asset 'features/notifications.js'
     %meta{ name: 'initialPath', content: request.path }
 
   %meta{ name: 'applicationServerKey', content: Rails.configuration.x.vapid_public_key }


### PR DESCRIPTION
Preloading is handled by glitch-soc's theming system, so all this currently did was to preload vanilla packs into glitch and preload twice in vanilla if the user was signed in.

The theming system does not conditionally preload though, but I wanted to leave that up for discussion before making changes. I'm not sure preloading is at all really necessary, but it is done upstream.

(Sidenote: the theming system seems to need some work)

Preload of getting-started has been removed as it was removed in 62782babd08bc2385a604e275bf88af925d137c1