### PR TITLE
Add env variable support for number of followable hashtags in feed column

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -20,8 +20,6 @@ services:
       ES_ENABLED: 'true'
       ES_HOST: es
       ES_PORT: '9200'
-      MAX_TOOT_CHARS: 666
-      MAX_FEED_HASHTAGS: 5
       LIBRE_TRANSLATE_ENDPOINT: http://libretranslate:5000
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -20,6 +20,8 @@ services:
       ES_ENABLED: 'true'
       ES_HOST: es
       ES_PORT: '9200'
+      MAX_TOOT_CHARS: 666
+      MAX_FEED_HASHTAGS: 5
       LIBRE_TRANSLATE_ENDPOINT: http://libretranslate:5000
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity

--- a/.env.production.sample
+++ b/.env.production.sample
@@ -251,6 +251,9 @@ SMTP_FROM_ADDRESS=notifications@example.com
 # Maximum allowed character count
 MAX_TOOT_CHARS=500
 
+# Maximum allowed hashtags to follow in a feed column
+MAX_FEED_HASHTAGS=4
+
 # Maximum number of pinned posts
 MAX_PINNED_TOOTS=5
 

--- a/.env.production.sample
+++ b/.env.production.sample
@@ -252,6 +252,8 @@ SMTP_FROM_ADDRESS=notifications@example.com
 MAX_TOOT_CHARS=500
 
 # Maximum allowed hashtags to follow in a feed column
+# Note that setting this value higher may cause significant
+# database load
 MAX_FEED_HASHTAGS=4
 
 # Maximum number of pinned posts

--- a/app/javascript/flavours/glitch/features/hashtag_timeline/components/column_settings.jsx
+++ b/app/javascript/flavours/glitch/features/hashtag_timeline/components/column_settings.jsx
@@ -10,6 +10,7 @@ import AsyncSelect from 'react-select/async';
 import Toggle from 'react-toggle';
 
 import SettingToggle from '../../notifications/components/setting_toggle';
+import { maxFeedHashtags } from 'flavours/glitch/initial_state';
 
 const messages = defineMessages({
   placeholder: { id: 'hashtag.column_settings.select.placeholder', defaultMessage: 'Enter hashtags…' },
@@ -46,9 +47,9 @@ class ColumnSettings extends PureComponent {
   onSelect = mode => value => {
     const oldValue = this.tags(mode);
 
-    // Prevent changes that add more than 4 tags, but allow removing
-    // tags that were already added before
-    if ((value.length > 4) && !(value < oldValue)) {
+    // Prevent changes that add more than the number of configured
+    // tags, but allow removing tags that were already added before
+    if ((value.length > maxFeedHashtags) && !(value < oldValue)) {
       return;
     }
 

--- a/app/javascript/flavours/glitch/features/hashtag_timeline/components/column_settings.jsx
+++ b/app/javascript/flavours/glitch/features/hashtag_timeline/components/column_settings.jsx
@@ -9,8 +9,9 @@ import { NonceProvider } from 'react-select';
 import AsyncSelect from 'react-select/async';
 import Toggle from 'react-toggle';
 
-import SettingToggle from '../../notifications/components/setting_toggle';
 import { maxFeedHashtags } from 'flavours/glitch/initial_state';
+
+import SettingToggle from '../../notifications/components/setting_toggle';
 
 const messages = defineMessages({
   placeholder: { id: 'hashtag.column_settings.select.placeholder', defaultMessage: 'Enter hashtags…' },

--- a/app/javascript/flavours/glitch/initial_state.js
+++ b/app/javascript/flavours/glitch/initial_state.js
@@ -105,6 +105,7 @@ export const hasMultiColumnPath = initialPath === '/'
  * @property {InitialStateMeta} meta
  * @property {object} local_settings
  * @property {number} max_toot_chars
+ * @property {number} max_feed_hashtags
  * @property {number} poll_limits
  */
 
@@ -168,6 +169,7 @@ export const sso_redirect = getMeta('sso_redirect');
 
 // Glitch-soc-specific settings
 export const maxChars = (initialState && initialState.max_toot_chars) || 500;
+export const maxFeedHashtags = (initialState && initialState.max_feed_hashtags) || 4;
 export const favouriteModal = getMeta('favourite_modal');
 export const pollLimits = (initialState && initialState.poll_limits);
 export const defaultContentType = getMeta('default_content_type');

--- a/app/models/tag_feed.rb
+++ b/app/models/tag_feed.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class TagFeed < PublicFeed
-  LIMIT_PER_MODE = 4
+  LIMIT_PER_MODE = (ENV['MAX_FEED_HASHTAGS'] || 4).to_i
 
   # @param [Tag] tag
   # @param [Account] account

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -5,7 +5,7 @@ class InitialStateSerializer < ActiveModel::Serializer
 
   attributes :meta, :compose, :accounts,
              :media_attachments, :settings,
-             :max_toot_chars, :poll_limits,
+             :max_toot_chars, :max_feed_hashtags, :poll_limits,
              :languages
 
   attribute :critical_updates_pending, if: -> { object&.role&.can?(:view_devops) && SoftwareUpdate.check_enabled? }
@@ -15,6 +15,10 @@ class InitialStateSerializer < ActiveModel::Serializer
 
   def max_toot_chars
     StatusLengthValidator::MAX_CHARS
+  end
+
+  def max_feed_hashtags
+    TagFeed::LIMIT_PER_MODE
   end
 
   def poll_limits


### PR DESCRIPTION
Pitch
In the same way that we have an environment variable to change the limit on the number of characters for a post, we should have an environment variable to change the limit on the number of hashtags that can be followed in a ui column.

Motivation
Users may want to follow more than four hashtags related to a specific topic. For example, #gardening #permaculture #ecology #urbanecology #urbangardening.

The argument against this in vanilla is a concern about server performance. As instance admins, that should be our call to make. It's up to us to balance the needs of our users vs the capacity of the server we're running on.

See https://github.com/glitch-soc/mastodon/issues/2489