### PR TITLE
Change mastodon-streaming nightly builds to be tagged as latest

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -56,7 +56,7 @@ jobs:
       labels: |
         org.opencontainers.image.description=Nightly build image used for testing purposes
       flavor: |
-        latest=auto
+        latest=true
       tags: |
         type=raw,value=edge
         type=raw,value=nightly


### PR DESCRIPTION
glitch-soc does not have releases, so it tags nightly container builds as latest; but we were not doing the same thing for the new `mastodon-streaming` container