### PR TITLE
Allow non-ASCII characters in emoji names

### DIFF
--- a/app/models/custom_emoji.rb
+++ b/app/models/custom_emoji.rb
@@ -27,7 +27,7 @@ class CustomEmoji < ApplicationRecord
   LOCAL_LIMIT = (ENV['MAX_EMOJI_SIZE'] || 256.kilobytes).to_i
   LIMIT       = [LOCAL_LIMIT, (ENV['MAX_REMOTE_EMOJI_SIZE'] || 256.kilobytes).to_i].max
 
-  SHORTCODE_RE_FRAGMENT = '[a-zA-Z0-9_]{2,}'
+  SHORTCODE_RE_FRAGMENT = '(([[:alnum:]])|_){2,}'
 
   SCAN_RE = /(?<=[^[:alnum:]:]|\n|^)
     :(#{SHORTCODE_RE_FRAGMENT}):


### PR DESCRIPTION
Tweaks the emoji shortcode regex to allow non-ASCII alphanumeric characters; this is for internationalization, to allow emoji names to be in languages that don’t fall within ASCII.