### PR TITLE
Change icons size to 21px

### DIFF
--- a/app/javascript/flavours/glitch/styles/components/misc.scss
+++ b/app/javascript/flavours/glitch/styles/components/misc.scss
@@ -171,8 +171,8 @@
 
 .icon {
   flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
+  width: 21px;
+  height: 21px;
   aspect-ratio: 1;
 
   path {


### PR DESCRIPTION
This is a really small change to reduce the size of the icons from 24 to 21px. I wanted to go as low as 20px, but it might be too small for non-desktop devices.

Because the new upstream icons are much thinner and sharper than the previous ones, I feel like the larger icons take too much real estate, and make the content less visible.

Here is the before/after comparison:
![before](https://github.com/glitch-soc/mastodon/assets/52980486/e74f5a50-f2f0-4915-a8bc-f616504f39f7)
![after](https://github.com/glitch-soc/mastodon/assets/52980486/5acdf983-a9c7-48b1-8f13-2144e830e7ae)
