### PR TITLE
Add github action workflow for manual security builds

### DIFF
--- a/.github/workflows/build-security.yml
+++ b/.github/workflows/build-security.yml
@@ -1,4 +1,6 @@
 name: Build security nightly container image
+on:
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/build-security.yml
+++ b/.github/workflows/build-security.yml
@@ -7,7 +7,6 @@ permissions:
 jobs:
   compute-suffix:
     runs-on: ubuntu-latest
-    if: github.repository == 'mastodon/mastodon'
     steps:
       - id: version_vars
         env:
@@ -26,8 +25,7 @@ jobs:
       use_native_arm64_builder: true
       cache: false
       push_to_images: |
-        tootsuite/mastodon
-        ghcr.io/mastodon/mastodon
+        ghcr.io/${{ github.repository_owner }}/mastodon
       version_prerelease: ${{ needs.compute-suffix.outputs.prerelease }}
       labels: |
         org.opencontainers.image.description=Nightly build image used for testing purposes
@@ -45,11 +43,10 @@ jobs:
     with:
       file_to_build: streaming/Dockerfile
       platforms: linux/amd64,linux/arm64
-      use_native_arm64_builder: true
+      use_native_arm64_builder: false
       cache: false
       push_to_images: |
-        tootsuite/mastodon-streaming
-        ghcr.io/mastodon/mastodon-streaming
+        ghcr.io/${{ github.repository_owner }}/mastodon
       version_prerelease: ${{ needs.compute-suffix.outputs.prerelease }}
       labels: |
         org.opencontainers.image.description=Nightly build image used for testing purposes

--- a/.github/workflows/build-security.yml
+++ b/.github/workflows/build-security.yml
@@ -1,0 +1,62 @@
+name: Build security nightly container image
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  compute-suffix:
+    runs-on: ubuntu-latest
+    if: github.repository == 'mastodon/mastodon'
+    steps:
+      - id: version_vars
+        env:
+          TZ: Etc/UTC
+        run: |
+          echo mastodon_version_prerelease=nightly.$(date --date='next day' +'%Y-%m-%d')-security>> $GITHUB_OUTPUT
+    outputs:
+      prerelease: ${{ steps.version_vars.outputs.mastodon_version_prerelease }}
+
+  build-image:
+    needs: compute-suffix
+    uses: ./.github/workflows/build-container-image.yml
+    with:
+      file_to_build: Dockerfile
+      platforms: linux/amd64,linux/arm64
+      use_native_arm64_builder: true
+      cache: false
+      push_to_images: |
+        tootsuite/mastodon
+        ghcr.io/mastodon/mastodon
+      version_prerelease: ${{ needs.compute-suffix.outputs.prerelease }}
+      labels: |
+        org.opencontainers.image.description=Nightly build image used for testing purposes
+      flavor: |
+        latest=auto
+      tags: |
+        type=raw,value=edge
+        type=raw,value=nightly
+        type=schedule,pattern=${{ needs.compute-suffix.outputs.prerelease }}
+    secrets: inherit
+
+  build-image-streaming:
+    needs: compute-suffix
+    uses: ./.github/workflows/build-container-image.yml
+    with:
+      file_to_build: streaming/Dockerfile
+      platforms: linux/amd64,linux/arm64
+      use_native_arm64_builder: true
+      cache: false
+      push_to_images: |
+        tootsuite/mastodon-streaming
+        ghcr.io/mastodon/mastodon-streaming
+      version_prerelease: ${{ needs.compute-suffix.outputs.prerelease }}
+      labels: |
+        org.opencontainers.image.description=Nightly build image used for testing purposes
+      flavor: |
+        latest=auto
+      tags: |
+        type=raw,value=edge
+        type=raw,value=nightly
+        type=schedule,pattern=${{ needs.compute-suffix.outputs.prerelease }}
+    secrets: inherit


### PR DESCRIPTION
cherry-pick change from upstream and adapt it to glitch-soc (no native arm builder, different container repositories)