### PR TITLE
Restore -streaming suffix for security builds

### DIFF
--- a/.github/workflows/build-security.yml
+++ b/.github/workflows/build-security.yml
@@ -48,7 +48,7 @@ jobs:
       use_native_arm64_builder: false
       cache: false
       push_to_images: |
-        ghcr.io/${{ github.repository_owner }}/mastodon
+        ghcr.io/${{ github.repository_owner }}/mastodon-streaming
       version_prerelease: ${{ needs.compute-suffix.outputs.prerelease }}
       labels: |
         org.opencontainers.image.description=Nightly build image used for testing purposes


### PR DESCRIPTION
https://github.com/glitch-soc/mastodon/pull/2599 changed things so that streaming containers are also uploaded to the `mastodon` container on GHCR (and not `mastodon-streaming`).

I pulled the latest nightly Ruby container but got a ~269Mb streaming image instead:

```
bash: line 1: bundle: command not found
eccles:~/masto$ ^C
eccles:~/masto$ docker image ls
REPOSITORY                              TAG                  IMAGE ID       CREATED          SIZE
ghcr.io/glitch-soc/mastodon             nightly              0f50e6526b28   47 minutes ago   269MB
ghcr.io/glitch-soc/mastodon             nightly.2024-01-29   144b7fb4fa7f   3 days ago       1.09GB
ghcr.io/glitch-soc/mastodon-streaming   nightly.2024-01-29   79efdd97b0d0   3 days ago       268MB
```