### PR TITLE
Remove status content from mobile actions modal

### DIFF
--- a/app/javascript/flavours/glitch/features/ui/components/actions_modal.jsx
+++ b/app/javascript/flavours/glitch/features/ui/components/actions_modal.jsx
@@ -5,11 +5,6 @@ import classNames from 'classnames';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 
-import { Avatar } from 'flavours/glitch/components/avatar';
-import { DisplayName } from 'flavours/glitch/components/display_name';
-import { RelativeTimestamp } from 'flavours/glitch/components/relative_timestamp';
-import StatusContent from 'flavours/glitch/components/status_content';
-
 import { IconButton } from '../../../components/icon_button';
 
 export default class ActionsModal extends ImmutablePureComponent {
@@ -58,33 +53,9 @@ export default class ActionsModal extends ImmutablePureComponent {
   };
 
   render () {
-    const status = this.props.status && (
-      <div className='status light'>
-        <div className='boost-modal__status-header'>
-          <div className='boost-modal__status-time'>
-            <a href={this.props.status.get('url')} className='status__relative-time' target='_blank' rel='noopener noreferrer'>
-              <RelativeTimestamp timestamp={this.props.status.get('created_at')} />
-            </a>
-          </div>
-
-          <a href={this.props.status.getIn(['account', 'url'])} className='status__display-name' rel='noopener noreferrer'>
-            <div className='status__avatar'>
-              <Avatar account={this.props.status.get('account')} size={48} />
-            </div>
-
-            <DisplayName account={this.props.status.get('account')} />
-          </a>
-        </div>
-
-        <StatusContent status={this.props.status} />
-      </div>
-    );
-
     return (
       <div className='modal-root__modal actions-modal'>
-        {status}
-
-        <ul className={classNames({ 'with-status': !!status })}>
+        <ul>
           {this.props.actions.map(this.renderAction)}
         </ul>
       </div>


### PR DESCRIPTION
This removes the full status being displayed in the mobile actions modal, in line with vanilla (commit 0ca29eaa).

Only the action list is scrollable, so large statuses make actions unavailable on a small screen. There doesn't seem to be any purpose in duplicating the status in the modal anyway.

Originally pointed out by @Enichan (#2614)

**Bonus:** the `<ul className={classNames({ 'with-status': !!status })}>` code is still [present in vanilla](https://github.com/mastodon/mastodon/blob/c07028b2fae4dc692570df84227023ca90443288/app/javascript/mastodon/features/ui/components/actions_modal.jsx#L41), however `status` now refers to `window.status`  and is clearly a bug. Not sure if I should make a separate PR about that.

Before and after:

![Screenshot 2024-02-10 at 17-50-25 Loud Computer](https://github.com/glitch-soc/mastodon/assets/336598/afdca9f2-3c9a-4f2d-b76a-3e12928a7ef6) ![Screenshot 2024-02-10 at 17-50-53 Loud Computer](https://github.com/glitch-soc/mastodon/assets/336598/1aab460a-a12a-4d2a-8157-56aedb95e324) 
