### PR TITLE
Make it easily change remote and/or local media count limits

### DIFF
--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -110,7 +110,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
   def process_status_params
     @status_parser = ActivityPub::Parser::StatusParser.new(@json, followers_collection: @account.followers_url, object: @object)
 
-    attachment_ids = process_attachments.take(4).map(&:id)
+    attachment_ids = process_attachments.take(Rails.configuration.x.mastodon.statuses[:max_media_attachments][:remote]).map(&:id)
 
     @params = {
       uri: @status_parser.uri,
@@ -260,7 +260,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
     as_array(@object['attachment']).each do |attachment|
       media_attachment_parser = ActivityPub::Parser::MediaAttachmentParser.new(attachment)
 
-      next if media_attachment_parser.remote_url.blank? || media_attachments.size >= 4
+      next if media_attachment_parser.remote_url.blank? || media_attachments.size >= Rails.configuration.x.mastodon.statuses[:max_media_attachments][:remote]
 
       begin
         media_attachment = MediaAttachment.create(

--- a/app/serializers/rest/instance_serializer.rb
+++ b/app/serializers/rest/instance_serializer.rb
@@ -58,7 +58,7 @@ class REST::InstanceSerializer < ActiveModel::Serializer
 
       statuses: {
         max_characters: StatusLengthValidator::MAX_CHARS,
-        max_media_attachments: 4,
+        max_media_attachments: Rails.configuration.x.mastodon.statuses[:max_media_attachments][:local],
         characters_reserved_per_url: StatusLengthValidator::URL_PLACEHOLDER_CHARS,
         supported_mime_types: HtmlAwareFormatter::STATUS_MIME_TYPES,
       },

--- a/app/serializers/rest/v1/instance_serializer.rb
+++ b/app/serializers/rest/v1/instance_serializer.rb
@@ -77,7 +77,7 @@ class REST::V1::InstanceSerializer < ActiveModel::Serializer
 
       statuses: {
         max_characters: StatusLengthValidator::MAX_CHARS,
-        max_media_attachments: 4,
+        max_media_attachments: Rails.configuration.x.mastodon.statuses[:max_media_attachments][:local],
         characters_reserved_per_url: StatusLengthValidator::URL_PLACEHOLDER_CHARS,
         supported_mime_types: HtmlAwareFormatter::STATUS_MIME_TYPES,
       },

--- a/app/services/activitypub/process_status_update_service.rb
+++ b/app/services/activitypub/process_status_update_service.rb
@@ -73,7 +73,7 @@ class ActivityPub::ProcessStatusUpdateService < BaseService
     as_array(@json['attachment']).each do |attachment|
       media_attachment_parser = ActivityPub::Parser::MediaAttachmentParser.new(attachment)
 
-      next if media_attachment_parser.remote_url.blank? || @next_media_attachments.size > 4
+      next if media_attachment_parser.remote_url.blank? || @next_media_attachments.size > Rails.configuration.x.mastodon.statuses[:max_media_attachments][:remote]
 
       begin
         media_attachment   = previous_media_attachments.find { |previous_media_attachment| previous_media_attachment.remote_url == media_attachment_parser.remote_url }

--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -146,9 +146,9 @@ class PostStatusService < BaseService
       return
     end
 
-    raise Mastodon::ValidationError, I18n.t('media_attachments.validations.too_many') if @options[:media_ids].size > 4 || @options[:poll].present?
+    raise Mastodon::ValidationError, I18n.t('media_attachments.validations.too_many') if @options[:media_ids].size > Rails.configuration.x.mastodon.statuses[:max_media_attachments][:local] || @options[:poll].present?
 
-    @media = @account.media_attachments.where(status_id: nil).where(id: @options[:media_ids].take(4).map(&:to_i))
+    @media = @account.media_attachments.where(status_id: nil).where(id: @options[:media_ids].take(Rails.configuration.x.mastodon.statuses[:max_media_attachments][:local]).map(&:to_i))
 
     raise Mastodon::ValidationError, I18n.t('media_attachments.validations.images_and_video') if @media.size > 1 && @media.find(&:audio_or_video?)
     raise Mastodon::ValidationError, I18n.t('media_attachments.validations.not_ready') if @media.any?(&:not_processed?)

--- a/app/services/update_status_service.rb
+++ b/app/services/update_status_service.rb
@@ -70,9 +70,9 @@ class UpdateStatusService < BaseService
   def validate_media!
     return [] if @options[:media_ids].blank? || !@options[:media_ids].is_a?(Enumerable)
 
-    raise Mastodon::ValidationError, I18n.t('media_attachments.validations.too_many') if @options[:media_ids].size > 4 || @options[:poll].present?
+    raise Mastodon::ValidationError, I18n.t('media_attachments.validations.too_many') if @options[:media_ids].size > Rails.configuration.x.mastodon.statuses[:max_media_attachments][:local] || @options[:poll].present?
 
-    media_attachments = @status.account.media_attachments.where(status_id: [nil, @status.id]).where(scheduled_status_id: nil).where(id: @options[:media_ids].take(4).map(&:to_i)).to_a
+    media_attachments = @status.account.media_attachments.where(status_id: [nil, @status.id]).where(scheduled_status_id: nil).where(id: @options[:media_ids].take(Rails.configuration.x.mastodon.statuses[:max_media_attachments][:local]).map(&:to_i)).to_a
 
     raise Mastodon::ValidationError, I18n.t('media_attachments.validations.images_and_video') if media_attachments.size > 1 && media_attachments.find(&:audio_or_video?)
     raise Mastodon::ValidationError, I18n.t('media_attachments.validations.not_ready') if media_attachments.any?(&:not_processed?)

--- a/config/initializers/mastodon.rb
+++ b/config/initializers/mastodon.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Mastodon
+    class Application < Rails::Application
+      config.x.mastodon = config_for(:mastodon)
+    end
+end

--- a/config/mastodon.yml
+++ b/config/mastodon.yml
@@ -1,0 +1,5 @@
+shared:
+  statuses:
+    max_media_attachments:
+      local: 4
+      remote: 16


### PR DESCRIPTION
This will introduce easily configurable file to change media limits.

If `ENV` way is more prefer, than `mastodon.yml` can be changed like:
```yml
shared:
  statuses:
    max_media_attachments:
      local: <%= ENV['MAX_STATUSES_LOCAL_MEDIA_ATTACHMENTS'] %>
      remote: <%= ENV['MAX_STATUSES_REMOTE_MEDIA_ATTACHMENTS'] %>
```

This PR is some part of mastodon/mastodon#27833.
This will fix #1975.
