### PR TITLE
Change list title input design to fit upstream

### DIFF
--- a/app/javascript/flavours/glitch/components/setting_text.jsx
+++ b/app/javascript/flavours/glitch/components/setting_text.jsx
@@ -23,7 +23,7 @@ export default class SettingText extends PureComponent {
       <label>
         <span style={{ display: 'none' }}>{label}</span>
         <input
-          className='setting-text'
+          className='glitch-setting-text'
           value={settings.getIn(settingPath)}
           onChange={this.handleChange}
           placeholder={label}

--- a/app/javascript/flavours/glitch/styles/components.scss
+++ b/app/javascript/flavours/glitch/styles/components.scss
@@ -3212,6 +3212,29 @@ $ui-header-height: 55px;
   }
 }
 
+input.glitch-setting-text {
+  box-sizing: border-box;
+  color: $darker-text-color;
+  background: transparent;
+  border: 0;
+  border-bottom: 2px solid $ui-primary-color;
+  outline: 0;
+  font-family: inherit;
+  margin-bottom: 10px;
+  padding: 7px 0;
+  width: 100%;
+
+  &:focus,
+  &:active {
+    color: $primary-text-color;
+    border-bottom-color: $ui-highlight-color;
+  }
+
+  @media screen and (width <= 600px) {
+    font-size: 16px;
+  }
+}
+
 .setting-text {
   display: block;
   box-sizing: border-box;

--- a/app/javascript/flavours/glitch/styles/components.scss
+++ b/app/javascript/flavours/glitch/styles/components.scss
@@ -2945,7 +2945,6 @@ $ui-header-height: 55px;
   cursor: pointer;
   white-space: nowrap;
   font-size: 16px;
-  flex: 0 0 auto;
   padding: 0;
   padding-inline-end: 5px;
   z-index: 3;
@@ -3216,31 +3215,49 @@ $ui-header-height: 55px;
 .setting-text {
   display: block;
   box-sizing: border-box;
-  color: $darker-text-color;
-  background: transparent;
-  border: 0;
-  border-bottom: 2px solid $ui-primary-color;
-  outline: 0;
+  margin: 0;
+  color: $inverted-text-color;
+  background: $white;
+  padding: 7px 10px;
   font-family: inherit;
-  margin-bottom: 10px;
-  padding: 7px 0;
-  width: 100%;
+  font-size: 14px;
+  line-height: 22px;
+  border-radius: 4px;
+  border: 1px solid $white;
 
-  &:focus,
-  &:active {
-    color: $primary-text-color;
-    border-bottom-color: $ui-highlight-color;
+  &:focus {
+    outline: 0;
+    border-color: lighten($ui-highlight-color, 12%);
   }
 
-  &.light {
-    color: $inverted-text-color;
-    border-bottom: 2px solid lighten($ui-base-color, 27%);
+  &__wrapper {
+    background: $white;
+    border: 1px solid $ui-secondary-color;
+    margin-bottom: 10px;
+    border-radius: 4px;
 
-    &:focus,
-    &:active {
-      color: $inverted-text-color;
-      border-bottom-color: $ui-highlight-color;
+    .setting-text {
+      border: 0;
+      margin-bottom: 0;
+      border-radius: 0;
+
+      &:focus {
+        border: 0;
+      }
     }
+
+    &__modifiers {
+      color: $inverted-text-color;
+      font-family: inherit;
+      font-size: 14px;
+      background: $white;
+    }
+  }
+
+  &__toolbar {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 20px;
   }
 
   @media screen and (width <= 600px) {
@@ -6448,56 +6465,11 @@ a.status-card.compact:hover {
   }
 
   .setting-text {
-    display: block;
-    box-sizing: border-box;
     width: 100%;
-    margin: 0;
-    color: $inverted-text-color;
-    background: $white;
-    padding: 10px;
-    font-family: inherit;
-    font-size: 14px;
     resize: none;
-    outline: 0;
-    border-radius: 4px;
-    border: 1px solid $ui-secondary-color;
     min-height: 100px;
     max-height: 50vh;
-    margin-bottom: 10px;
-
-    &:focus {
-      border: 1px solid darken($ui-secondary-color, 8%);
-    }
-
-    &__wrapper {
-      background: $white;
-      border: 1px solid $ui-secondary-color;
-      margin-bottom: 10px;
-      border-radius: 4px;
-
-      .setting-text {
-        border: 0;
-        margin-bottom: 0;
-        border-radius: 0;
-
-        &:focus {
-          border: 0;
-        }
-      }
-
-      &__modifiers {
-        color: $inverted-text-color;
-        font-family: inherit;
-        font-size: 14px;
-        background: $white;
-      }
-    }
-
-    &__toolbar {
-      display: flex;
-      justify-content: space-between;
-      margin-bottom: 20px;
-    }
+    border: 0;
   }
 
   .setting-toggle {
@@ -7738,10 +7710,10 @@ noscript {
 }
 
 .column-inline-form {
-  padding: 7px 15px;
-  padding-inline-end: 5px;
+  padding: 15px;
   display: flex;
   justify-content: flex-start;
+  gap: 15px;
   align-items: center;
   background: lighten($ui-base-color, 4%);
 
@@ -7750,17 +7722,7 @@ noscript {
 
     input {
       width: 100%;
-      margin-bottom: 6px;
-
-      &:focus {
-        outline: 0;
-      }
     }
-  }
-
-  .icon-button {
-    flex: 0 0 auto;
-    margin: 0 5px;
   }
 }
 

--- a/app/javascript/flavours/glitch/styles/mastodon-light/diff.scss
+++ b/app/javascript/flavours/glitch/styles/mastodon-light/diff.scss
@@ -80,6 +80,10 @@ html {
   background: $white;
 }
 
+.column-header {
+  border-bottom: 0;
+}
+
 .column-header__button.active {
   color: $ui-highlight-color;
 
@@ -422,7 +426,7 @@ html {
 .column-header__collapsible-inner {
   background: darken($ui-base-color, 4%);
   border: 1px solid lighten($ui-base-color, 8%);
-  border-top: 0;
+  border-bottom: 0;
 }
 
 .column-settings__hashtags .column-select__option {


### PR DESCRIPTION
Reduce CSS differences with upstream and fix a few issues. List edit looks a bit awkward but it's upstream's design and it's more obvious it's an input.

Regexp filter input class name has been changed to a glitch-soc-only class name and the style has been preserved as upstream's style looked too jarring and upstream has no similar inputs anymore.

![image](https://github.com/glitch-soc/mastodon/assets/384364/7c9af983-818b-4723-a518-51a36075973a)

## Before

![image](https://github.com/glitch-soc/mastodon/assets/384364/0c7ab5a3-2982-4631-9687-c4de75fce61c)
![image](https://github.com/glitch-soc/mastodon/assets/384364/dc6dae45-7451-448d-91ee-411522c380e1)
![image](https://github.com/glitch-soc/mastodon/assets/384364/02c68945-f8ef-46b4-a714-e22ad9e3674c)

## After

![image](https://github.com/glitch-soc/mastodon/assets/384364/173397dd-a4d7-4892-b18b-2e25c7169ab0)
![image](https://github.com/glitch-soc/mastodon/assets/384364/a823ceca-4072-4bb2-9c57-6777548cee10)
![image](https://github.com/glitch-soc/mastodon/assets/384364/137c17d2-9c36-4ded-9e93-b9c8a048a68f)
