### PR TITLE
Fix logging error in streaming server

### DIFF
--- a/streaming/index.js
+++ b/streaming/index.js
@@ -767,7 +767,7 @@ const startServer = async () => {
 
       // Only send local-only statuses to logged-in users
       if ((event === 'update' || event === 'status.update') && payload.local_only && !(req.accountId && allowLocalOnly)) {
-        log.silly(req.requestId, `Message ${payload.id} filtered because it was local-only`);
+        log.debug(`Message ${payload.id} filtered because it was local-only`);
         return;
       }
 


### PR DESCRIPTION
Logger changed upstream causing `log.silly` to error and crash the server for local only statuses