### PR TITLE
Fix error when attempting to delete posts that triggered a notification request (#29666)

### DIFF
--- a/app/models/notification_request.rb
+++ b/app/models/notification_request.rb
@@ -7,7 +7,7 @@
 #  id                  :bigint(8)        not null, primary key
 #  account_id          :bigint(8)        not null
 #  from_account_id     :bigint(8)        not null
-#  last_status_id      :bigint(8)        not null
+#  last_status_id      :bigint(8)
 #  notifications_count :bigint(8)        default(0), not null
 #  dismissed           :boolean          default(FALSE), not null
 #  created_at          :datetime         not null

--- a/db/migrate/20240320163441_change_notification_request_last_status_id_nullable.rb
+++ b/db/migrate/20240320163441_change_notification_request_last_status_id_nullable.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ChangeNotificationRequestLastStatusIdNullable < ActiveRecord::Migration[7.1]
+  def change
+    change_column_null :notification_requests, :last_status_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_10_123453) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_20_163441) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -689,7 +689,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_10_123453) do
   create_table "notification_requests", id: :bigint, default: -> { "timestamp_id('notification_requests'::text)" }, force: :cascade do |t|
     t.bigint "account_id", null: false
     t.bigint "from_account_id", null: false
-    t.bigint "last_status_id", null: false
+    t.bigint "last_status_id"
     t.bigint "notifications_count", default: 0, null: false
     t.boolean "dismissed", default: false, null: false
     t.datetime "created_at", null: false


### PR DESCRIPTION
Cherry-pick upstream change.

Not merging the other stuff yet because I'm not confident in the severed relationships code at this point, but this commit fixes a nasty bug with notification requests and post deletion.