### PR TITLE
Increase the height of collapsed toots to 12 rem (192 px with default browser settings)

### DIFF
--- a/app/javascript/flavours/glitch/styles/components.scss
+++ b/app/javascript/flavours/glitch/styles/components.scss
@@ -1557,7 +1557,7 @@ body > [data-popper-placement] {
         bottom: 0;
         inset-inline-start: 0;
         inset-inline-end: 0;
-        background: linear-gradient(transparent, var(--background-color));
+        background: linear-gradient(transparent, transparent 50%, var(--background-color));
         pointer-events: none;
       }
 

--- a/app/javascript/flavours/glitch/styles/components.scss
+++ b/app/javascript/flavours/glitch/styles/components.scss
@@ -1545,7 +1545,7 @@ body > [data-popper-placement] {
     }
 
     .status__content {
-      height: 20px;
+      height: 12rem;
       overflow: hidden;
       text-overflow: ellipsis;
       padding-top: 0;


### PR DESCRIPTION
As noted in #2483, current collapsed toots barely display the first line of the text of the toot, which basically hides the toot almost entirely.

This PR increases the height of a collapsed toot to 12 rem (192 px if the user didn't change their browser's default font size), which is about the height of a "normal" 500-character toot on a 1920x1080 desktop with 100% zoom. This allows the reader to have an idea about the toot's contents to decide whether to unfold it or not.

It would be perhaps even better to have the height be set dynamically based on the maximum non-collapsed height configured in the app settings, but that is a task for a separate PR, as it would require more work.

This fixes the immediate readability problem with collapsed toots.