### PR TITLE
Improve minimal size compose box wide mode

### DIFF
--- a/app/javascript/flavours/glitch/styles/components.scss
+++ b/app/javascript/flavours/glitch/styles/components.scss
@@ -7255,7 +7255,7 @@ img.modal-warning {
   }
 
   .drawer {
-    min-width: 300px;
+    min-width: 325px;
     max-width: 400px;
     flex: 1 1 200px;
   }


### PR DESCRIPTION
Hello, I don't know if this is the right way to do it, but currently, in wide mode, the compose column can be small enough to lose some information about character count:
![image](https://github.com/glitch-soc/mastodon/assets/58464216/96acc425-c1d8-412f-9649-6a89e38e4031) ![image](https://github.com/glitch-soc/mastodon/assets/58464216/1c2e6cc0-90d3-4c41-ade4-d1252bad53e7)


325px seems to be enough for up to a 5-digit character count.