### PR TITLE
Add crossorigin to inert css

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -30,7 +30,7 @@
     = theme_style_tags current_theme
 
     -# Needed for the wicg-inert polyfill. It needs to be on it's own <style> tag, with this `id`
-    = flavoured_stylesheet_pack_tag 'inert', media: 'all', id: 'inert-style'
+    = flavoured_stylesheet_pack_tag 'inert', media: 'all', crossorigin: 'anonymous', id: 'inert-style'
 
     = javascript_pack_tag 'common', crossorigin: 'anonymous'
     = preload_locale_pack


### PR DESCRIPTION
Missing `crossorigin` attribute inihibits proper loading through a CDN when CDN_HOST is set to a different domain. 

This addresses issue #2739.