### PR TITLE
Fix detailed statuses being clickable and linking to broken pages

### DIFF
--- a/app/javascript/flavours/glitch/features/status/components/detailed_status.tsx
+++ b/app/javascript/flavours/glitch/features/status/components/detailed_status.tsx
@@ -381,6 +381,7 @@ export const DetailedStatus: React.FC<{
           tagLinks={tagMisleadingLinks}
           rewriteMentions={rewriteMentions}
           parseClick={parseClick}
+          disabled
           {...(statusContentProps as any)}
         />
 


### PR DESCRIPTION
I missed a glitch-soc-specific quirk when porting the Typescript rewrite to glitch-soc.