### PR TITLE
Fix video player's height in detailed status view

### DIFF
--- a/app/javascript/flavours/glitch/features/status/components/detailed_status.tsx
+++ b/app/javascript/flavours/glitch/features/status/components/detailed_status.tsx
@@ -259,6 +259,7 @@ export const DetailedStatus: React.FC<{
           src={attachment.get('url')}
           alt={description}
           lang={language}
+          inline
           width={300}
           height={150}
           onOpenVideo={handleOpenVideo}


### PR DESCRIPTION
In the future, we probably want to rework the whole thing to better match upstream.