### PR TITLE
Fix issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.web_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1.web_bug_report.yml
@@ -1,7 +1,6 @@
 name: Bug Report (Web Interface)
 description: There is a problem using Mastodon's web interface.
-labels: ['status/to triage', 'area/web interface']
-type: Bug
+labels: [bug, 'status/to triage', 'area/web interface']
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/2.server_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/2.server_bug_report.yml
@@ -1,8 +1,7 @@
 name: Bug Report (server / API)
 description: |
   There is a problem with the HTTP server, REST API, ActivityPub interaction, etc.
-labels: ['status/to triage']
-type: 'Bug'
+labels: [bug, 'status/to triage']
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/3.troubleshooting.yml
+++ b/.github/ISSUE_TEMPLATE/3.troubleshooting.yml
@@ -1,8 +1,7 @@
 name: Deployment troubleshooting
 description: |
   You are a server administrator and you are encountering a technical issue during installation, upgrade or operations of Mastodon.
-labels: ['status/to triage']
-type: 'Troubleshooting'
+labels: [bug, 'status/to triage']
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/4.feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/4.feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature Request
 description: I have a suggestion
-type: Suggestion
+labels: [suggestion]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
It seems it was not possible to open new issues due to the templates from upstream depending on Github's beta issues feature, which we have not opted into.