### PR TITLE
Turn local-only threads into a one-way street

### DIFF
--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -496,7 +496,7 @@ class Status < ApplicationRecord
   def set_local_only
     return unless account.domain.nil? && !attribute_changed?(:local_only)
 
-    self.local_only = marked_local_only?
+    self.local_only = marked_local_only? || thread&.local_only
   end
 
   def set_conversation

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -290,6 +290,23 @@ RSpec.describe Status do
         end
       end
     end
+
+    describe 'on a status in a local-only thread' do
+      subject { described_class.new }
+
+      context 'when a status does not contain the local-only emoji' do
+        let(:thread) { Fabricate(:Status, local_only: true) }
+
+        before do
+          subject.thread = thread
+        end
+        
+        it 'is marked local-only' do
+          subject.save!
+
+          expect(subject).to be_local_only
+        end
+    end
   end
 
   describe '#reported?' do


### PR DESCRIPTION
We have an instance that runs a modified fork of Glitch. 
Some clients don't automatically copy the eye emoji into a reply to a local-only message and users forget to set it manually. This leads to posts that are intended to be local-only being federated unintentionally. 

We'd like to to turn local-only threads into a one-way streets:
Once a post has been made local-only, all replies to it should be local-only as well. This prevents leaking information. 

If a user wants to make federated reply in a thread, they should reply to the latest federated post, which would not give away information about the existence of the local-only portions of a thread to users on other instances.  