### PR TITLE
[Glitch] Standalone share page: Dispatch fetchServer for maxChars

### DIFF
--- a/app/javascript/flavours/glitch/containers/compose_container.jsx
+++ b/app/javascript/flavours/glitch/containers/compose_container.jsx
@@ -1,6 +1,7 @@
 import { Provider } from 'react-redux';
 
 import { fetchCustomEmojis } from 'flavours/glitch/actions/custom_emojis';
+import { fetchServer } from 'flavours/glitch/actions/server';
 import { hydrateStore } from 'flavours/glitch/actions/store';
 import { Router } from 'flavours/glitch/components/router';
 import Compose from 'flavours/glitch/features/standalone/compose';
@@ -13,6 +14,7 @@ if (initialState) {
 }
 
 store.dispatch(fetchCustomEmojis());
+store.dispatch(fetchServer());
 
 const ComposeContainer = () => (
   <IntlProvider>


### PR DESCRIPTION
Fixes https://github.com/glitch-soc/mastodon/issues/2687

Regression was introduced in 6da69967d0df35b04deb66192b6ecf960451c7b3, since we no longer include the maximum character count in the initial state, instead, it is fetched separately via the server details.

This may be worth upstreaming, as [they'll likely have the same bug](https://github.com/mastodon/mastodon/blob/9712518b2fb2585df3bcff95a687c291f04a4199/app/javascript/mastodon/containers/compose_container.jsx) ~~(however, I won't be the one to do open a PR there. Have fun with it, this is AGPLv3 after all \^-\^). As such, I have also modified the vanilla part of this code in this PR.~~