### PR TITLE
Fix media attachments in report modal

### DIFF
--- a/app/javascript/flavours/glitch/features/report/components/status_check_box.jsx
+++ b/app/javascript/flavours/glitch/features/report/components/status_check_box.jsx
@@ -46,7 +46,8 @@ class StatusCheckBox extends PureComponent {
           </div>
         </div>
 
-        <StatusContent status={status} media={<MediaAttachments status={status} visible={false} />} />
+        <StatusContent status={status} />
+        <MediaAttachments status={status} visible={false} />
       </div>
     );
 


### PR DESCRIPTION
Media attachments weren't shown in the report modal since they were passed as `media` to `StatusContent`, but `StatusContent` doesn't use the media prop anymore.

Instead match the file with vanilla.