### PR TITLE
Sync Glitch follow button with Mastodon

### DIFF
--- a/app/javascript/flavours/glitch/components/follow_button.tsx
+++ b/app/javascript/flavours/glitch/components/follow_button.tsx
@@ -78,10 +78,10 @@ export const FollowButton: React.FC<{
     label = intl.formatMessage(messages.edit_profile);
   } else if (!relationship) {
     label = <LoadingIndicator />;
-  } else if (!relationship.following && relationship.followed_by) {
-    label = intl.formatMessage(messages.followBack);
   } else if (relationship.following || relationship.requested) {
     label = intl.formatMessage(messages.unfollow);
+  } else if (relationship.followed_by) {
+    label = intl.formatMessage(messages.followBack);
   } else {
     label = intl.formatMessage(messages.follow);
   }


### PR DESCRIPTION
Fixes the follow button saying "Follow back" when it actually will cancel the follow request (mastodon/mastodon#31934) and makes it say "Mutual" when you're mutuals.

I noticed this happen when someone was following me but my follow request was still pending, and I found the Glitch follow button was inconsistent with the Mastodon one. With this change, they should behave identically to one another.