### PR TITLE
Fix missing notification badge on desktop layout

### DIFF
--- a/app/javascript/flavours/glitch/features/ui/components/navigation_panel.tsx
+++ b/app/javascript/flavours/glitch/features/ui/components/navigation_panel.tsx
@@ -102,11 +102,7 @@ const NotificationsLink = () => {
   const showCount = useAppSelector(
     (state) =>
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-      state.local_settings.getIn([
-        'notifications',
-        'tab_badge',
-        false,
-      ]) as boolean,
+      state.local_settings.getIn(['notifications', 'tab_badge']) as boolean,
   );
   const intl = useIntl();
 


### PR DESCRIPTION
The changes in 9101067154e0e6632f095c5f19ceed43d6ebf28f appear to have created an issue where the notification badge in the nav panel on the desktop layout is missing, no matter what the setting for displaying it is. Mobile is unaffected as the bottom bar uses a different component.