### PR TITLE
Fix inverted regex filter condition

### DIFF
--- a/app/javascript/flavours/glitch/features/ui/containers/status_list_container.js
+++ b/app/javascript/flavours/glitch/features/ui/containers/status_list_container.js
@@ -51,7 +51,7 @@ const makeGetStatusIds = (pending = false) => createSelector([
     }
 
     const searchIndex = statusForId.get('reblog') ? statuses.getIn([statusForId.get('reblog'), 'search_index']) : statusForId.get('search_index');
-    if (regex && !regex.test(searchIndex)) {
+    if (regex && regex.test(searchIndex)) {
       return false;
     }
 


### PR DESCRIPTION
The inverted condition caused only own toots and toots matching the regex to be shown instead of matches being filtered.