### PR TITLE
Fix trends hiding media query values for glitch

### DIFF
--- a/app/javascript/flavours/glitch/styles/components.scss
+++ b/app/javascript/flavours/glitch/styles/components.scss
@@ -3646,25 +3646,25 @@ a.account__display-name {
     padding-inline-start: 16px;
   }
 
-  @media screen and (height <= 930px) {
+  @media screen and (height <= 871px) {
     &__portal .trends__item:nth-child(n + 5) {
       display: none;
     }
   }
 
-  @media screen and (height <= (930px - 56px)) {
+  @media screen and (height <= (871px - 56px)) {
     &__portal .trends__item:nth-child(n + 4) {
       display: none;
     }
   }
 
-  @media screen and (height <= (930px - 56px * 2)) {
+  @media screen and (height <= (871px - 56px * 2)) {
     &__portal .trends__item:nth-child(n + 3) {
       display: none;
     }
   }
 
-  @media screen and (height <= (930px - 56px * 3)) {
+  @media screen and (height <= (871px - 56px * 3)) {
     &__portal {
       display: none;
     }


### PR DESCRIPTION
:warning: haven't actually tested it outside the web inspector

The trends hiding media queries are optimized for vanilla, since glitch-soc adds another entry + hides the logo, this works better as it avoids the nested scroll bar.

|vanilla|glitch-before|glitch-after|

### vanilla

https://github.com/user-attachments/assets/1b5a65f4-fdf1-4513-8355-a7769d244d1d

### glitch before

https://github.com/user-attachments/assets/2f224f91-59a0-4f56-b0c1-e9f26ef8291e

### glitch after

https://github.com/user-attachments/assets/d617ad9e-0f39-463c-8793-753f2bf061f4





