### PR TITLE
Merge upstream changes up to 06c2393805eee6b2e4b4aa17787129a2d542b71d into stable-4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to this project will be documented in this file.
 - Fix WebUI handling of deleted quoted posts (#35909 and #35918 by @ClearlyClaire and @diondiondion)
 - Fix “Edit” and “Delete & Redraft” on a poll not inserting empty option (#35892 by @ClearlyClaire)
 - Fix loading of some compatibility CSS on some configurations (#35876 by @shleeable)
-- Fix HttpLog not being enabled with `RAILS_LOGÈ_LEVEL=debug` (#35833 by @mjankowski)
+- Fix HttpLog not being enabled with `RAILS_LOG_LEVEL=debug` (#35833 by @mjankowski)
 - Fix self-destruct scheduler behavior on some Redis setups (#35823 by @ClearlyClaire)
 - Fix `tootctl admin create` not bypassing reserved username checks (#35779 by @ClearlyClaire)
 - Fix interaction policy changes in implicit updates not being saved (#35751 by @ClearlyClaire)

--- a/app/javascript/mastodon/actions/importer/normalizer.js
+++ b/app/javascript/mastodon/actions/importer/normalizer.js
@@ -81,7 +81,7 @@ export function normalizeStatus(status, normalOldStatus) {
   } else {
     // If the status has a CW but no contents, treat the CW as if it were the
     // status' contents, to avoid having a CW toggle with seemingly no effect.
-    if (normalStatus.spoiler_text && !normalStatus.content) {
+    if (normalStatus.spoiler_text && !normalStatus.content && !normalStatus.quote) {
       normalStatus.content = normalStatus.spoiler_text;
       normalStatus.spoiler_text = '';
     }


### PR DESCRIPTION
## Skipped changes

- 06c2393805eee6b2e4b4aa17787129a2d542b71d (glitch flavor doesn't have that behavior)