### PR TITLE
Fix crash in “Private Mentions” column in glitch-soc

### DIFF
--- a/app/javascript/flavours/glitch/features/direct_timeline/components/conversation.jsx
+++ b/app/javascript/flavours/glitch/features/direct_timeline/components/conversation.jsx
@@ -148,7 +148,7 @@ export const Conversation = ({ conversation, scrollKey }) => {
 
   menu.push({ text: intl.formatMessage(messages.delete), action: handleDelete });
 
-  const names = accounts.map(a => (
+  const names = accounts.map((account) => (
     <LinkedDisplayName displayProps={{account, variant: 'simple'}} key={account.get('id')} />
   )).reduce((prev, cur) => [prev, ', ', cur]);
 


### PR DESCRIPTION
Fixes #3190

Caused by an error when porting recent upstream changes, sorry.