### PR TITLE
Reimplement mention rewriting in new HTML handling code

### DIFF
--- a/app/javascript/flavours/glitch/components/status/handled_link.stories.tsx
+++ b/app/javascript/flavours/glitch/components/status/handled_link.stories.tsx
@@ -21,9 +21,13 @@ const meta = {
   render({ mentionAccount, hashtagAccount, ...args }) {
     let mention: HandledLinkProps['mention'] | undefined;
     if (mentionAccount === 'local') {
-      mention = { id: '1', acct: 'testuser' };
+      mention = { id: '1', acct: 'testuser', username: 'testuser' };
     } else if (mentionAccount === 'remote') {
-      mention = { id: '2', acct: 'remoteuser@mastodon.social' };
+      mention = {
+        id: '2',
+        acct: 'remoteuser@mastodon.social',
+        username: 'remoteuser',
+      };
     }
     return (
       <>


### PR DESCRIPTION
Upstream has rewritten emoji and HTML handling as a whole (this is behind the `modern_emojis` feature flag at the moment), and two glitch-soc features need to be reimplemented (mention rewriting, and misleading link tagging).

This PR is about mention rewriting.

I currently don't know how to do misleading link tagging with this new code.