### PR TITLE
Fix `d` bookmark keyboard shortcut

### DIFF
--- a/app/javascript/flavours/glitch/components/hotkeys/index.tsx
+++ b/app/javascript/flavours/glitch/components/hotkeys/index.tsx
@@ -105,6 +105,7 @@ const hotkeyMatcherMap = {
   reply: just('r'),
   favourite: just('f'),
   boost: just('b'),
+  bookmark: just('d'),
   quote: just('q'),
   mention: just('m'),
   open: any('enter', 'o'),


### PR DESCRIPTION
Note: this is going to break `g` + `d`