### PR TITLE
Fix quotes with only CWs not having fallback link when posting with other content types

### DIFF
--- a/app/lib/advanced_text_formatter.rb
+++ b/app/lib/advanced_text_formatter.rb
@@ -38,7 +38,7 @@ class AdvancedTextFormatter < TextFormatter
 
   # Differs from TextFormatter by not messing with newline after parsing
   def to_s
-    return ''.html_safe if text.blank?
+    return add_quote_fallback('').html_safe if text.blank? # rubocop:disable Rails/OutputSafety
 
     html = rewrite do |entity|
       if entity[:url]


### PR DESCRIPTION
This is essentially mastodon/mastodon#36963 for the advanced text formatter. Makes sure fallback links appear when posting as Markdown/HTML.