### PR TITLE
[Fix undefined `current_flavour` in controllers (/settings/flavours page)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,7 +11,6 @@ class ApplicationController < ActionController::Base
   include CacheConcern
   include PreloadingConcern
   include DomainControlHelper
-  include ThemeHelper
   include DatabaseHelper
   include AuthorizedFetchHelper
   include SelfDestructHelper

--- a/app/controllers/settings/flavours_controller.rb
+++ b/app/controllers/settings/flavours_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Settings::FlavoursController < Settings::BaseController
+  include ThemeHelper
+
   layout 'admin'
 
   before_action :authenticate_user!


### PR DESCRIPTION
After the theming infrastructure migration (#37612, #37807), `ThemingConcern` was removed and theme-related methods were moved to `ThemeHelper`. However, controllers like `Settings::FlavoursController` call `current_flavour` directly in their actions, which is not accessible from a view helper module.

Include `ThemeHelper` in `ApplicationController` to restore access to `current_flavour`, `current_skin`, `current_theme`, and other theme methods in all controllers.