### PR TITLE
[Glitch] Fix `quote-inline` fallback being removed even for legacy quotes (backport)

### DIFF
--- a/app/javascript/flavours/glitch/components/status_content.jsx
+++ b/app/javascript/flavours/glitch/components/status_content.jsx
@@ -177,7 +177,7 @@ class StatusContent extends PureComponent {
           {children}
         </HandledLink>
       );
-    } else if (element.classList.contains('quote-inline')) {
+    } else if (element.classList.contains('quote-inline') && this.props.status.get('quote')) {
       return null;
     }
     return undefined;


### PR DESCRIPTION
Port 2a9c7d2b9e51cdfbc636972c0f9ffdbe06c02d59 to glitch-soc