### PR TITLE
Change the default glitch-soc secondary privacy button behavior

### DIFF
--- a/app/javascript/flavours/glitch/reducers/local_settings.js
+++ b/app/javascript/flavours/glitch/reducers/local_settings.js
@@ -9,7 +9,7 @@ const initialState = ImmutableMap({
   fullwidth_columns: false,
   stretch   : true,
   side_arm  : 'none',
-  side_arm_reply_mode : 'keep',
+  side_arm_reply_mode : 'restrict',
   show_reply_count : true,
   always_show_spoilers_field: false,
   confirm_boost_missing_media_description: false,


### PR DESCRIPTION
“Keep” is confusing and error-prone, “restrict” is consistent with the default button and much safer.