### PR TITLE
fix inert state on active carousel slide #3564

### DIFF
--- a/app/javascript/flavours/glitch/components/carousel/index.tsx
+++ b/app/javascript/flavours/glitch/components/carousel/index.tsx
@@ -235,7 +235,7 @@ const CarouselSlideWrapper = <SlideProps extends CarouselSlideProps>({
       className={className}
       role='group'
       aria-roledescription='slide'
-      inert={active}
+      inert={!active}
       data-index={index}
     >
       {children}


### PR DESCRIPTION
fix: #3564

applies `inert` only to inactive carousel slides. 
updates both glitch and vanilla carousel implementations.
