### PR TITLE
[Glitch] Fix blank CW enabled when redrafting sensitive-media-only posts

### DIFF
--- a/app/javascript/flavours/glitch/reducers/compose.js
+++ b/app/javascript/flavours/glitch/reducers/compose.js
@@ -708,7 +708,7 @@ export const composeReducer = (state = initialState, action) => {
         map.set('spoiler', true);
         map.set('spoiler_text', action.spoiler_text);
       } else {
-        map.set('spoiler', action.status.get('sensitive') && action.status.get('media_attachments').size > 0);
+        map.set('spoiler', false);
         map.set('spoiler_text', '');
       }
 


### PR DESCRIPTION
In glitch, spoiler (CW) and sensitive (media) are independent flags,
but REDRAFT/COMPOSE_SET_STATUS inherited vanilla's conflated logic:
```js
map.set('spoiler', action.status.get('sensitive') && action.status.get('media_attachments').size > 0);
```
For posts with sensitive media but no CW, this turned the CW toggle on.
sensitive is already preserved earlier, so leave the CW off instead.

If needed, could add `map.set('sensitive', true)` to the `else` block, 
but I dont think that is necessary here.