### PR TITLE
[Glitch] Fix blank CW enabled when redrafting sensitive-media-only posts (REDRAFT case)

### DIFF
--- a/app/javascript/flavours/glitch/reducers/compose.js
+++ b/app/javascript/flavours/glitch/reducers/compose.js
@@ -669,7 +669,7 @@ export const composeReducer = (state = initialState, action) => {
           map.set('sensitive', true);
         }
       } else {
-        map.set('spoiler', action.status.get('sensitive') && action.status.get('media_attachments').size > 0);
+        map.set('spoiler', false);
         map.set('spoiler_text', '');
       }
 


### PR DESCRIPTION
Sorry for the inconvenience. The same incorrect line also exists in the edit(`COMPOSE_SET_STATUS`) section, causing the patch to target the wrong location (my mistake—it happened because I moved to the GitHub web editor). Both `REDRAFT` and `COMPOSE_SET_STATUS` case are affected, but the redraft fix was omitted from the previous commit. This change applies the fix to the actual redraft line that was previously missed.