### PR TITLE
[Glitch] Fix collection notification settings pillbar styling

### DIFF
--- a/app/javascript/flavours/glitch/features/notifications/components/column_settings_group.tsx
+++ b/app/javascript/flavours/glitch/features/notifications/components/column_settings_group.tsx
@@ -101,7 +101,7 @@ export const ColumnSettingsGroup: FC<{ label: ReactNode; type: string }> = ({
     <section role='group' aria-labelledby={`notifications-${type}`}>
       <h3 id={`notifications-${type}`}>{label}</h3>
 
-      <div className='column-settings__row'>
+      <div className='column-settings__pillbar'>
         <PillBarButton
           disabled={!browserPermission}
           prefix='notifications_desktop'


### PR DESCRIPTION
Fixed: class name `&__row` to `&__pillbar`

### Screenshots

|   Before   |   After   |
|------------|-----------|
| <img width="375" height="164" alt="image" src="https://github.com/user-attachments/assets/69444603-1cc4-414d-920f-51b351c5fde4" /> | <img width="375" height="106" alt="image" src="https://github.com/user-attachments/assets/0a8389ab-a03d-49ea-af9e-3236d3c0e0db" /> |