### PR TITLE
Fix local-only indicator in detailed status

### DIFF
--- a/app/javascript/flavours/glitch/features/status/components/detailed_status.tsx
+++ b/app/javascript/flavours/glitch/features/status/components/detailed_status.tsx
@@ -569,8 +569,8 @@ export const DetailedStatus: React.FC<{
               />
             </a>
 
-            {visibilityLink}
             {localOnlyLink}
+            {visibilityLink}
             {applicationLink}
           </div>
 

--- a/app/javascript/flavours/glitch/features/status/components/detailed_status.tsx
+++ b/app/javascript/flavours/glitch/features/status/components/detailed_status.tsx
@@ -6,11 +6,12 @@
 import type { CSSProperties } from 'react';
 import { useState, useRef, useCallback, useEffect } from 'react';
 
-import { FormattedMessage } from 'react-intl';
+import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 
 import classNames from 'classnames';
 import { Link } from 'react-router-dom';
 
+import HomeIcon from '@/material-icons/400-24px/home.svg?react';
 import { AnimatedNumber } from 'flavours/glitch/components/animated_number';
 import AttachmentList from 'flavours/glitch/components/attachment_list';
 import { Avatar } from 'flavours/glitch/components/avatar';
@@ -21,6 +22,7 @@ import { FilterWarning } from 'flavours/glitch/components/filter_warning';
 import { FormattedDateWrapper } from 'flavours/glitch/components/formatted_date';
 import type { StatusLike } from 'flavours/glitch/components/hashtag_bar';
 import { getHashtagBarForStatus } from 'flavours/glitch/components/hashtag_bar';
+import { Icon } from 'flavours/glitch/components/icon';
 import { IconLogo } from 'flavours/glitch/components/logo';
 import MediaGallery from 'flavours/glitch/components/media_gallery';
 import { MentionsPlaceholder } from 'flavours/glitch/components/mentions_placeholder';
@@ -39,6 +41,13 @@ import { useAppSelector } from 'flavours/glitch/store';
 import { compareUrls } from 'flavours/glitch/utils/compare_urls';
 
 import Card from './card';
+
+const messages = defineMessages({
+  localOnly: {
+    id: 'status.local_only',
+    defaultMessage: 'Only visible from your instance',
+  },
+});
 
 interface VideoModalOptions {
   startTime: number;
@@ -85,6 +94,7 @@ export const DetailedStatus: React.FC<{
   const [height, setHeight] = useState(0);
   const [showDespiteFilter, setShowDespiteFilter] = useState(false);
   const nodeRef = useRef<HTMLDivElement>(null);
+  const intl = useIntl();
 
   const letterboxMedia = useAppSelector(
     (state) =>
@@ -359,6 +369,18 @@ export const DetailedStatus: React.FC<{
     </>
   );
 
+  const localOnlyLink = status.get('local_only') ? (
+    <>
+      ·
+      <Icon
+        id='home'
+        icon={HomeIcon}
+        className='status__visibility-icon'
+        aria-label={intl.formatMessage(messages.localOnly)}
+      />
+    </>
+  ) : null;
+
   if (['private', 'direct'].includes(status.get('visibility') as string)) {
     reblogLink = '';
   } else {
@@ -548,6 +570,7 @@ export const DetailedStatus: React.FC<{
             </a>
 
             {visibilityLink}
+            {localOnlyLink}
             {applicationLink}
           </div>
 


### PR DESCRIPTION
Since support for the local-only emoji was removed, opening a post in `DetailedStatus` no longer provides any indication that the post is local-only.

This change fixes the issue by displaying the existing home icon to the right of the visibility icon when `local_only` is true.

|before|after|
|---|---|
|<img width="600" height="291" alt="before patch" src="https://github.com/user-attachments/assets/9a25cfe3-6b80-4154-ad94-0d7dc978936f" />|<img width="600" height="291" alt="d" src="https://github.com/user-attachments/assets/9c1de7f9-8858-460a-96f8-e0620299aa83" />|

